### PR TITLE
feat: pin lazy content-script injection in MV3 manifest (#73)

### DIFF
--- a/docs/superpowers/decisions/2026-05-08-lazy-injection-manifest.md
+++ b/docs/superpowers/decisions/2026-05-08-lazy-injection-manifest.md
@@ -1,0 +1,31 @@
+# ADR: Lazy content-script injection — manifest pinned to `activeTab` + `scripting`
+
+**Date:** 2026-05-08
+**Status:** Accepted
+**Issue:** [#73 — Pin extraction trigger as lazy-on-popup-open (architecture)](https://github.com/chriscantu/speedreader-chrome/issues/73)
+**Related:** [#17](https://github.com/chriscantu/speedreader-chrome/issues/17), [#45](https://github.com/chriscantu/speedreader-chrome/issues/45)
+
+## Context
+
+The article-extraction spec (`docs/superpowers/specs/2026-05-08-article-extraction.md` §"Trigger Timing — lazy on popup-open") commits behaviorally to extraction running only on popup-open, not on page load. The MV3 manifest must enforce that contract — otherwise `content_scripts` declared with `matches: ['<all_urls>']` would inject on every navigation regardless of whether the user invoked the extension, defeating the design goal of paying zero per-tab CPU cost on uninvited tabs.
+
+The previous manifest declared both an eager `content_scripts` entry and `host_permissions: ['<all_urls>']` — neither is needed under the lazy model.
+
+## Decision
+
+1. **No `content_scripts` entry in the manifest.** The content script is injected on demand by the service worker via `chrome.scripting.executeScript({ target: { tabId }, files: [...] })` when the popup posts an `extract-summary` message.
+2. **Drop `host_permissions: ['<all_urls>']`.** The `activeTab` permission grants temporary host access to the active tab on user gesture (toolbar click → popup open). Per the [Chrome `chrome.scripting` docs](https://developer.chrome.com/docs/extensions/reference/api/scripting), `activeTab` is sufficient for `executeScript` against the current tab; broad host permissions are not required.
+3. **Permission set:** `["storage", "activeTab", "scripting"]`.
+
+## Consequences
+
+- **Positive — store review.** Dropping `<all_urls>` removes the broad-host-permissions disclosure that triggers extra Chrome Web Store scrutiny. Issue #45's permission-justification document inherits a much smaller surface to defend.
+- **Positive — privacy posture.** SpeedReader has access only to a tab the user explicitly activates via the popup. Background tabs are never read.
+- **Trade-off — keyboard shortcut.** The `Ctrl+Shift+Y` global command (issue #34) cannot rely on `activeTab` directly; the command handler must open the popup (or programmatically request the user-gesture-bound permission via the `action.openPopup()` path) before invoking `executeScript`. Tracked under #34's implementation, not regressed here.
+- **Trade-off — restricted-URL guard moves to runtime.** Without an eager `content_scripts.matches` filter, the service worker is the sole gatekeeper for `chrome://`, `chrome-extension://`, and Web Store URLs. Already in scope for the extraction spec's §Failure Modes.
+- **Safari parity.** Safari's content-blocker and App Extension model is stricter than Chrome's; the lazy/`activeTab` posture aligns more closely with Safari's per-page activation, simplifying a future shared-core port.
+
+## Alternatives rejected
+
+- **Keep eager `content_scripts` + drop `<all_urls>` to specific origins.** Defeats the "general-purpose reading tool" stance — the extension must work on any page, so any non-`<all_urls>` matches list is wrong.
+- **Keep `<all_urls>` host permission as belt-and-suspenders.** Adds nothing under the lazy injection model and pays the full Web Store review cost for no functional return.

--- a/docs/superpowers/specs/2026-05-08-article-extraction.md
+++ b/docs/superpowers/specs/2026-05-08-article-extraction.md
@@ -198,3 +198,13 @@ The popup hi-fi mock (`docs/design/Speed Reader Hi-Fi.html`, surface `02 Toolbar
 **Rationale:** running Readability on every navigated tab is a per-tab CPU cost on pages the user never invokes us on, with no UX return. Lazy-on-popup-open is the floor; the eager path is a pessimization for users who only RSVP-read occasionally.
 
 **Acceptance criterion add:** the test harness MUST assert that loading a fixture page does NOT call `extract()` until a popup-open message is dispatched.
+
+### Manifest pin (issue #73)
+
+The behavioral lazy-on-popup-open contract above is enforced at the MV3 manifest level by:
+
+- **No `content_scripts` entry.** Eagerly-declared content scripts inject on every navigation matching `matches`, which would impose per-tab CPU cost on uninvited pages — exactly the failure mode this section rejects. The content script is injected on demand by the service worker via `chrome.scripting.executeScript({ target: { tabId }, files: [...] })` when the popup posts an `extract-summary` message.
+- **Permission set: `["storage", "activeTab", "scripting"]`.** No `host_permissions` declared. `activeTab` grants temporary host access to the active tab on user gesture (popup click), which is sufficient for `chrome.scripting.executeScript` per the [Chrome scripting API docs](https://developer.chrome.com/docs/extensions/reference/api/scripting). Dropping `<all_urls>` materially simplifies Chrome Web Store review (see #45).
+- **Restricted-URL guard.** Without an eager `content_scripts.matches` filter, the service worker is the sole gatekeeper for `chrome://`, `chrome-extension://`, `view-source:`, `about:`, and `https://chrome.google.com/webstore/*`. The guard is checked before every `executeScript` call (see §Failure Modes).
+
+Full rationale and trade-offs: `docs/superpowers/decisions/2026-05-08-lazy-injection-manifest.md`.

--- a/src/chrome/manifest.ts
+++ b/src/chrome/manifest.ts
@@ -2,10 +2,20 @@
  * SpeedReader Chrome Extension — Manifest V3
  *
  * This manifest is the single source of truth for the extension's
- * Chrome Web Store configuration.  Every permission and host
- * permission is documented with a user-facing justification in
- * `docs/permission-justifications.md` (precursor to the store-listing
- * doc).
+ * Chrome Web Store configuration.  Every permission is documented with
+ * a user-facing justification in `docs/permission-justifications.md`
+ * (precursor to the store-listing doc).
+ *
+ * Injection model: lazy / on-demand.  No `content_scripts` entry — the
+ * content script is injected by the service worker via
+ * `chrome.scripting.executeScript` after the user opens the popup.  The
+ * `activeTab` permission grants temporary host access on user gesture,
+ * which removes the need for `host_permissions: ['<all_urls>']`.
+ *
+ * See:
+ * - `docs/superpowers/decisions/2026-05-08-lazy-injection-manifest.md`
+ * - `docs/superpowers/specs/2026-05-08-article-extraction.md`
+ *   §"Trigger Timing — lazy on popup-open"
  *
  * Fields referenced by later issues are marked with TODO(#N).
  */
@@ -37,24 +47,29 @@ export default {
   // --- Options page -------------------------------------------------------
   options_page: 'src/chrome/options/index.html',
 
-  // --- Permissions (non-host) ---------------------------------------------
+  // --- Permissions --------------------------------------------------------
   // Each permission is justified in docs/permission-justifications.md.
+  //
+  // - storage    — persist user settings (WPM, font, theme).
+  // - activeTab  — grants temporary host access to the active tab on user
+  //                gesture (popup click).  Replaces `<all_urls>` host
+  //                permissions for the lazy-injection model.
+  // - scripting  — required to call `chrome.scripting.executeScript` from
+  //                the service worker to inject the content script on
+  //                demand.
   permissions: ['storage', 'activeTab', 'scripting'],
 
-  // --- Host permissions ---------------------------------------------------
-  // Required so the content script can run on any article page.
-  // Justification: SpeedReader is a general-purpose reading tool and must
-  // work on any URL the user visits.  See docs/permission-justifications.md.
-  host_permissions: ['<all_urls>'],
+  // --- Host permissions: intentionally omitted ----------------------------
+  // The lazy-injection model (popup-open → service worker →
+  // chrome.scripting.executeScript against the active tab) runs entirely
+  // under `activeTab`.  See ADR
+  // `docs/superpowers/decisions/2026-05-08-lazy-injection-manifest.md`.
 
-  // --- Content scripts ----------------------------------------------------
-  content_scripts: [
-    {
-      matches: ['<all_urls>'],
-      js: ['src/chrome/content/index.ts'],
-      run_at: 'document_idle',
-    },
-  ],
+  // --- Content scripts: intentionally omitted -----------------------------
+  // The content script is injected on demand via
+  // `chrome.scripting.executeScript`, NOT registered for eager match-all
+  // injection.  Eager injection would impose per-tab CPU cost on pages
+  // the user never invokes SpeedReader on.
 
   // --- Web accessible resources -------------------------------------------
   // Fonts bundled with the extension so content scripts can reference them


### PR DESCRIPTION
## Summary

Pins the MV3 manifest to enforce the lazy-on-popup-open extraction trigger committed in the article-extraction spec (PR #75). Removes the eagerly-declared `content_scripts` entry and `host_permissions: ['<all_urls>']`; relies on `activeTab` + `scripting` for on-demand injection via `chrome.scripting.executeScript` from the service worker.

Permission set: `['storage', 'activeTab', 'scripting']`. No host permissions.

## Why

- The article-extraction spec (`docs/superpowers/specs/2026-05-08-article-extraction.md` §"Trigger Timing — lazy on popup-open") commits behaviorally to extraction running only on popup-open, not on page load. An eager `content_scripts` entry would defeat that — Chrome injects matching content scripts on every navigation regardless of whether the user invoked the extension.
- Per the [Chrome scripting API docs](https://developer.chrome.com/docs/extensions/reference/api/scripting), `activeTab` is sufficient for `chrome.scripting.executeScript` against the current tab on user gesture; `<all_urls>` host permissions are not required.
- Dropping `<all_urls>` materially simplifies Chrome Web Store review (issue #45).

Full rationale: `docs/superpowers/decisions/2026-05-08-lazy-injection-manifest.md`.

## Changes

- `src/chrome/manifest.ts` — remove `content_scripts`, remove `host_permissions`. Comments call out the lazy injection model and ADR location.
- `docs/superpowers/specs/2026-05-08-article-extraction.md` — append "Manifest pin (issue #73)" subsection under "Trigger Timing — lazy on popup-open".
- `docs/superpowers/decisions/2026-05-08-lazy-injection-manifest.md` — new ADR.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm test` — 57/57 passing
- [x] `npm run build` — emits `dist/manifest.json` with no `content_scripts` and no `host_permissions`; permissions `['storage', 'activeTab', 'scripting']`
- [ ] Manual smoke: load unpacked, open popup, confirm `chrome://extensions` shows only `Read your data on the active tab when you click the extension` (deferred — content script not yet implemented; no popup-triggered injection path exists in code yet, only the manifest contract)

## Closes

Closes #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
