### PR TITLE
test: port Safari settings-defaults parity tests (#87)

### DIFF
--- a/src/core/settings/__tests__/schema.test.ts
+++ b/src/core/settings/__tests__/schema.test.ts
@@ -43,3 +43,68 @@ describe('SettingsSchemaV1', () => {
     expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, version: 2 }).success).toBe(false);
   });
 });
+
+// Spirit-port of Safari's `clampFontSize` / `clampChunkSize` test cases from
+// chriscantu/speed-reader → tests/js/settings-defaults.test.js. Safari uses
+// pure clamp helpers that return MIN/MAX/DEFAULT for out-of-range or NaN
+// input. Chrome rejects-on-parse via Zod instead. Both strategies protect
+// downstream code from invalid values; these tests assert the rejection
+// behavior at the same boundaries Safari clamps to.
+describe('SettingsSchemaV1 — boundary cases (Safari parity)', () => {
+  it('accepts fontSize at lower boundary 12 (parity: clampFontSize accepts FONT_SIZE_MIN)', () => {
+    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, fontSize: 12 }).success).toBe(true);
+  });
+
+  it('accepts fontSize at upper boundary 48 (parity: clampFontSize accepts FONT_SIZE_MAX)', () => {
+    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, fontSize: 48 }).success).toBe(true);
+  });
+
+  it('accepts wpm at lower boundary 100', () => {
+    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, wpm: 100 }).success).toBe(true);
+  });
+
+  it('accepts wpm at upper boundary 600', () => {
+    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, wpm: 600 }).success).toBe(true);
+  });
+
+  it('rejects fontSize NaN (parity: clampFontSize returns FONT_SIZE_DEFAULT)', () => {
+    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, fontSize: NaN }).success).toBe(false);
+  });
+
+  it('rejects fontSize string (parity: clampFontSize returns FONT_SIZE_DEFAULT)', () => {
+    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, fontSize: 'big' }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects wpm NaN', () => {
+    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, wpm: NaN }).success).toBe(false);
+  });
+
+  it('rejects missing wpm key', () => {
+    const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
+    delete partial.wpm;
+    expect(SettingsSchemaV1.safeParse(partial).success).toBe(false);
+  });
+});
+
+// Spirit-port of Safari's `SETTINGS_KEYS` / `SETTINGS_DEFAULTS` checks.
+// Safari maintains a flat key list constant; Chrome derives the key set
+// from the Zod schema shape. Chrome's design intentionally diverges:
+//   - Chrome KEEPS `theme` (light/dark/system). Safari removed it.
+//   - Chrome lacks `paper`, `alignment`, `chunkSize` — `paper` adjudicated
+//     against Chrome's theme system (#74), `alignment` and `chunkSize`
+//     tracked in their own follow-up issues.
+//   - Chrome has `font`, `openDyslexic`, `punctuationPacing` — not in Safari.
+describe('DEFAULT_SETTINGS covers every schema field (Safari parity)', () => {
+  it('DEFAULT_SETTINGS round-trips through the schema', () => {
+    expect(SettingsSchemaV1.safeParse(DEFAULT_SETTINGS).success).toBe(true);
+  });
+
+  it('DEFAULT_SETTINGS has a value for every schema key', () => {
+    const shapeKeys = Object.keys(SettingsSchemaV1.shape);
+    for (const key of shapeKeys) {
+      expect(DEFAULT_SETTINGS).toHaveProperty(key);
+    }
+  });
+});


### PR DESCRIPTION
Closes #87.

## Gap analysis

Compared `chriscantu/speed-reader/tests/js/settings-defaults.test.js` against `src/core/settings/`.

| Safari `describe` block | Cases | Chrome status | Action |
|---|---|---|---|
| `clampFontSize` | 6 | Boundary rejection covered partially via `SettingsSchemaV1` (`fontSize` range [12, 48]); boundary-inclusive + NaN + non-number cases were missing. | Ported as spirit-equivalent Zod rejection tests (boundaries 12/48 accepted, NaN/string rejected). |
| `SETTINGS_KEYS` | 1 | Chrome derives keys from the Zod schema shape; no flat constant. | Ported as "DEFAULT_SETTINGS has a value for every schema key". |
| `SETTINGS_DEFAULTS` | 2 | `DEFAULT_SETTINGS` exists. Coverage was implicit ("accepts the canonical defaults"). | Added explicit shape-coverage test. |
| `validateAlignment` | 5 | **Field doesn't exist** in Chrome — `alignment` not in schema. | Filed as #93 (schema bump + migration); not ported here. |
| `clampChunkSize` | 5 | **Field doesn't exist** in Chrome — `chunkSize` not in schema. | Already tracked in **#51** (Chunk size 2–3 word display). |
| `validatePaper` | 6 | **Field doesn't exist** in Chrome — `paper` adjudicated against Chrome's `theme` system. | Tracked under **#74** (Theme expansion). |
| `SETTINGS_KEYS includes paper` + `does not have theme in key list` | 2 | Chrome **intentionally diverges**: keeps `theme`, lacks `paper`. Documented as comment in new test block. | No port — divergence is by design per `CLAUDE.md` ("Safari parity is MVP floor, not ceiling"). |

## Why spirit-port instead of literal port

Safari exposes pure clamp helpers (`clampFontSize`, `clampChunkSize`) that mutate invalid input to MIN/MAX/DEFAULT. Chrome rejects invalid input via Zod parse failures. Both strategies protect downstream code; literal porting the clamp functions would either duplicate or replace the Zod approach. The new tests assert the rejection behavior at the same boundaries Safari clamps to, which is the spec-level intent Safari encoded.

## Divergence documented in test file

```ts
//   - Chrome KEEPS `theme` (light/dark/system). Safari removed it.
//   - Chrome lacks `paper`, `alignment`, `chunkSize` — `paper` adjudicated
//     against Chrome's theme system (#74), `alignment` and `chunkSize`
//     tracked in their own follow-up issues.
//   - Chrome has `font`, `openDyslexic`, `punctuationPacing` — not in Safari.
```

## Test plan

- [x] `npm test -- src/core/settings` — 26 pass (16 prior + 10 new)
- [x] `npm test` — full suite: 117 pass
- [x] `npm run build` — tsc + vite OK
- [x] `npm run lint` — zero warnings
- [x] `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
