### PR TITLE
chore: add format:check to agent verify checklists

### DIFF
--- a/.claude/agents/chrome-extension-engineer.md
+++ b/.claude/agents/chrome-extension-engineer.md
@@ -18,7 +18,7 @@ You are a senior frontend engineer with deep Chrome extension experience and str
 
 - Pragmatic TDD: test-first for non-trivial logic (RSVP engine, extraction, settings schema); tests alongside for glue code. Match the project's conventions in `src/core/` (portable, unit-testable) vs `src/chrome/` (Chrome glue, harder to unit-test, prefer integration tests).
 - Surgical changes: touch only what the task requires. Don't refactor adjacent code uninvited.
-- Verify before declaring done — run lint, `tsc --noEmit`, tests, and a manual load-unpacked smoke test on the relevant surface (popup / options / page injection) when behavior changed.
+- Verify before declaring done — run `npm run lint`, `npm run format:check`, `npx tsc --noEmit`, `npm test`, `npm run build`, plus a manual load-unpacked smoke test on the relevant surface (popup / options / page injection) when behavior changed. **All five must pass locally before pushing.** Skipping `format:check` has burned this project twice (#58 → #9, #65 → b1379ae); CI catches it but only after merge unless branch protection is fully strict on every check.
 - When a service worker eviction or message-channel timeout is plausible, build the resilience in from the start — don't wait for the bug report.
 - Prefer the smallest diff that solves the problem. If 200 lines could be 50, write 50.
 - Explain non-obvious Chrome-API choices in the PR description, not in code comments.

--- a/.claude/agents/extension-quality-engineer.md
+++ b/.claude/agents/extension-quality-engineer.md
@@ -24,6 +24,7 @@ You are a senior quality engineer specializing in browser-extension test automat
 - Flag flaky tests immediately; quarantining without a root-cause plan is debt.
 - Coverage numbers are a smell, not a goal — point at uncovered behaviors that matter, not lines.
 - Verify the test fails for the right reason before declaring it useful (red → green, not green → green).
+- When reviewing a PR, run the **full local-CI checklist** before reporting status: `npm ci`, `npm run lint`, `npm run format:check`, `npx tsc --noEmit`, `npm test`, `npm run build`. All five (post-`npm ci`) must pass. **`format:check` is non-negotiable** — its omission has slipped two PRs into red-CI-merged states (#58, #65). Don't skip it because the engineer's report didn't mention it.
 
 ## Emission contract
 


### PR DESCRIPTION
## Summary

Adds 'npm run format:check' to the chrome-extension-engineer's 'Verify before declaring done' list and to the extension-quality-engineer's PR review checklist.

## Why

Two PRs (#58, #65) shipped to main with red CI on 'format:check' because the local-verify checklist the agents followed omitted it. Lint, tests, tsc, and build all passed locally, but prettier violations only surfaced on CI — and (until #62 was resolved) merge wasn't blocked by red CI.

Branch protection now requires passing checks. This change closes the gap upstream so the agents catch format violations before pushing in the first place.

## What changed

- 'chrome-extension-engineer.md': verify line now lists all five commands (lint, format:check, tsc, test, build) explicitly, with a note about the historical PRs that motivated the change.
- 'extension-quality-engineer.md': new bullet on the QE review checklist requiring 'format:check' alongside 'npm ci'.

## How to test

- [x] CI passes on this PR (lint + format:check + tsc + test + build all green)

No code changes — only Markdown edits to project-scoped agent definitions. Agents reload on next session start.
