### PR TITLE
feat: settings schema, storage adapter, and migration hook (#32)

### DIFF
--- a/docs/superpowers/specs/2026-05-08-settings-schema.md
+++ b/docs/superpowers/specs/2026-05-08-settings-schema.md
@@ -1,0 +1,157 @@
+# Settings Schema Spec
+
+**Date:** 2026-05-08
+**Status:** Approved
+**Issue:** [#32 — Settings schema, storage, and migration](https://github.com/chriscantu/speedreader-chrome/issues/32)
+**Milestone:** M1 (MVP parity)
+**Scope:** Pin the persisted settings shape, validation, storage backend, migration hook, and the read/write/subscribe API. Sets the contract every other M1 feature reads from.
+
+---
+
+## Problem Statement
+
+Every M1 feature reads from settings: WPM (#15), theme + font (#27, #28), overlay rendering (#19), the options page (#30), and the popup (#29). Without a versioned, validated settings contract there is no stable place for those features to land — each consumer would invent its own shape and drift. The Safari reference stores settings as ad-hoc keys; the Chrome port has the opportunity to ship one canonical schema with a migration path before the install base exists, while the cost of getting it wrong is still zero.
+
+A settings schema is also where corrupt-data resilience pays off most: `chrome.storage.sync` can return partial payloads after a sync conflict, and a malformed payload on cold start would crash the service worker before any UI rendered.
+
+## Constraints
+
+- **MV3 service worker.** No persistent state in memory across worker wake cycles — settings must be re-read each cold start. The storage call is the cache.
+- **Local-only.** No network beyond `chrome.storage.sync`'s built-in cross-device replication. No analytics on settings changes.
+- **Solo-maintainer.** Migration machinery has to be cheap to reason about. One forward-only sequential chain, not a graph.
+- **`src/core/` boundary.** Pure schema, defaults, and migrations live in `src/core/settings/` with no `chrome.*` imports. The `chrome.storage.sync` adapter lives in `src/chrome/settings/`. Keeps the core portable for a future shared-core extraction across Safari + Chrome.
+
+## Decision
+
+### Storage backend: `chrome.storage.sync`
+
+Settings ride Chrome's signed-in-account sync so a user's WPM, theme, and font follow them across devices. Quotas to respect:
+
+- 120 writes/minute, 1800 writes/hour
+- ~1.8 KB/sec sustained
+- 100 KB total per extension, 8 KB per item
+
+The whole settings blob is one item well under 8 KB. The risk is write rate — slider-style controls in the options page can fire change events at 60 Hz. Mitigation: **300 ms trailing-edge debounce** on `saveSettings` (see API below).
+
+**Reading position** (#48) explicitly stays on `chrome.storage.local`. Position updates are high-frequency and per-device; syncing them would burn quota and offers no cross-device value.
+
+### Validation: Zod
+
+[Zod](https://github.com/colinhacks/zod) (~12 KB minified) parses the raw value on every read. The cost buys first-install corrupt-data resilience: a partially-synced or hand-edited blob fails parsing and falls back to defaults instead of throwing in the service worker.
+
+### Storage key
+
+A single key: **`speedreader.settings`**. The schema version lives **inside the value** as a `version` field, never in the key. Rationale: the key stays stable forever; version-as-field means a v3 install reading a v1 blob can migrate in place without orphaning a `speedreader.settings.v1` key on every old device.
+
+### Schema shape
+
+Source of truth: `src/core/settings/schema.ts`. The Zod object is `SettingsSchemaV1` (the parser/validator); the inferred TypeScript type is `SettingsV1`. The two names are kept distinct so consumers that need the runtime parser and consumers that only need the static type don't share a symbol.
+
+```ts
+import { z } from 'zod';
+
+export const SettingsSchemaV1 = z.object({
+  version: z.literal(1),
+  wpm: z.number().int().min(100).max(600).multipleOf(10),
+  theme: z.enum(['light', 'dark', 'system']),
+  font: z.string(),
+  fontSize: z.number().int().min(12).max(48),
+  openDyslexic: z.boolean(),
+  punctuationPacing: z.boolean(),
+});
+
+export type SettingsV1 = z.infer<typeof SettingsSchemaV1>;
+
+export const CURRENT_VERSION = 1 as const;
+```
+
+Field notes:
+
+- `wpm` — bounded to the documented Safari range, multiples of 10 to match slider granularity.
+- `theme: 'system'` follows `prefers-color-scheme`; the overlay resolves it at render time.
+- `font` is a free string in v1; the curated enum lands with #28 and will be a v2 migration if it tightens.
+- `openDyslexic` is the toggle for the bundled OpenDyslexic face; `font` and the toggle are independent so a user can have OpenDyslexic on as an override.
+- `punctuationPacing` defaults on; tracks the Safari behaviour.
+
+### Defaults
+
+Source of truth: `src/core/settings/defaults.ts`.
+
+```ts
+export const DEFAULT_SETTINGS: SettingsV1 = {
+  version: 1,
+  wpm: 250,
+  theme: 'system',
+  font: 'system-ui',
+  fontSize: 20,
+  openDyslexic: false,
+  punctuationPacing: true,
+};
+```
+
+A single export consumed by **both** the first-install seed write **and** the options-page "reset to defaults" affordance — no duplicated literal, no drift.
+
+### Migration strategy
+
+Source of truth: `src/core/settings/migrations.ts`. Public entry point:
+
+```ts
+export function migrate(rawValue: unknown): SettingsV1;
+```
+
+Behavior:
+
+- Non-object / null / array input → fresh copy of `DEFAULT_SETTINGS`. Never throws.
+- Sequential migrators keyed by source version run forward to `CURRENT_VERSION`. v1 ships an identity hook for `0 → 1` purely to keep the composition path exercised in tests.
+- After migrators run, the value is shallow-merged onto `DEFAULT_SETTINGS` (so a missing field acquires its default), then `SettingsSchemaV1.safeParse`'d.
+- Parse failure logs a warning and returns a fresh copy of `DEFAULT_SETTINGS`. **Corrupt data never crashes the worker.**
+
+Adding a v2 later: drop a migrator into the `MIGRATIONS` table keyed by `1`, bump `CURRENT_VERSION` in `schema.ts`, ship a new `SettingsSchemaV2`. The hook ships now so v2 lands cheap later.
+
+### Read/write/subscribe API
+
+Source of truth: `src/chrome/settings/storage.ts`. This is the only file in the project that imports `chrome.storage.*` for settings.
+
+```ts
+export async function loadSettings(): Promise<SettingsV1>;
+export function saveSettings(partial: Partial<SettingsV1>): Promise<void>;
+export function subscribeSettings(listener: (s: SettingsV1) => void): () => void;
+```
+
+Behavior:
+
+- `loadSettings` reads `speedreader.settings` from `chrome.storage.sync`. **On first install (`raw === undefined`) it seeds `DEFAULT_SETTINGS` and writes the canonical seed back** so the next read is a fast pass-through. It also writes back when migration reshapes the stored value (version bump or partial-payload repair). The seed write is unconditional on `raw === undefined` — there is no falsy short-circuit.
+- `saveSettings(partial)` coalesces calls within a **300 ms trailing-edge** window into one write. Sliders that fire at 60 Hz produce one write, not 60. Each call returns a Promise that resolves when its containing flush completes.
+- `subscribeSettings(listener)` wires `chrome.storage.onChanged`, filters to area `'sync'` and key `speedreader.settings`, runs the new value through `migrate`, and forwards. Live updates from a sibling tab, the options page, or a different signed-in device all flow through the same path. Returns an unsubscribe function.
+
+### File layout
+
+```
+src/core/settings/
+  schema.ts        SettingsSchemaV1, SettingsV1, CURRENT_VERSION
+  defaults.ts      DEFAULT_SETTINGS
+  migrations.ts    migrate(rawValue)
+  index.ts         barrel
+src/chrome/settings/
+  storage.ts       loadSettings, saveSettings, subscribeSettings
+```
+
+Boundary contract: `src/core/settings/**` has zero `chrome.*` imports. The adapter does not re-export the schema; consumers import core directly.
+
+## Out of Scope
+
+- **Reading position (#48)** — lands on `chrome.storage.local`, separate spec.
+- **Settings UI (#30)** — the options page consumes this contract; layout is its own spec.
+- **Curated font enum (#28)** — v1 keeps `font: string`; tightening to an enum is a v2 migration.
+- **Export / import** — post-M1.
+
+## Acceptance Criteria
+
+1. `SettingsSchemaV1.parse` accepts a valid v1 blob with all fields at defaults.
+2. `migrate({ version: 0 })` returns a value satisfying `SettingsSchemaV1` with `version === 1`.
+3. `migrate(undefined)`, `migrate(null)`, `migrate('garbage')`, and `migrate([])` each return a value deep-equal to `DEFAULT_SETTINGS` and never throw.
+4. `migrate({ version: 1, wpm: 'not-a-number' })` falls back to `DEFAULT_SETTINGS` (logs warning, no throw).
+5. `loadSettings` on a fresh profile (`chrome.storage.sync.get` resolves to `{}`) writes `DEFAULT_SETTINGS` back under `speedreader.settings` and resolves to `DEFAULT_SETTINGS`.
+6. `saveSettings({ wpm: 300 })` called 10 times in a 100 ms window results in exactly one `chrome.storage.sync.set` call ~300 ms after the last invocation.
+7. `subscribeSettings` fires when a sibling context writes to `speedreader.settings` on the `sync` area, and does not fire for unrelated keys or the `local` area.
+8. Grep confirms `src/core/settings/**/*.ts` contains zero `chrome.` references.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,15 +7,20 @@
     "": {
       "name": "speedreader-chrome",
       "version": "0.1.0",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.0.0-beta.28",
         "@eslint/js": "^10.0.1",
         "@types/chrome": "^0.0.287",
+        "@types/sinon-chrome": "^2.2.16",
         "@typescript-eslint/eslint-plugin": "^8.58.2",
         "@typescript-eslint/parser": "^8.58.2",
         "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.1.8",
         "prettier": "^3.8.3",
+        "sinon-chrome": "^3.0.1",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.58.2",
         "vite": "^6.3.0",
@@ -1116,6 +1121,47 @@
         "win32"
       ]
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
+      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "deprecated": "Deprecated: no longer maintained and no longer used by Sinon packages. See\n  https://github.com/sinonjs/nise/issues/243 for replacement details.",
+      "dev": true,
+      "license": "(Unlicense OR Apache-2.0)"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1184,6 +1230,34 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sinon": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.1.tgz",
+      "integrity": "sha512-5yoJSqLbjH8T9V2bksgRayuhpZy+723/z6wBOR+Soe4ZlXC0eW8Na71TeaZPUWDQvM7LYKa9UGFc6LRqxiR5fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinon-chrome": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chrome/-/sinon-chrome-2.2.16.tgz",
+      "integrity": "sha512-gAaX/QaSMy6x7JyeGTDn1Bye7ZcM2xdkNdlCStVHsDfWPNQ9lN8FYVU5NRpbdxrFeqntfm0yxMx55VF8OEF66Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chrome": "*",
+        "@types/sinon": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1604,6 +1678,13 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1731,6 +1812,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.1.tgz",
+      "integrity": "sha512-Z3u54A8qGyqFOSr2pk0ijYs8mOE9Qz8kTvtKeBI+upoG9j04Sq+oI7W8zAJiQybDcESET8/uIdHzs0p3k4fZlw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -2247,6 +2338,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "dev": true,
@@ -2302,6 +2403,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2352,6 +2460,13 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2391,6 +2506,20 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -2475,6 +2604,30 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nise": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^5.0.1",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/lolex": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
     },
     "node_modules/node-html-parser": {
       "version": "7.1.0",
@@ -2575,6 +2728,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
       }
     },
     "node_modules/pathe": {
@@ -2784,6 +2947,35 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sinon": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "deprecated": "16.1.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
+        "supports-color": "^5.5.0"
+      }
+    },
+    "node_modules/sinon-chrome": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sinon-chrome/-/sinon-chrome-3.0.1.tgz",
+      "integrity": "sha512-NTEFhyuiWEMnRmIqldUiA2DhKn2EqnZxyEk5Ez5rBXj+Nl54aJ0MEmF4wjltrxecxd8zlNLxyE0HyLabev9JsQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lodash": "^4.16.3",
+        "sinon": "^7.2.3",
+        "urijs": "^1.18.2"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "dev": true,
@@ -2805,6 +2997,19 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -2890,6 +3095,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "dev": true,
@@ -2943,6 +3158,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.4.2",
@@ -3211,6 +3433,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,14 +18,19 @@
     "@crxjs/vite-plugin": "^2.0.0-beta.28",
     "@eslint/js": "^10.0.1",
     "@types/chrome": "^0.0.287",
+    "@types/sinon-chrome": "^2.2.16",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.8.3",
+    "sinon-chrome": "^3.0.1",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.58.2",
     "vite": "^6.3.0",
     "vitest": "^4.1.5"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
   }
 }

--- a/src/chrome/settings/__tests__/storage.test.ts
+++ b/src/chrome/settings/__tests__/storage.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import sinonChrome from 'sinon-chrome';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
 import type { SettingsV1 } from '../../../core/settings/schema';
+import { DEBOUNCE_MS } from '../storage';
 
 const KEY = 'speedreader.settings';
 
@@ -106,7 +107,7 @@ describe('chrome settings storage adapter', () => {
     // No write yet (debounce pending).
     expect(stub.storage.sync.set).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS_FOR_TEST);
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
     await Promise.all(promises);
 
     // Exactly one set call (the trailing-edge write); set may also fire from
@@ -121,7 +122,7 @@ describe('chrome settings storage adapter', () => {
     storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV1;
     const { saveSettings } = await import('../storage');
     const p = saveSettings({ theme: 'dark' });
-    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS_FOR_TEST);
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
     await p;
     const stored = storedRaw as SettingsV1;
     expect(stored.version).toBe(1);
@@ -161,5 +162,3 @@ describe('chrome settings storage adapter', () => {
     expect(listener).toHaveBeenCalledWith(DEFAULT_SETTINGS);
   });
 });
-
-const DEBOUNCE_MS_FOR_TEST = 300;

--- a/src/chrome/settings/__tests__/storage.test.ts
+++ b/src/chrome/settings/__tests__/storage.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import sinonChrome from 'sinon-chrome';
+import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
+import type { SettingsV1 } from '../../../core/settings/schema';
+
+const KEY = 'speedreader.settings';
+
+interface ChromeStub {
+  storage: {
+    sync: {
+      get: ReturnType<typeof vi.fn>;
+      set: ReturnType<typeof vi.fn>;
+    };
+    onChanged: {
+      addListener: ReturnType<typeof vi.fn>;
+      removeListener: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+let storedRaw: unknown;
+type ChangeListener = (
+  changes: Record<string, chrome.storage.StorageChange>,
+  area: chrome.storage.AreaName,
+) => void;
+let changeListeners: ChangeListener[] = [];
+
+function installChromeStub(): ChromeStub {
+  storedRaw = undefined;
+  changeListeners = [];
+  const stub: ChromeStub = {
+    storage: {
+      sync: {
+        get: vi.fn((key: string) => {
+          if (key === KEY) return Promise.resolve({ [KEY]: storedRaw });
+          return Promise.resolve({});
+        }),
+        set: vi.fn((items: Record<string, unknown>) => {
+          storedRaw = items[KEY];
+          return Promise.resolve();
+        }),
+      },
+      onChanged: {
+        addListener: vi.fn((cb: ChangeListener) => {
+          changeListeners.push(cb);
+        }),
+        removeListener: vi.fn((cb: ChangeListener) => {
+          changeListeners = changeListeners.filter((l) => l !== cb);
+        }),
+      },
+    },
+  };
+  (globalThis as unknown as { chrome: ChromeStub }).chrome = stub;
+  return stub;
+}
+
+function emitChange(newValue: unknown, area: chrome.storage.AreaName = 'sync'): void {
+  const change = { [KEY]: { newValue, oldValue: undefined } };
+  changeListeners.forEach((cb) => cb(change, area));
+}
+
+// Touch sinon-chrome import so the dep stays explicit even though we use vi-based mocks
+void sinonChrome;
+
+describe('chrome settings storage adapter', () => {
+  beforeEach(() => {
+    installChromeStub();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('loadSettings seeds defaults on first install (storage empty)', async () => {
+    const { loadSettings } = await import('../storage');
+    const settings = await loadSettings();
+    expect(settings).toEqual(DEFAULT_SETTINGS);
+    // Write-back occurred to canonicalise.
+    expect(storedRaw).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it('loadSettings returns valid stored payload as-is', async () => {
+    storedRaw = { ...DEFAULT_SETTINGS, wpm: 380 } satisfies SettingsV1;
+    const { loadSettings } = await import('../storage');
+    const settings = await loadSettings();
+    expect(settings.wpm).toBe(380);
+  });
+
+  it('loadSettings repairs a corrupt payload to defaults and writes back', async () => {
+    storedRaw = 'not-an-object';
+    const { loadSettings } = await import('../storage');
+    const settings = await loadSettings();
+    expect(settings).toEqual(DEFAULT_SETTINGS);
+    expect(storedRaw).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it('saveSettings coalesces 10 calls within 300ms into one write', async () => {
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV1;
+    const { saveSettings } = await import('../storage');
+    const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
+
+    const promises: Promise<void>[] = [];
+    for (let wpm = 250; wpm < 350; wpm += 10) {
+      promises.push(saveSettings({ wpm }));
+    }
+    // No write yet (debounce pending).
+    expect(stub.storage.sync.set).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS_FOR_TEST);
+    await Promise.all(promises);
+
+    // Exactly one set call (the trailing-edge write); set may also fire from
+    // an internal load() canonicalisation if storedRaw mismatched, so assert
+    // the *final* persisted wpm rather than count alone.
+    const finalStored = storedRaw as SettingsV1;
+    expect(finalStored.wpm).toBe(340);
+    expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
+  });
+
+  it('saveSettings preserves the version field', async () => {
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV1;
+    const { saveSettings } = await import('../storage');
+    const p = saveSettings({ theme: 'dark' });
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS_FOR_TEST);
+    await p;
+    const stored = storedRaw as SettingsV1;
+    expect(stored.version).toBe(1);
+    expect(stored.theme).toBe('dark');
+  });
+
+  it('subscribeSettings invokes listener with parsed payload on sync change', async () => {
+    const { subscribeSettings } = await import('../storage');
+    const listener = vi.fn();
+    const unsubscribe = subscribeSettings(listener);
+
+    const next: SettingsV1 = { ...DEFAULT_SETTINGS, wpm: 420 };
+    emitChange(next, 'sync');
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(next);
+
+    unsubscribe();
+    emitChange(next, 'sync');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribeSettings ignores changes from non-sync areas', async () => {
+    const { subscribeSettings } = await import('../storage');
+    const listener = vi.fn();
+    subscribeSettings(listener);
+
+    emitChange({ ...DEFAULT_SETTINGS, wpm: 300 }, 'local');
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('subscribeSettings falls back to defaults for corrupt change payload', async () => {
+    const { subscribeSettings } = await import('../storage');
+    const listener = vi.fn();
+    subscribeSettings(listener);
+
+    emitChange('garbage', 'sync');
+    expect(listener).toHaveBeenCalledWith(DEFAULT_SETTINGS);
+  });
+});
+
+const DEBOUNCE_MS_FOR_TEST = 300;

--- a/src/chrome/settings/index.ts
+++ b/src/chrome/settings/index.ts
@@ -1,0 +1,1 @@
+export { loadSettings, saveSettings, subscribeSettings } from './storage';

--- a/src/chrome/settings/storage.ts
+++ b/src/chrome/settings/storage.ts
@@ -2,7 +2,9 @@ import type { SettingsV1 } from '../../core/settings/schema';
 import { migrate } from '../../core/settings/migrations';
 
 const KEY = 'speedreader.settings';
-const DEBOUNCE_MS = 300;
+export const DEBOUNCE_MS = 300;
+
+export type SaveSettingsInput = Omit<Partial<SettingsV1>, 'version'>;
 
 /**
  * Read settings from `chrome.storage.sync`, migrating + validating the raw
@@ -20,11 +22,24 @@ export async function loadSettings(): Promise<SettingsV1> {
   return settings;
 }
 
-let pendingPartial: Partial<SettingsV1> | null = null;
+let pendingPartial: SaveSettingsInput | null = null;
 let pendingTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingResolvers: Array<() => void> = [];
 let pendingRejectors: Array<(err: unknown) => void> = [];
 
+/**
+ * Trailing-edge flush of coalesced `saveSettings` calls.
+ *
+ * NOTE: this awaits `loadSettings()` to obtain the current canonical state
+ * before merging. `loadSettings()` may itself issue a `chrome.storage.sync.set`
+ * to canonicalise the stored payload (first install, version bump, or repair
+ * of a partial value). In those cases the full save sequence fires *two*
+ * underlying `set` calls — one canonicalisation, one merged save. Spec AC #6
+ * ("exactly one set ~300 ms after the last save") still holds because it
+ * concerns the debounced save itself; the canonicalisation is a separate,
+ * one-time event. Future integration tests should not assert
+ * `set.toHaveBeenCalledTimes(1)` blindly across a first-install + save flow.
+ */
 async function flushPendingSave(): Promise<void> {
   const partial = pendingPartial ?? {};
   const resolvers = pendingResolvers;
@@ -48,7 +63,7 @@ async function flushPendingSave(): Promise<void> {
  * single trailing-edge write to stay under `chrome.storage.sync`'s 120
  * writes/minute rate limit when wired to slider-style controls.
  */
-export function saveSettings(partial: Partial<SettingsV1>): Promise<void> {
+export function saveSettings(partial: SaveSettingsInput): Promise<void> {
   pendingPartial = { ...(pendingPartial ?? {}), ...partial };
   if (pendingTimer !== null) clearTimeout(pendingTimer);
   return new Promise<void>((resolve, reject) => {

--- a/src/chrome/settings/storage.ts
+++ b/src/chrome/settings/storage.ts
@@ -1,0 +1,78 @@
+import type { SettingsV1 } from '../../core/settings/schema';
+import { migrate } from '../../core/settings/migrations';
+
+const KEY = 'speedreader.settings';
+const DEBOUNCE_MS = 300;
+
+/**
+ * Read settings from `chrome.storage.sync`, migrating + validating the raw
+ * value. If migration reshapes the stored value (first install, version bump,
+ * or repair of a partial payload), the canonical form is written back so the
+ * next read is a fast pass-through.
+ */
+export async function loadSettings(): Promise<SettingsV1> {
+  const result = await chrome.storage.sync.get(KEY);
+  const raw = result[KEY];
+  const settings = migrate(raw);
+  if (raw === undefined || JSON.stringify(raw) !== JSON.stringify(settings)) {
+    await chrome.storage.sync.set({ [KEY]: settings });
+  }
+  return settings;
+}
+
+let pendingPartial: Partial<SettingsV1> | null = null;
+let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingResolvers: Array<() => void> = [];
+let pendingRejectors: Array<(err: unknown) => void> = [];
+
+async function flushPendingSave(): Promise<void> {
+  const partial = pendingPartial ?? {};
+  const resolvers = pendingResolvers;
+  const rejectors = pendingRejectors;
+  pendingPartial = null;
+  pendingTimer = null;
+  pendingResolvers = [];
+  pendingRejectors = [];
+  try {
+    const current = await loadSettings();
+    const next: SettingsV1 = { ...current, ...partial, version: current.version };
+    await chrome.storage.sync.set({ [KEY]: next });
+    resolvers.forEach((r) => r());
+  } catch (err) {
+    rejectors.forEach((r) => r(err));
+  }
+}
+
+/**
+ * Save a partial settings update. Calls within 300 ms are coalesced into a
+ * single trailing-edge write to stay under `chrome.storage.sync`'s 120
+ * writes/minute rate limit when wired to slider-style controls.
+ */
+export function saveSettings(partial: Partial<SettingsV1>): Promise<void> {
+  pendingPartial = { ...(pendingPartial ?? {}), ...partial };
+  if (pendingTimer !== null) clearTimeout(pendingTimer);
+  return new Promise<void>((resolve, reject) => {
+    pendingResolvers.push(resolve);
+    pendingRejectors.push(reject);
+    pendingTimer = setTimeout(() => {
+      void flushPendingSave();
+    }, DEBOUNCE_MS);
+  });
+}
+
+/**
+ * Subscribe to settings changes from any source — including a sibling tab,
+ * the options page, or a different signed-in device via Chrome sync. Returns
+ * an unsubscribe function.
+ */
+export function subscribeSettings(listener: (s: SettingsV1) => void): () => void {
+  const handler = (
+    changes: Record<string, chrome.storage.StorageChange>,
+    area: chrome.storage.AreaName,
+  ) => {
+    if (area !== 'sync' || !changes[KEY]) return;
+    listener(migrate(changes[KEY].newValue));
+  };
+  chrome.storage.onChanged.addListener(handler);
+  return () => chrome.storage.onChanged.removeListener(handler);
+}

--- a/src/core/settings/__tests__/migrations.test.ts
+++ b/src/core/settings/__tests__/migrations.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { migrate } from '../migrations';
+import { DEFAULT_SETTINGS } from '../defaults';
+import { SettingsSchemaV1 } from '../schema';
+
+describe('migrate', () => {
+  it('returns a fresh defaults clone for undefined input (first install)', () => {
+    const result = migrate(undefined);
+    expect(result).toEqual(DEFAULT_SETTINGS);
+    // ensure it's a clone, not the singleton
+    expect(result).not.toBe(DEFAULT_SETTINGS);
+  });
+
+  it('returns defaults for null', () => {
+    expect(migrate(null)).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it('returns defaults for a string (corrupt payload)', () => {
+    expect(migrate('garbage')).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it('returns defaults for an array', () => {
+    expect(migrate([1, 2, 3])).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it('returns defaults for schema-incompatible value (out-of-range wpm)', () => {
+    expect(migrate({ ...DEFAULT_SETTINGS, wpm: 9999 })).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it('passes through a valid v1 payload', () => {
+    const valid = { ...DEFAULT_SETTINGS, wpm: 380, theme: 'dark' as const };
+    expect(migrate(valid)).toEqual(valid);
+  });
+
+  it('round-trips: default -> modify -> migrate matches modified value', () => {
+    const modified = { ...DEFAULT_SETTINGS, wpm: 320, openDyslexic: true };
+    const written = JSON.parse(JSON.stringify(modified)); // simulate storage round-trip
+    const read = migrate(written);
+    expect(read).toEqual(modified);
+    expect(SettingsSchemaV1.safeParse(read).success).toBe(true);
+  });
+
+  it('migrates a synthetic v0 payload up to v1 via the migration hook', () => {
+    // v0 lacks an explicit version field; defaults fill in the rest.
+    const v0 = { wpm: 300, theme: 'dark', font: 'Georgia', fontSize: 22 };
+    const result = migrate(v0);
+    expect(result.version).toBe(1);
+    expect(result.wpm).toBe(300);
+    expect(result.theme).toBe('dark');
+    // Fields absent in v0 come from defaults.
+    expect(result.openDyslexic).toBe(DEFAULT_SETTINGS.openDyslexic);
+    expect(result.punctuationPacing).toBe(DEFAULT_SETTINGS.punctuationPacing);
+  });
+
+  it('fills in missing fields from defaults when partial v1 is stored', () => {
+    const partial = { version: 1, wpm: 350 };
+    const result = migrate(partial);
+    expect(result.wpm).toBe(350);
+    expect(result.theme).toBe(DEFAULT_SETTINGS.theme);
+    expect(result.fontSize).toBe(DEFAULT_SETTINGS.fontSize);
+  });
+});

--- a/src/core/settings/__tests__/schema.test.ts
+++ b/src/core/settings/__tests__/schema.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { SettingsSchemaV1 } from '../schema';
+import { DEFAULT_SETTINGS } from '../defaults';
+
+describe('SettingsSchemaV1', () => {
+  it('accepts the canonical defaults', () => {
+    const parsed = SettingsSchemaV1.safeParse(DEFAULT_SETTINGS);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts a known-good payload', () => {
+    const parsed = SettingsSchemaV1.safeParse({
+      version: 1,
+      wpm: 400,
+      theme: 'dark',
+      font: 'Georgia',
+      fontSize: 24,
+      openDyslexic: true,
+      punctuationPacing: false,
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects wpm outside [100, 600]', () => {
+    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, wpm: 50 }).success).toBe(false);
+    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, wpm: 9999 }).success).toBe(false);
+  });
+
+  it('rejects wpm not multiples of 10', () => {
+    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, wpm: 255 }).success).toBe(false);
+  });
+
+  it('rejects fontSize outside [12, 48]', () => {
+    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, fontSize: 8 }).success).toBe(false);
+    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, fontSize: 64 }).success).toBe(false);
+  });
+
+  it('rejects an unknown theme', () => {
+    expect(
+      SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, theme: 'sepia' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects a wrong version literal', () => {
+    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, version: 2 }).success).toBe(false);
+  });
+});

--- a/src/core/settings/defaults.ts
+++ b/src/core/settings/defaults.ts
@@ -1,0 +1,11 @@
+import type { SettingsV1 } from './schema';
+
+export const DEFAULT_SETTINGS: SettingsV1 = {
+  version: 1,
+  wpm: 250,
+  theme: 'system',
+  font: 'system-ui',
+  fontSize: 20,
+  openDyslexic: false,
+  punctuationPacing: true,
+};

--- a/src/core/settings/index.ts
+++ b/src/core/settings/index.ts
@@ -1,0 +1,3 @@
+export { SettingsSchemaV1, CURRENT_VERSION, type SettingsV1 } from './schema';
+export { DEFAULT_SETTINGS } from './defaults';
+export { migrate } from './migrations';

--- a/src/core/settings/migrations.ts
+++ b/src/core/settings/migrations.ts
@@ -1,0 +1,44 @@
+import { SettingsSchemaV1, CURRENT_VERSION, type SettingsV1 } from './schema';
+import { DEFAULT_SETTINGS } from './defaults';
+
+type Migrator = (raw: Record<string, unknown>) => Record<string, unknown>;
+
+/**
+ * Sequential migrators keyed by source version. To add a 1->2 migration in
+ * the future, drop in `1: m1to2` and bump `CURRENT_VERSION` in `schema.ts`.
+ *
+ * Identity hook for v0->v1 keeps the composition path exercised in tests
+ * even while v1 is current.
+ */
+const MIGRATIONS: Record<number, Migrator> = {
+  0: (raw) => ({ ...raw, version: 1 }),
+};
+
+/**
+ * Best-effort migration. Never throws — corrupt or schema-incompatible input
+ * falls back to a fresh copy of `DEFAULT_SETTINGS` so a malformed payload
+ * cannot crash the service worker on cold start.
+ */
+export function migrate(rawValue: unknown): SettingsV1 {
+  if (rawValue == null || typeof rawValue !== 'object' || Array.isArray(rawValue)) {
+    return { ...DEFAULT_SETTINGS };
+  }
+
+  let value = { ...(rawValue as Record<string, unknown>) };
+  let v = typeof value.version === 'number' ? value.version : 0;
+
+  while (v < CURRENT_VERSION) {
+    const step = MIGRATIONS[v];
+    if (!step) break;
+    value = step(value);
+    v += 1;
+  }
+
+  const merged = { ...DEFAULT_SETTINGS, ...value, version: CURRENT_VERSION };
+  const parsed = SettingsSchemaV1.safeParse(merged);
+  if (!parsed.success) {
+    console.warn('[speedreader] settings failed validation, falling back to defaults', parsed.error);
+    return { ...DEFAULT_SETTINGS };
+  }
+  return parsed.data;
+}

--- a/src/core/settings/schema.ts
+++ b/src/core/settings/schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const SettingsSchemaV1 = z.object({
+  version: z.literal(1),
+  wpm: z.number().int().min(100).max(600).multipleOf(10),
+  theme: z.enum(['light', 'dark', 'system']),
+  font: z.string(),
+  fontSize: z.number().int().min(12).max(48),
+  openDyslexic: z.boolean(),
+  punctuationPacing: z.boolean(),
+});
+
+export type SettingsV1 = z.infer<typeof SettingsSchemaV1>;
+
+export const CURRENT_VERSION = 1 as const;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,13 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: false,
-    include: ['src/core/**/*.test.ts', 'src/core/**/__tests__/**/*.test.ts'],
-    exclude: ['src/chrome/**', 'node_modules/**', 'dist/**'],
+    include: [
+      'src/core/**/*.test.ts',
+      'src/core/**/__tests__/**/*.test.ts',
+      // Narrow inclusion: settings adapter only. Rest of src/chrome/** stays
+      // excluded — those surfaces are integration-tested via Playwright (#38).
+      'src/chrome/settings/**/__tests__/**/*.test.ts',
+    ],
+    exclude: ['node_modules/**', 'dist/**'],
   },
 });


### PR DESCRIPTION
## Summary

Implements issue #32 — versioned settings schema, migration hook, and chrome.storage.sync adapter — per the 2026-05-08 settings-schema spec.

## Spec section -> file mapping

- §2 Schema (Zod, v1) -> `src/core/settings/schema.ts` — exports `SettingsSchemaV1`, `SettingsV1` type, `CURRENT_VERSION`.
- §4 Defaults (single source of truth) -> `src/core/settings/defaults.ts` — `DEFAULT_SETTINGS`.
- §5 Migration strategy -> `src/core/settings/migrations.ts` — `migrate(unknown): SettingsV1`. Identity v0->v1 migrator wired in to keep the composition path exercised; `MIGRATIONS` map ready for 1->2 and beyond.
- §6 Read/Write API + §7 Debounce -> `src/chrome/settings/storage.ts` — `loadSettings` (migrate-on-load with canonical write-back), `saveSettings` (300 ms trailing-edge debounce coalescing partial updates), `subscribeSettings`.
- Re-exports: `src/core/settings/index.ts`, `src/chrome/settings/index.ts`.

## Boundary

`grep -rE '\bchrome\.' src/core/settings` returns nothing — schema/migrations stay platform-agnostic. Only the adapter touches `chrome.storage`.

## Tests (24 cases, all green)

- `schema.test.ts` (7) — accepts defaults + known-good; rejects wpm out-of-range, non-multiple-of-10, fontSize out-of-range, unknown theme, wrong version literal.
- `migrations.test.ts` (9) — undefined/null/string/array all -> defaults; out-of-range falls back; valid passes through; round-trip default->modify->migrate matches; synthetic v0->v1 hook composes; partial v1 fills from defaults.
- `storage.test.ts` (8) — first-install seeds defaults, valid stored returns as-is, corrupt repairs + writes back, **10-call debounce coalesces to 1 `set`**, version preserved through partial save, subscribe parses sync changes / ignores other areas / repairs corrupt change payload.

`npm test`, `npm run lint`, `tsc --noEmit`, `npm run build` all pass.

## Adapter-test path: 1 (sinon-chrome devDep + narrow vitest include)

`vitest.config.ts` now includes `src/chrome/settings/**/__tests__/**/*.test.ts` while the rest of `src/chrome/**` stays excluded. The actual mocking uses `vi.fn` against a hand-rolled chrome stub (let me track stored value + listener list directly — simpler than sinon-chrome's stub surface for this specific shape); `sinon-chrome` is imported to keep the dep explicit and available for other adapters later. Rationale: the 300 ms debounce + migrate-on-load round-trip are exactly the cases unit tests catch and Playwright (#38) won't.

## Spec notes for architect

- Spec §6 `loadSettings` write-back guard reads `if (raw && JSON.stringify(...))`; on first install `raw === undefined` so the falsy short-circuit skips the seed write. Implementation guards `raw === undefined` explicitly so first-install canonicalises (matches the §5 'first install -> seed DEFAULT_SETTINGS' description and is what the storage.test.ts seeds-defaults case asserts). Worth a one-line spec amend; not fixed here.
- Spec exports the schema as `SettingsV1` (line 47). Issue brief asks for `SettingsSchemaV1` (Zod) + `SettingsV1` (type). Implementation follows the brief; spec §2 should rename to `SettingsSchemaV1` to disambiguate from the type.

## Test plan

- [x] `npm test` — 38 passed (24 in settings).
- [x] `npm run lint` — clean.
- [x] `tsc --noEmit` (via `npm run build`) — clean.
- [x] `npm run build` — vite build succeeds.
- [x] Boundary check: `grep -rE '\bchrome\.' src/core/settings` -> empty.
- [ ] Manual load-unpacked smoke test deferred to #30 (options page wires this up); adapter has no UI surface to smoke alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
