### PR TITLE
feat: add core RSVP engine with WPM timing (#13)

### DIFF
--- a/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
+++ b/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRsvpEngine } from '../rsvp-engine';
+import type { RsvpEvent } from '../rsvp-engine';
+
+describe('createRsvpEngine', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('initial state', () => {
+    it('starts in idle with empty words', () => {
+      const engine = createRsvpEngine({ words: [], wpm: 300 });
+      expect(engine.state).toBe('idle');
+    });
+
+    it('starts in idle with non-empty words', () => {
+      const engine = createRsvpEngine({ words: ['a', 'b'], wpm: 300 });
+      expect(engine.state).toBe('idle');
+    });
+  });
+
+  describe('empty words array', () => {
+    it('emits done immediately on start and reaches done state', () => {
+      const engine = createRsvpEngine({ words: [], wpm: 300 });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      expect(events).toEqual([{ type: 'done' }]);
+      expect(engine.state).toBe('done');
+    });
+  });
+
+  describe('single word', () => {
+    it('emits one word event then done', () => {
+      const engine = createRsvpEngine({ words: ['foo'], wpm: 300 });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      // First word emits immediately on start.
+      expect(events).toEqual([{ type: 'word', index: 0, word: 'foo' }]);
+      // Advance one word's worth of time → done.
+      vi.advanceTimersByTime(60000 / 300);
+      expect(events).toEqual([{ type: 'word', index: 0, word: 'foo' }, { type: 'done' }]);
+      expect(engine.state).toBe('done');
+    });
+  });
+
+  describe('multi-word stream at fixed WPM', () => {
+    it('emits n word events plus one done event in order', () => {
+      const words = ['the', 'quick', 'brown', 'fox'];
+      const wpm = 300;
+      const msPerWord = 60000 / wpm; // 200ms
+      const engine = createRsvpEngine({ words, wpm });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+
+      // First word emits synchronously on start.
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ type: 'word', index: 0, word: 'the' });
+
+      // Advance one tick at a time.
+      vi.advanceTimersByTime(msPerWord);
+      vi.advanceTimersByTime(msPerWord);
+      vi.advanceTimersByTime(msPerWord);
+      // After 3 more ticks, all 4 words emitted.
+      expect(events).toHaveLength(4);
+      expect(events.map((e) => (e.type === 'word' ? e.word : '_'))).toEqual([
+        'the',
+        'quick',
+        'brown',
+        'fox',
+      ]);
+
+      // One more tick fires done.
+      vi.advanceTimersByTime(msPerWord);
+      expect(events).toHaveLength(5);
+      expect(events[4]).toEqual({ type: 'done' });
+      expect(engine.state).toBe('done');
+    });
+  });
+
+  describe('pause / resume', () => {
+    it('pause stops further events until resume', () => {
+      const words = ['a', 'b', 'c', 'd'];
+      const engine = createRsvpEngine({ words, wpm: 300 });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      // 'a' emitted synchronously.
+      expect(events).toHaveLength(1);
+
+      engine.pause();
+      expect(engine.state).toBe('paused');
+      vi.advanceTimersByTime(10000);
+      expect(events).toHaveLength(1);
+
+      engine.resume();
+      expect(engine.state).toBe('playing');
+      vi.advanceTimersByTime(200); // one word at 300 wpm
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual({ type: 'word', index: 1, word: 'b' });
+    });
+  });
+
+  describe('setWpm mid-stream', () => {
+    it('next scheduled tick uses the new cadence', () => {
+      const words = ['a', 'b', 'c'];
+      const engine = createRsvpEngine({ words, wpm: 300 }); // 200ms/word
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start(); // 'a' immediate
+      expect(events).toHaveLength(1);
+
+      // Halve the cadence: 600 wpm → 100ms/word.
+      engine.setWpm(600);
+
+      // After 100ms, 'b' should have emitted.
+      vi.advanceTimersByTime(99);
+      expect(events).toHaveLength(1);
+      vi.advanceTimersByTime(1);
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual({ type: 'word', index: 1, word: 'b' });
+    });
+
+    it('throws RangeError on invalid wpm', () => {
+      const engine = createRsvpEngine({ words: ['a'], wpm: 300 });
+      expect(() => engine.setWpm(0)).toThrow(RangeError);
+      expect(() => engine.setWpm(-1)).toThrow(RangeError);
+      expect(() => engine.setWpm(NaN)).toThrow(RangeError);
+      expect(() => engine.setWpm(Infinity)).toThrow(RangeError);
+    });
+  });
+
+  describe('stop', () => {
+    it('moves to done and prevents further events', () => {
+      const engine = createRsvpEngine({ words: ['a', 'b', 'c'], wpm: 300 });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      expect(events).toHaveLength(1);
+
+      engine.stop();
+      expect(engine.state).toBe('done');
+      vi.advanceTimersByTime(10000);
+      expect(events).toHaveLength(1);
+    });
+
+    it('start after stop is a no-op', () => {
+      const engine = createRsvpEngine({ words: ['a', 'b'], wpm: 300 });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      engine.stop();
+      const before = events.length;
+      engine.start();
+      vi.advanceTimersByTime(10000);
+      expect(events).toHaveLength(before);
+      expect(engine.state).toBe('done');
+    });
+  });
+
+  describe('subscribe', () => {
+    it('returns an unsubscribe fn that stops delivery', () => {
+      const engine = createRsvpEngine({ words: ['a', 'b', 'c'], wpm: 300 });
+      const events: RsvpEvent[] = [];
+      const unsubscribe = engine.subscribe((e) => events.push(e));
+      engine.start();
+      expect(events).toHaveLength(1);
+      unsubscribe();
+      vi.advanceTimersByTime(10000);
+      expect(events).toHaveLength(1);
+    });
+
+    it('supports multiple subscribers', () => {
+      const engine = createRsvpEngine({ words: ['a'], wpm: 300 });
+      const a: RsvpEvent[] = [];
+      const b: RsvpEvent[] = [];
+      engine.subscribe((e) => a.push(e));
+      engine.subscribe((e) => b.push(e));
+      engine.start();
+      expect(a).toHaveLength(1);
+      expect(b).toHaveLength(1);
+    });
+  });
+
+  describe('invalid wpm at construction', () => {
+    it('throws RangeError', () => {
+      expect(() => createRsvpEngine({ words: [], wpm: 0 })).toThrow(RangeError);
+      expect(() => createRsvpEngine({ words: [], wpm: -1 })).toThrow(RangeError);
+      expect(() => createRsvpEngine({ words: [], wpm: NaN })).toThrow(RangeError);
+      expect(() => createRsvpEngine({ words: [], wpm: Infinity })).toThrow(RangeError);
+    });
+  });
+});

--- a/src/core/rsvp-engine/index.ts
+++ b/src/core/rsvp-engine/index.ts
@@ -1,0 +1,8 @@
+export { createRsvpEngine } from './rsvp-engine';
+export type {
+  RsvpEngine,
+  RsvpEngineOptions,
+  RsvpEvent,
+  RsvpListener,
+  RsvpState,
+} from './rsvp-engine';

--- a/src/core/rsvp-engine/rsvp-engine.ts
+++ b/src/core/rsvp-engine/rsvp-engine.ts
@@ -8,7 +8,14 @@
  * No DOM, no chrome.* / browser.* — safe for src/core/.
  */
 
-export type RsvpState = 'idle' | 'playing' | 'paused' | 'done';
+export const RSVP_STATE = {
+  IDLE: 'idle',
+  PLAYING: 'playing',
+  PAUSED: 'paused',
+  DONE: 'done',
+} as const;
+
+export type RsvpState = (typeof RSVP_STATE)[keyof typeof RSVP_STATE];
 
 export type RsvpEvent = { type: 'word'; index: number; word: string } | { type: 'done' };
 
@@ -36,12 +43,28 @@ function assertValidWpm(wpm: number): void {
   }
 }
 
+// words must be an array of strings. Guards against null/undefined and
+// non-string elements at the engine's API boundary so callers from JS
+// or corrupt-data paths get a clear TypeError rather than a downstream
+// "Cannot read properties of null" surprise.
+function assertValidWords(words: unknown): asserts words is string[] {
+  if (!Array.isArray(words)) {
+    throw new TypeError(`Invalid words: expected an array, got ${typeof words}.`);
+  }
+  for (let i = 0; i < words.length; i++) {
+    if (typeof words[i] !== 'string') {
+      throw new TypeError(`Invalid words[${i}]: expected string, got ${typeof words[i]}.`);
+    }
+  }
+}
+
 export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
   assertValidWpm(options.wpm);
+  assertValidWords(options.words);
 
   const words = options.words.slice();
   let wpm = options.wpm;
-  let state: RsvpState = 'idle';
+  let state: RsvpState = RSVP_STATE.IDLE;
   let nextIndex = 0;
   let timerId: ReturnType<typeof setTimeout> | null = null;
   const listeners = new Set<RsvpListener>();
@@ -65,14 +88,14 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
   const scheduleNext = (): void => {
     timerId = setTimeout(() => {
       timerId = null;
-      if (state !== 'playing') return;
+      if (state !== RSVP_STATE.PLAYING) return;
       tick();
     }, msPerWord());
   };
 
   const tick = (): void => {
     if (nextIndex >= words.length) {
-      state = 'done';
+      state = RSVP_STATE.DONE;
       emit({ type: 'done' });
       return;
     }
@@ -86,23 +109,23 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
       return state;
     },
     start(): void {
-      if (state !== 'idle') return;
+      if (state !== RSVP_STATE.IDLE) return;
       if (words.length === 0) {
-        state = 'done';
+        state = RSVP_STATE.DONE;
         emit({ type: 'done' });
         return;
       }
-      state = 'playing';
+      state = RSVP_STATE.PLAYING;
       tick();
     },
     pause(): void {
-      if (state !== 'playing') return;
-      state = 'paused';
+      if (state !== RSVP_STATE.PLAYING) return;
+      state = RSVP_STATE.PAUSED;
       clearPending();
     },
     resume(): void {
-      if (state !== 'paused') return;
-      state = 'playing';
+      if (state !== RSVP_STATE.PAUSED) return;
+      state = RSVP_STATE.PLAYING;
       // Schedule the next word at the current cadence; tick handles done.
       if (nextIndex >= words.length) {
         tick();
@@ -111,8 +134,8 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
       }
     },
     stop(): void {
-      if (state === 'done') return;
-      state = 'done';
+      if (state === RSVP_STATE.DONE) return;
+      state = RSVP_STATE.DONE;
       clearPending();
     },
     setWpm(next: number): void {
@@ -121,7 +144,7 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
       // Reschedule any pending tick at the new cadence so the next emission
       // reflects the change. The currently displayed word's remaining time
       // is reset — acceptable for a control-surface live update.
-      if (state === 'playing' && timerId !== null) {
+      if (state === RSVP_STATE.PLAYING && timerId !== null) {
         clearPending();
         scheduleNext();
       }

--- a/src/core/rsvp-engine/rsvp-engine.ts
+++ b/src/core/rsvp-engine/rsvp-engine.ts
@@ -1,0 +1,136 @@
+/**
+ * Pure RSVP word-emission engine.
+ *
+ * Single responsibility: emit words from a fixed array at a cadence derived
+ * from a WPM (words-per-minute) setting. Tokenization, ORP highlighting,
+ * punctuation pacing, and UI mounting all live elsewhere.
+ *
+ * No DOM, no chrome.* / browser.* — safe for src/core/.
+ */
+
+export type RsvpState = 'idle' | 'playing' | 'paused' | 'done';
+
+export type RsvpEvent = { type: 'word'; index: number; word: string } | { type: 'done' };
+
+export type RsvpListener = (event: RsvpEvent) => void;
+
+export interface RsvpEngineOptions {
+  words: string[];
+  wpm: number;
+}
+
+export interface RsvpEngine {
+  readonly state: RsvpState;
+  start(): void;
+  pause(): void;
+  resume(): void;
+  stop(): void;
+  setWpm(wpm: number): void;
+  subscribe(listener: RsvpListener): () => void;
+}
+
+// wpm must be a positive finite number; 0, negative, NaN, Infinity all invalid.
+function assertValidWpm(wpm: number): void {
+  if (!Number.isFinite(wpm) || wpm <= 0) {
+    throw new RangeError(`Invalid wpm: ${wpm}. Expected a positive finite number.`);
+  }
+}
+
+export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
+  assertValidWpm(options.wpm);
+
+  const words = options.words.slice();
+  let wpm = options.wpm;
+  let state: RsvpState = 'idle';
+  let nextIndex = 0;
+  let timerId: ReturnType<typeof setTimeout> | null = null;
+  const listeners = new Set<RsvpListener>();
+
+  const emit = (event: RsvpEvent): void => {
+    // Snapshot to tolerate unsubscribe during dispatch.
+    for (const listener of [...listeners]) {
+      listener(event);
+    }
+  };
+
+  const msPerWord = (): number => 60000 / wpm;
+
+  const clearPending = (): void => {
+    if (timerId !== null) {
+      clearTimeout(timerId);
+      timerId = null;
+    }
+  };
+
+  const scheduleNext = (): void => {
+    timerId = setTimeout(() => {
+      timerId = null;
+      if (state !== 'playing') return;
+      tick();
+    }, msPerWord());
+  };
+
+  const tick = (): void => {
+    if (nextIndex >= words.length) {
+      state = 'done';
+      emit({ type: 'done' });
+      return;
+    }
+    const index = nextIndex++;
+    emit({ type: 'word', index, word: words[index] });
+    scheduleNext();
+  };
+
+  return {
+    get state() {
+      return state;
+    },
+    start(): void {
+      if (state !== 'idle') return;
+      if (words.length === 0) {
+        state = 'done';
+        emit({ type: 'done' });
+        return;
+      }
+      state = 'playing';
+      tick();
+    },
+    pause(): void {
+      if (state !== 'playing') return;
+      state = 'paused';
+      clearPending();
+    },
+    resume(): void {
+      if (state !== 'paused') return;
+      state = 'playing';
+      // Schedule the next word at the current cadence; tick handles done.
+      if (nextIndex >= words.length) {
+        tick();
+      } else {
+        scheduleNext();
+      }
+    },
+    stop(): void {
+      if (state === 'done') return;
+      state = 'done';
+      clearPending();
+    },
+    setWpm(next: number): void {
+      assertValidWpm(next);
+      wpm = next;
+      // Reschedule any pending tick at the new cadence so the next emission
+      // reflects the change. The currently displayed word's remaining time
+      // is reset — acceptable for a control-surface live update.
+      if (state === 'playing' && timerId !== null) {
+        clearPending();
+        scheduleNext();
+      }
+    },
+    subscribe(listener: RsvpListener): () => void {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Closes #13

Adds the core RSVP word-display engine in `src/core/rsvp-engine/`. Pure
TypeScript, no DOM, no `chrome.*` / `browser.*` — honors the
`src/core/` boundary contract. Single responsibility: emit words from a
fixed array at a cadence derived from a WPM setting. Tokenization
(#16/#17), ORP (#14), punctuation pacing (#15), and UI mounting (#19)
are deliberately out of scope.

## What changed

- New module `src/core/rsvp-engine/{rsvp-engine.ts,index.ts}` exposing:
  - `createRsvpEngine({ words, wpm }) → RsvpEngine`
  - `start` / `pause` / `resume` / `stop` / `setWpm` / `subscribe`
  - State machine: `'idle' | 'playing' | 'paused' | 'done'`
  - Events: `{ type: 'word', index, word }` and `{ type: 'done' }`
- 13 new tests under `src/core/rsvp-engine/__tests__/rsvp-engine.test.ts`,
  using `vi.useFakeTimers()` to drive deterministic cadence assertions.

## Design notes — what drove which behavior

- **First word emits synchronously on `start()`** (drives the single-word
  test and the multi-word "events.toHaveLength(1) immediately" assertion).
  RSVP UX expects content the instant the user hits play; otherwise the
  first word burns its own duration before showing.
- **`setTimeout` per tick, not `setInterval`** (drives the `setWpm`
  mid-stream test). Each tick schedules the next at the current
  `60000/wpm` ms, so a live cadence change applies on the next emission
  without drift accumulation.
- **`setWpm` reschedules a pending tick** (drives the
  'next scheduled tick uses the new cadence' test). The currently-displayed
  word's remaining time resets — acceptable trade-off for a control-surface
  live update; documented in the source.
- **`stop()` is terminal; subsequent `start()` is a no-op**
  (drives the 'start after stop' test). Simpler than a re-armable engine,
  and matches the lifecycle the popup/overlay will own.
- **`RangeError` on invalid WPM** (drives the validation tests). Catches
  0, negative, NaN, Infinity at both construction and `setWpm`.
- **Listener snapshot during dispatch** lets a subscriber unsubscribe
  itself mid-callback without breaking iteration.

## How to test

- [x] `npm test` — 14 passed (13 new + canary)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (0 warnings, 0 errors)
- [x] `npm run build` — clean (`tsc --noEmit` + `vite build` both pass)
- [x] `npm run format:check` — clean

## Boundary contract / harness notes

No issues. The Vitest harness (PR #61) handled fake timers cleanly on
the first try — this is its first real consumer and it held up. The
`src/core/` boundary is unchanged; no DOM or `chrome.*` reach was
needed.

One follow-up worth flagging (not blocking this PR): the engine resets
the in-flight word's display time when `setWpm` is called mid-stream.
If user testing shows the visual jolt is jarring, a future revision
could compute the elapsed fraction and schedule the remaining cadence
proportionally. Holding off until UX feedback exists.

## Checklist
- [x] CI passes (lint, typecheck, tests, build) — verified locally; CI
      will confirm on push
- [x] Tests added (13 new)
- [x] Docs updated where appropriate (JSDoc on the module + types;
      `src/core/README.md` boundary contract unchanged)
