### PR TITLE
feat: add splitWordAtFocus + port Safari tests (#85)

### DIFF
--- a/src/core/orp/__tests__/orp.test.ts
+++ b/src/core/orp/__tests__/orp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { orp } from '../orp';
+import { orp, splitWordAtFocus } from '../orp';
 
 // ORP heuristic ported from Safari reference:
 //   chriscantu/speed-reader →
@@ -109,5 +109,57 @@ describe('orp', () => {
   it('strips multiple trailing punctuation chars: "really?!"', () => {
     // "really?!" → strip → "really" length 6 → floor(6*0.3)=1
     expect(orp('really?!')).toBe(1);
+  });
+});
+
+// Mirrors Safari `splitWordAtFocus` describe block in
+// chriscantu/speed-reader → tests/js/focus-point.test.js (lines 47-90).
+// The splitter divides a word into the substring before the ORP, the ORP
+// character itself, and the substring after it — used by the overlay to
+// render the focus character in a contrasting color.
+describe('splitWordAtFocus', () => {
+  it('splits "comprehension" into before/focus/after (Safari parity)', () => {
+    // focus-point.test.js line 48: orp=3 → 'com' | 'p' | 'rehension'
+    expect(splitWordAtFocus('comprehension')).toEqual({
+      before: 'com',
+      focus: 'p',
+      after: 'rehension',
+    });
+  });
+
+  it('splits single-char "I" with empty before/after (Safari parity)', () => {
+    // focus-point.test.js line 57
+    expect(splitWordAtFocus('I')).toEqual({
+      before: '',
+      focus: 'I',
+      after: '',
+    });
+  });
+
+  it('splits short word "the" (Safari parity)', () => {
+    // focus-point.test.js line 66: orp=0 → '' | 't' | 'he'
+    expect(splitWordAtFocus('the')).toEqual({
+      before: '',
+      focus: 't',
+      after: 'he',
+    });
+  });
+
+  it('preserves trailing punctuation in after part: "hello," (Safari parity)', () => {
+    // focus-point.test.js line 75: orp=1 → 'h' | 'e' | 'llo,'
+    expect(splitWordAtFocus('hello,')).toEqual({
+      before: 'h',
+      focus: 'e',
+      after: 'llo,',
+    });
+  });
+
+  it('returns empty parts for empty string (Safari parity)', () => {
+    // focus-point.test.js line 84
+    expect(splitWordAtFocus('')).toEqual({
+      before: '',
+      focus: '',
+      after: '',
+    });
   });
 });

--- a/src/core/orp/index.ts
+++ b/src/core/orp/index.ts
@@ -1,1 +1,1 @@
-export { orp } from './orp';
+export { orp, splitWordAtFocus } from './orp';

--- a/src/core/orp/orp.ts
+++ b/src/core/orp/orp.ts
@@ -33,3 +33,32 @@ export function orp(word: string): number {
   if (stripped.length <= 3) return 0;
   return Math.floor(stripped.length * 0.3);
 }
+
+/**
+ * Splits a word at its ORP into three parts so the overlay can render the
+ * focus character in a contrasting color while preserving the rest of the
+ * word around it.
+ *
+ * Ported for parity from the Safari reference implementation:
+ *   chriscantu/speed-reader →
+ *   SpeedReader/SpeedReaderExtension/Resources/rsvp/focus-point.js
+ *   (splitWordAtFocus).
+ *
+ * The split uses the ORP index from {@link orp} against the ORIGINAL word
+ * (not the punctuation-stripped form), so trailing punctuation remains in
+ * the `after` part. Empty input is treated as a degenerate case and all
+ * three parts are empty strings.
+ */
+export function splitWordAtFocus(word: string): {
+  before: string;
+  focus: string;
+  after: string;
+} {
+  if (word === '') return { before: '', focus: '', after: '' };
+  const idx = orp(word);
+  return {
+    before: word.slice(0, idx),
+    focus: word.charAt(idx),
+    after: word.slice(idx + 1),
+  };
+}


### PR DESCRIPTION
Closes #85.

## Gap analysis

Compared `chriscantu/speed-reader/tests/js/focus-point.test.js` against `src/core/orp/__tests__/orp.test.ts` on this branch's base.

| Safari `describe` block | Cases | Chrome status | Action |
|---|---|---|---|
| `calculateFocusPoint` | 8 | Already covered — 8 "Safari parity" cases in `orp.test.ts` lines 20-58 directly mirror these. | None (no duplicate ports). |
| `splitWordAtFocus` | 5 | Function does not exist in `src/core/orp/`. | Ported all 5 cases; added the `splitWordAtFocus` helper alongside. |

## Why expand scope to add `splitWordAtFocus`

Issue #85 framed the work as tests-only, but the Safari `splitWordAtFocus` tests can't land without the function. The Safari API ships `orp` and `splitWordAtFocus` as a pair — the splitter is the natural consumer of the ORP index, and the existing `orp.ts` JSDoc already references "the overlay to render that character in a contrasting color". Adding it now keeps the parity surface coherent and unblocks the overlay UI work (#52 etc.) without a follow-up cycle.

## Behavior

`splitWordAtFocus(word) → { before, focus, after }`:
- Empty string → all three parts empty.
- Otherwise: split the **original** word (not the punctuation-stripped form) at `orp(word)`, so trailing punctuation stays in `after` (matches Safari).

## Test plan

- [x] `npm test -- src/core/orp` — 24 pass (19 prior + 5 new)
- [x] `npm test` — full suite: 107 pass
- [x] `npm run build` — tsc + vite OK
- [x] `npm run lint` — zero warnings
- [x] `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
