### PR TITLE
chore: gitignore _handoff*.md for session-bridge notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Thumbs.db
 
 # Local state for issue-creation scripts
 scripts/.milestone-numbers.tsv
+
+# Local session-bridge handoff notes (not load-bearing decisions)
+_handoff*.md


### PR DESCRIPTION
## Summary
Adds a one-line .gitignore entry for `_handoff*.md` at the repo root.

## Why
Session-bridge handoff notes between Claude sessions are inherently transient (they rot within hours). Committing them creates misleading historical artifacts. Local-only via gitignore keeps them findable from the repo without polluting history.

## How to test
- [x] CI passes
- [x] `git check-ignore _handoff.md` reports the file as ignored after merge

## Checklist
- [x] CI passes (lint, typecheck, tests, build)
- [x] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)