### PR TITLE
docs: recover specs #35 and #17

### DIFF
--- a/docs/superpowers/specs/2026-05-08-article-extraction.md
+++ b/docs/superpowers/specs/2026-05-08-article-extraction.md
@@ -1,0 +1,183 @@
+# Article Extraction Spec
+
+**Date:** 2026-05-08
+**Status:** Approved
+**Issue:** [#17 — Article extraction via Readability](https://github.com/chriscantu/speedreader-chrome/issues/17)
+**Milestone:** M1 (MVP parity)
+**Scope:** Decide the extraction strategy, define the extractor / tokenizer contract, fixture-test plan, and selection fallback boundary.
+
+---
+
+## Problem Statement
+
+The RSVP engine (`src/core/rsvp-engine/`) needs a stream of normalized words. Nothing in M1 ships meaningful UX without a working extractor — overlay (#19), selection fallback (#18), and the popup "Read this page" affordance all consume this contract. Extraction quality is named in the design doc (`2026-04-19-chrome-port-backlog-design.md`, Key Risks) as the **single biggest UX determinant** for the port.
+
+The Safari reference (`chriscantu/speed-reader`) advertises automatic extraction in its README but does not document the algorithm. Treating Safari as the floor (per `feedback_parity_is_floor_not_ceiling.md`): if a library beats it, take the library.
+
+## Decision
+
+**Use [`@mozilla/readability`](https://github.com/mozilla/readability) as the sole primary extractor. No Safari-port. No hybrid in M1.**
+
+### Options evaluated
+
+| Option | Pros | Cons |
+|---|---|---|
+| **A. Mozilla Readability** | Battle-tested in Firefox Reader View; MIT; maintained; handles `<article>`, `<main>`, `[role=main]`, then text-density heuristics; understands hydrated SPA DOM. | ~50 KB minified bundle cost; opinionated on listicles; no paywall awareness. |
+| **B. Safari-port** | Zero new dependency; theoretically pixel-parity with Safari output. | Safari source is undocumented from outside; reverse-engineering an undisclosed heuristic for a solo maintainer is higher cost than adopting the reference library. Likely no UX win. |
+| **C. Hybrid (Readability primary, Safari heuristics secondary)** | Maximum recall on edge cases. | Two extractors to maintain; ambiguous attribution when results diverge; dependency surface grows; not justified without evidence Readability misses on the M1 fixture corpus. |
+
+**Rationale:** Solo-maintainer scope plus "use the library everyone uses." If the fixture corpus exposes a class of pages where Readability fails systematically and a known heuristic fixes them, revisit hybrid in M2. M1 ships A.
+
+**Bundle cost:** ~50 KB minified is accepted. The popup, options page, and service worker do not import Readability — only the content script does. The cost is paid once, lazily, when the user activates SpeedReader on a tab.
+
+## Output Contract
+
+Pure data — no DOM nodes cross the extraction boundary. The engine and overlay never see HTML.
+
+```ts
+// src/core/extraction/types.ts
+export interface ExtractedArticle {
+  /** Tokenized words ready for the RSVP engine. Punctuation stays attached
+   *  (e.g. "Hello," "world.") so #15 punctuation pacing can detect it. */
+  words: string[];
+  /** Normalized plain text, paragraph-preserving (\n\n between paragraphs).
+   *  Source of truth — `words` is `tokenize(text)`. */
+  text: string;
+  title?: string;
+  byline?: string;
+  excerpt?: string;
+  siteName?: string;
+  /** location.href at extraction time. */
+  sourceUrl: string;
+  /** Which path produced this result. */
+  source: 'readability' | 'selection';
+}
+
+export type ExtractionResult =
+  | { ok: true; article: ExtractedArticle }
+  | { ok: false; reason: ExtractionFailure };
+
+export type ExtractionFailure =
+  | 'restricted-page'   // chrome://, chrome-extension://, view-source:, Web Store
+  | 'no-content'        // Readability returned null
+  | 'insufficient'      // word count below threshold (see below)
+  | 'paywall-suspected' // short visible text + subscribe-density heuristic
+  | 'unknown-error';
+```
+
+## Tokenization Boundary
+
+Two-stage pipeline. Extraction yields paragraph-preserving plain text; tokenization is a separate pure function so the same tokenizer serves both Readability output and user selections.
+
+```ts
+// src/core/tokenize/index.ts
+export function tokenize(text: string): string[];
+```
+
+**Rules:**
+
+- Split on Unicode whitespace (`\p{White_Space}` regex with `u` flag).
+- Punctuation stays attached to the adjacent word — RSVP punctuation pacing (#15) inspects trailing chars to add micro-dwell on `.`, `,`, `;`, `:`, `!`, `?`, `—`, `…`.
+- Hyphenated words (`well-being`, `state-of-the-art`) are one token.
+- Em/en dashes between words (`life — death`) split into surrounding tokens; the dash itself is dropped.
+- Contractions (`don't`, `it's`) are one token.
+- Ellipses (`...`, `…`) attach to the preceding word.
+- Strip zero-width characters (`U+200B`, `U+200C`, `U+200D`, `U+FEFF`).
+- Collapse runs of whitespace to a single space; `\n\n` between paragraphs preserved as a sentinel for #15 paragraph pacing.
+
+The tokenizer is pure, in `src/core/tokenize/`, fully unit-testable.
+
+## Code Layout
+
+| Path | Role | Boundary |
+|---|---|---|
+| `src/core/tokenize/` | `tokenize(text): string[]` — pure. | `src/core/` (no platform APIs). |
+| `src/core/extraction/types.ts` | `ExtractedArticle`, `ExtractionResult`. | `src/core/` (types only). |
+| `src/chrome/extraction/extract.ts` | Wraps `@mozilla/readability`, runs in content script, owns lifecycle (DOMContentLoaded gate, retry policy, restricted-page guard). | `src/chrome/`. |
+| `src/chrome/extraction/selection.ts` | Reads `window.getSelection()`, runs through `tokenize`. | `src/chrome/`. |
+
+**Boundary trade-off:** `src/core/README.md` previously slotted "Article extraction" under core. We're keeping the *types and tokenizer* in core (portable to Safari) but pushing the *Readability invocation and lifecycle* into `src/chrome/extraction/`. Lifecycle is platform-coupled (content-script timing, restricted-URL list, `chrome.runtime.id` for messaging). When the Safari port lands, it will mirror the wrapper under `src/safari/extraction/` and reuse the core types + tokenizer untouched. The `src/core/README.md` "planned contents" list will be amended to reflect this in the implementation PR.
+
+## Insufficient Content & Selection Fallback
+
+**Threshold:** extraction is "insufficient" when `words.length < 30`. Rationale: at the default 300 WPM, 30 words is ~6 seconds of reading — anything shorter is almost certainly nav chrome, a paywall stub, or an extraction miss, not an article worth RSVP'ing.
+
+**Trigger sequence:**
+
+1. Content script runs `extract()` after `DOMContentLoaded`.
+2. If `ok: false` with reason `no-content` or `insufficient`, retry once after `requestIdleCallback` (fallback: `setTimeout(500)`) — covers SPAs that hydrate post-paint.
+3. If retry still fails, surface failure to the popup. Popup shows: *"Couldn't find an article on this page. Select some text and click 'Read selection' to start anyway."*
+4. Popup exposes a **"Read selection"** button, enabled when the active tab reports a non-empty selection (the content script reports selection state on popup-open via `runtime.sendMessage`).
+5. M2-tracked: context-menu entry (`chrome.contextMenus`) "Read selection with SpeedReader." Out of scope for M1.
+
+## Failure Modes
+
+| Mode | Detection | Behavior |
+|---|---|---|
+| **Restricted page** (`chrome://*`, `chrome-extension://*`, `https://chrome.google.com/webstore/*`, `view-source:*`, `about:*`) | URL match in service worker before content-script injection. | Popup shows "SpeedReader can't run on this page." No extraction attempt. |
+| **SPA late hydration** | First extraction returns `insufficient`. | One retry via `requestIdleCallback` / 500 ms; no third attempt — avoids spin on infinite-scroll feeds. |
+| **Paywall-suspected** | Visible article body < 200 words AND DOM contains ≥ 2 of: `subscribe`, `paywall`, `metered`, `register to read` (case-insensitive token match in body text). | Return `paywall-suspected`; popup shows "This page may be paywalled — try selecting the visible text." Do NOT attempt bypass. |
+| **iframes** | Extractor runs in top frame only. | Out of scope for M1. Documented; tracked under #56 (`future`). |
+| **Unknown error** | Readability throws. | Catch, log to `console.warn` with structured `{ url, error }`, return `unknown-error`. No telemetry — local-only constraint. |
+
+## Test Strategy
+
+### Unit (Vitest)
+
+- **Tokenizer** — `src/core/tokenize/__tests__/`. Edge cases: ASCII baseline, contractions, hyphenated compounds, em/en dashes, ellipses, mixed punctuation, Unicode whitespace, zero-width chars, RTL text passthrough (no special handling, just don't crash), CJK (no spaces — produces one mega-token; documented limitation, see Out-of-Scope).
+- **Failure-mode classifier** — restricted-URL matcher, paywall heuristic.
+
+### Integration (Vitest + JSDOM)
+
+- **Fixture corpus** — `tests/fixtures/extraction/`. Each fixture is a saved HTML file + a sibling `.expected.json`:
+
+  ```json
+  {
+    "minWords": 400,
+    "maxWords": 1200,
+    "firstWords": ["The", "quick", "brown", "fox", "jumped"],
+    "lastWords": ["and", "they", "lived", "happily", "ever"],
+    "title": "Example Post"
+  }
+  ```
+
+- **Target corpus (10–12 fixtures):**
+  1. Plain blog post (Markdown-rendered)
+  2. NYT-style news article
+  3. Substack post
+  4. Wikipedia article
+  5. GitHub issue thread (challenges Readability; confirms behavior)
+  6. Listicle (numbered headers + short paragraphs)
+  7. Single-paragraph microblog
+  8. SPA-rendered post saved post-hydration
+  9. Short paywall stub (asserts `paywall-suspected`)
+  10. Code-heavy technical post (asserts code blocks survive as text)
+  11. (Optional) MDN docs page
+  12. (Optional) Non-English (Spanish or German) article — sanity check, no language-specific logic
+
+### E2E
+
+Deferred to Playwright (#38). Smoke: load unpacked, navigate to a fixture URL, click the popup action, assert the overlay opens with the expected first word.
+
+## Acceptance Criteria
+
+- [ ] `@mozilla/readability` added to `dependencies`; bundle delta documented in PR (~50 KB minified expected).
+- [ ] `src/core/tokenize/` exports `tokenize(text)` and passes ≥ 20 unit-test cases covering the rules above.
+- [ ] `src/core/extraction/types.ts` exports `ExtractedArticle`, `ExtractionResult`, `ExtractionFailure` with the shapes above.
+- [ ] `src/chrome/extraction/extract.ts` returns `ExtractionResult` and:
+  - Guards restricted URLs.
+  - Retries once on `insufficient` after `requestIdleCallback` / 500 ms.
+  - Returns `paywall-suspected` when the heuristic fires.
+- [ ] Fixture suite green on ≥ 10 fixtures with documented `minWords`/`maxWords`/`firstWords`/`lastWords`.
+- [ ] Selection fallback wired: popup "Read selection" button activates when content script reports a non-empty selection.
+- [ ] `tsc --noEmit` clean; `npm test` green; lint clean.
+
+## Out of Scope
+
+- Saved articles (#52, future)
+- PDF / ePub extraction (#53, future)
+- iframe extraction (#56, future)
+- Reading-position memory (#48, M2)
+- Translation, language detection, RTL-aware tokenization, CJK word segmentation (post-M1)
+- Paywall bypass (never — ethical and legal floor)
+- Context-menu entry for selection (M2)

--- a/docs/superpowers/specs/2026-05-08-responsive-overlay.md
+++ b/docs/superpowers/specs/2026-05-08-responsive-overlay.md
@@ -1,0 +1,131 @@
+# Responsive Overlay Spec
+
+**Date:** 2026-05-08
+**Status:** Approved
+**Issue:** [#35 — Responsive overlay 320 px → 4K](https://github.com/chriscantu/speedreader-chrome/issues/35)
+**Milestone:** M1 (MVP parity) with one explicit post-M1 carve-out (Document Picture-in-Picture).
+**Scope:** Pin the overlay's responsive layout philosophy, scaling formulas, control-bar adaptation, accessibility-driven breakpoints, and Chrome-only platform improvements that meaningfully help neurodivergent readers.
+
+---
+
+## Problem Statement
+
+The RSVP overlay is the only surface the reader actually sees while reading. It runs as a shadow-DOM island inside arbitrary host pages, which means we cannot rely on the host's CSS, cannot assume viewport equals usable space (DevTools, sidebars, split-screen browsers, and Document-PiP windows all consume part of the viewport), and cannot afford layout shift mid-read — losing ORP fixation costs the reader the line and is a primary failure mode for ADHD users.
+
+Safari's reference implementation targets a fixed desktop layout. Porting that as-is would regress on phones (parity floor: 320 px) and would leave Chrome-only platform affordances on the table that genuinely improve the experience for neurodivergent users (Windows high-contrast users, Document-PiP for ADHD task-overlay reading).
+
+The Safari extension is the **MVP floor, not the ceiling.**
+
+## Constraints
+
+- **Shadow-DOM isolation.** Overlay CSS cannot leak in or out. All styling is scoped; host CSS does not affect us.
+- **Container-query-first.** The overlay's usable size is independent of the viewport (browser DevTools open at the side, browser sidebars, future Document-PiP at ~400×300). Viewport queries lie about our available space.
+- **WCAG 2.2 AA at minimum.** 1.4.10 Reflow (no horizontal scroll at 320 CSS px / 400% zoom), 1.4.4 Resize Text (200% zoom without loss of content/function), 1.4.11 Non-text Contrast, 2.5.8 Target Size (Minimum) at 24×24 CSS px, and the AAA target of 44×44 where the overlay's primary controls are concerned.
+- **No layout shift mid-read.** ORP column position MUST be stable once a session starts. Re-flow on container resize is permitted between sessions, not during.
+- **MV3 + local-only.** Everything ships statically; no runtime CSS fetched from a CDN. No telemetry on which breakpoints fire.
+- **Solo-maintainer.** Bias toward fewer breakpoints and simpler CSS over pixel-perfect tuning per device class.
+
+## Decision
+
+### 1. Breakpoint philosophy — fluid-first with two container-query inflections
+
+Three tiers, measured against the overlay container via `@container`, **not** viewport:
+
+- `narrow` — `< 480px` container width. Phone-portrait, narrow PiP, side-docked DevTools.
+- `wide` — `480px – 1279px`. Default desktop, tablet landscape.
+- `ultra` — `≥ 1280px`. 4K, 21:9, ultrawide.
+
+```css
+.overlay { container-type: inline-size; container-name: rsvp; }
+
+@container rsvp (max-width: 479px)  { /* narrow */ }
+@container rsvp (min-width: 1280px) { /* ultra  */ }
+```
+
+Between inflection points, type and spacing scale fluidly via `clamp()`. This satisfies WCAG 1.4.10 (Reflow): at the 320 CSS px floor, no horizontal scroll, no clipped controls. It also satisfies 1.4.4 (Resize Text) cleanly because everything is in `rem` / `cqi` / `ch` — a 200% browser zoom triples the container query thresholds in tandem with the type, so the overlay re-tiers on zoom the same way it does on resize.
+
+### 2. Word-area sizing
+
+```css
+.word {
+  font-size: clamp(2rem, 5.5cqi + 1rem, 5.5rem);
+  line-height: 1.15;
+  font-variant-numeric: tabular-nums;
+}
+.reading-zone { max-inline-size: min(72ch, 1100px); margin-inline: auto; }
+```
+
+- **Floor `2rem` (32 px @ default).** Minimum legible RSVP size for dyslexic readers per Atkinson Hyperlegible's recommended floor; below this ORP fixation degrades.
+- **Fluid term `5.5cqi + 1rem`.** `cqi` is "1% of container inline size," so the word grows with the overlay, not the viewport. The `+ 1rem` baseline keeps the word usable when the container is very narrow (Document-PiP at 320 px wide → ~2.76rem, well above the floor).
+- **Ceiling `5.5rem` (88 px @ default).** Above this, single-word RSVP starts to require saccades the format is meant to eliminate; the format breaks down before the screen runs out.
+- **`max-inline-size: min(72ch, 1100px)`.** Caps the reading column on 4K and 21:9 monitors so ORP fixation doesn't drift across a meter of glass. `72ch` keeps the cap proportional to the chosen font; `1100px` is the absolute bound.
+
+### 3. Control-bar adaptation
+
+| Tier | Layout | Target size | Placement |
+|---|---|---|---|
+| `narrow` | Single horizontal row, icon-only, condensed | `min-height: 44px` (AAA) | **Bottom-pinned** within overlay (thumb-reach) |
+| `wide` | Icon + label, full controls visible | 40×40 CSS px (AA: ≥24, design: 40 for non-thumb pointers) | Top of reader pane |
+| `ultra` | Same as `wide`, controls grouped left/right with central word area | 40×40 | Top of reader pane |
+
+WCAG 2.5.8 minimum is 24×24. We go to 44×44 on `narrow` because that tier is presumed thumb-reachable and the cost is zero.
+
+### 4. Context-preview placement
+
+The previous-3 / upcoming-3 word peek (a documented ADHD comprehension aid) collapses by tier:
+
+- `narrow`: previous-1 + upcoming-1 only, single line above and below the word. Three-word preview crowds out the ORP column on phones.
+- `wide` / `ultra`: full previous-3 / upcoming-3.
+
+### 5. Pointer vs touch
+
+Touch affordances key off **input modality**, not container size — a Surface tablet at 1280 px is touch; a phone with a paired Bluetooth mouse is fine pointer. Conflating "small viewport" with "touch" is the regression the Safari version has.
+
+```css
+@media (pointer: coarse) { .control-bar button { min-height: 44px; min-width: 44px; } }
+@media (hover: hover)    { .control-bar button:hover { /* hover affordance */ } }
+```
+
+`(pointer: coarse)` raises target sizes regardless of tier; `(hover: hover)` gates hover-only affordances so touch users never depend on a state they can't trigger.
+
+### 6. Accessibility-driven breakpoints
+
+- **200% zoom** — covered by the `rem`-based scale; tiers re-key on the scaled container width naturally. **Verify:** at 200% browser zoom on a 1280 px viewport, the overlay renders in `narrow` tier with no horizontal scroll.
+- **400% zoom (WCAG 1.4.10 ceiling)** — at 1280 CSS px / 400%, content reflows to a 320 CSS px equivalent column. The overlay collapses to `narrow`; verify no clipped controls.
+- **`forced-colors: active`** — Windows High Contrast Mode. Replace all custom colors with system tokens (`CanvasText`, `Canvas`, `Highlight`, `HighlightText`, `ButtonText`, `ButtonFace`). ORP highlight uses `Highlight` / `HighlightText`. **This is the #1 Chrome-only accessibility win over the Safari version (M1).**
+- **`prefers-contrast: more`** — boost stroke widths and use the highest-contrast palette variant.
+- **`prefers-reduced-motion: reduce`** — affects **overlay chrome transitions only** (fades, slides, control-bar reveals). It explicitly does **NOT** alter RSVP cadence; cadence is the format. Reducing it would slow reading without consent. Pause/resume affordance is the user's escape hatch for cadence; reduced-motion is the user's escape hatch for chrome.
+
+  Photosensitive-seizure note: at user-configurable WPM ≥ 700 the per-word cadence approaches 12 Hz, well above WCAG 2.3.1's 3-flash/sec threshold for *flashing*. RSVP word swaps are not flashes (no luminance cycling against the same region), but the engine MUST hard-cap WPM at 1000 and surface a one-time warning above 600 WPM.
+
+### 7. Chrome-only improvements over Safari
+
+| Feature | Tier | User benefit | Platform | Fallback | Cost |
+|---|---|---|---|---|---|
+| `forced-colors` / `prefers-contrast` palettes | **M1** | Windows HCM users get a usable overlay; AAA-grade contrast on demand | CSS only | n/a — already covered by base styles | ~30 lines of CSS, one fixture screenshot per palette |
+| Document Picture-in-Picture reader | **post-M1, flagged** | Read in a floating window over other apps. Genuine ADHD multitask unlock — read article while on a call, read docs while coding. Safari cannot do this today. | `documentPictureInPicture` API (Chrome 116+, Edge) | Falls back to in-page overlay if API absent or `documentPictureInPicture` rejects | **Doubles overlay layout test surface** — every container-query tier must work in PiP windows down to ~240×180. Flagged behind `experimentalDocPiP` in settings; off by default. |
+| `Highlight` API for ORP underline | M1 | Native, GPU-accelerated highlight rendering for the ORP letter; smoother at high WPM, no DOM mutation per tick | CSS Custom Highlight API (Chrome 105+) | Falls back to a styled `<span>` wrapping the ORP letter | Small. Adds one capability check; both code paths share the tokenizer output. |
+| `prefers-reduced-data` palette | M1 (cheap) | Disables decorative gradients/shadows on metered connections; reduces paint cost on low-end devices | CSS media query | No-op when not asserted | ~5 lines. |
+
+Document-PiP is the headline post-M1 improvement. It's flagged not because it's risky but because it is the only proposed addition that meaningfully expands the test matrix; we want M1 stability before paying that cost.
+
+## Out of Scope
+
+- Color palette / theme detail and named-theme tokens (lives with #27 / #28).
+- Icon SVG assets and visual design.
+- Animation duration / easing curves beyond the `prefers-reduced-motion` switch.
+- Font-stack selection and OpenDyslexic toggle logic (#28).
+- Document Picture-in-Picture **UX details** — placement of controls, default window size, restore behavior. This spec only commits to the feature flag, capability check, and fallback contract.
+- i18n of shortcut hints and control labels.
+
+## Acceptance Criteria
+
+1. At a 320×568 viewport in DevTools device mode, the overlay renders without horizontal scroll, the word region computed font-size is ≥ 2rem, and all control-bar buttons are ≥ 44×44 CSS px.
+2. At a 3840×2160 viewport, the reading zone's `max-inline-size` resolves to ≤ 1100 px and the word does not exceed 5.5rem.
+3. With browser zoom at 400% on a 1280 px viewport, no element clips, no horizontal scroll appears, the overlay is in `narrow` tier, and all controls remain reachable by Tab.
+4. Under `forced-colors: active` (emulated via DevTools Rendering panel), the overlay uses only system color tokens; no fixed `#hex` values render. Axe scan passes with zero contrast violations.
+5. With `(pointer: coarse)` emulated, every control-bar button satisfies `getBoundingClientRect()` ≥ 44×44, regardless of container tier.
+6. With `prefers-reduced-motion: reduce`, overlay open/close transitions complete in ≤ 1 frame. RSVP cadence at the user-configured WPM is unchanged (verified by tick-interval measurement).
+7. With the overlay container resized live from 1200 px → 360 px, the tier switch from `wide` → `narrow` does NOT trigger a layout shift in the active word column (ORP column position stable; verified by `ResizeObserver` snapshot before/after the tick).
+8. Axe-core scan against the overlay in all three tiers passes with no `color-contrast` or `target-size` violations.
+9. Document-PiP feature flag, when enabled and supported, opens a PiP window and the overlay renders correctly down to a 320 px PiP window width; when unsupported, the toggle is hidden and the in-page overlay path is used.


### PR DESCRIPTION
## Summary

Recovery PR. Both specs were drafted in earlier agent dispatches but never made it into git — same failure class that hit the settings spec for #32 before branch protection caught it.

- **Responsive overlay (#35)** — redrafted from scratch after the prior content was lost. Container-query-first, `clamp()` word sizing, `forced-colors` and Document Picture-in-Picture as Chrome-only improvements over the Safari reference.
- **Article extraction (#17)** — the original on-disk draft from the architect dispatch; verified intact, committed without changes. Implementation is still pending so #17 stays open after merge.

Closes #35. References #17 (does not close).

## Test plan

- [ ] Spec files render correctly on the GitHub PR diff view (markdown, tables, code fences).
- [ ] CI lint / typecheck / build passes (docs-only change should be green).
- [ ] Architect reviews spec content for parity with prior decisions before merge.
