### PR TITLE
test: port Safari state-machine parity tests (#86)

### DIFF
--- a/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
+++ b/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
@@ -196,4 +196,67 @@ describe('createRsvpEngine', () => {
       expect(() => createRsvpEngine({ words: [], wpm: Infinity })).toThrow(RangeError);
     });
   });
+
+  // Spirit-port of Safari `state-machine.test.js` `init` block (WPM clamping)
+  // and `togglePlayPause` block. Chrome's engine deliberately diverges:
+  //
+  //   - Safari clamps wpm into [100, 600] inside the state machine
+  //     (`init('Hello world.', { wpm: 50 })` → `sm.wpm === 100`). Chrome
+  //     keeps the engine permissive — any positive finite number is
+  //     accepted — and enforces the [100, 600] product range at the
+  //     persistence layer via `SettingsSchemaV1`. This separates
+  //     control-surface validation from engine cadence math.
+  //
+  //   - Safari ships a `togglePlayPause()` helper on the state machine.
+  //     Chrome's engine intentionally omits it; callers compose
+  //     `pause()` / `resume()` against the public `state` getter.
+  describe('Safari parity / divergence', () => {
+    it('engine accepts wpm below Safari clamp floor (100); clamping is a settings concern', () => {
+      // Equivalent Safari case: `init('Hello world.', { wpm: 50 })` clamps to 100.
+      // Chrome accepts 50 and emits words at 60000/50 = 1200ms cadence.
+      const engine = createRsvpEngine({ words: ['a', 'b'], wpm: 50 });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      // 'a' emits synchronously.
+      expect(events).toHaveLength(1);
+      vi.advanceTimersByTime(1199);
+      expect(events).toHaveLength(1);
+      vi.advanceTimersByTime(1);
+      expect(events).toHaveLength(2);
+    });
+
+    it('engine accepts wpm above Safari clamp ceiling (600); clamping is a settings concern', () => {
+      // Equivalent Safari case: `init('Hello world.', { wpm: 999 })` clamps to 600.
+      // Chrome accepts 999 and emits at 60000/999 ≈ 60.06ms.
+      const engine = createRsvpEngine({ words: ['a', 'b'], wpm: 999 });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      expect(events).toHaveLength(1);
+      vi.advanceTimersByTime(61);
+      expect(events).toHaveLength(2);
+    });
+
+    it('pause/resume cycles compose into a togglePlayPause equivalent', () => {
+      // Equivalent Safari cases: `togglePlayPause` (plays when paused, pauses
+      // when playing). Chrome composes `pause()` / `resume()` against the
+      // exposed state.
+      const engine = createRsvpEngine({ words: ['a', 'b', 'c'], wpm: 300 });
+      engine.start();
+      expect(engine.state).toBe('playing');
+
+      // First toggle: playing → paused
+      if (engine.state === 'playing') engine.pause();
+      expect(engine.state).toBe('paused');
+
+      // Second toggle: paused → playing
+      if (engine.state === 'paused') engine.resume();
+      expect(engine.state).toBe('playing');
+
+      // Third toggle round-trip
+      if (engine.state === 'playing') engine.pause();
+      expect(engine.state).toBe('paused');
+    });
+  });
 });


### PR DESCRIPTION
Closes #86.

## Gap analysis

Compared `chriscantu/speed-reader/tests/js/state-machine.test.js` (Safari `RSVPStateMachine`) against `src/core/rsvp-engine/createRsvpEngine`.

Fundamental architectural divergence — Safari ships a monolithic class that handles tokenization + state + chunks + seek + time + context preview + sentence nav. Chrome ships a lean factory whose single responsibility is word emission at a WPM cadence; the rest is decomposed into separate modules (`tokenize`, future `pacing`, future controls API).

| Safari `describe` block | Cases | Chrome status | Action |
|---|---|---|---|
| `init` (text → words) | 7 | Tokenization is a separate `tokenize` module; engine consumes `words: string[]`. | Already covered by existing engine + tokenize tests. |
| `init` wpm clamping | 3 | **Divergent**: Safari clamps `[50, 100]` → 100. Chrome engine accepts any positive finite wpm; clamping lives at the settings layer (`SettingsSchemaV1`). | Ported as 2 spirit tests documenting the divergence. |
| `play` / `pause` | 4 | Covered by existing `pause / resume` block. | No additional cases needed. |
| `togglePlayPause` | 2 | Chrome composes `pause()` / `resume()` against the exposed `state`; no helper. | Ported as 1 composition test ("pause/resume cycles compose into a togglePlayPause equivalent"). |
| `tick` (advance + delay) | 8 | Covered by existing `multi-word stream at fixed WPM`. Punctuation-pause cases need #91 (`calculateDelay`). | No additional cases here; #91 will own them. |
| `prevSentence` / `nextSentence` | 7 | **Missing feature**, depends on #90 (sentence-boundary detection). | Deferred to #90 follow-ups. |
| `adjustWpm` | covered by `setWpm mid-stream` | ✓ | Already covered. |
| `currentWord` / `progress` | 2 / 4 | **Missing feature**. | Filed as **#96**. |
| `seekTo` (+ `seekTo with chunks`) | combined | **Missing feature**. | Filed as **#95**. |
| `timeElapsed` / `timeRemaining` (+ `with chunks`) | combined | **Missing feature**. | Filed as **#96**. |
| `contextSentence` (+ `with chunks`) | combined | **Missing feature**, depends on #90. | Filed as **#97**. |
| Chunks (`init with chunkSize`, `tick with chunks`, `rebuildChunks`, `currentDisplay`, etc.) | many | **Missing feature**, multi-word display. | Already tracked in **#51**. |

## What was ported (3 tests)

```ts
describe('Safari parity / divergence', () => {
  it('engine accepts wpm below Safari clamp floor (100); clamping is a settings concern', …);
  it('engine accepts wpm above Safari clamp ceiling (600); clamping is a settings concern', …);
  it('pause/resume cycles compose into a togglePlayPause equivalent', …);
});
```

In-code comment documents the divergence rationale so future readers don't accidentally add clamp logic into the engine layer.

## Follow-up issues filed

- #95 — Add `seekTo` API to rsvp-engine
- #96 — Add `progress` / `timeElapsed` / `timeRemaining` to rsvp-engine
- #97 — Add `contextSentence` to rsvp-engine (depends on #90)

Pre-existing follow-ups already covering Safari surface: #51 (chunks), #90 (sentence-boundary), #91 (punctuation-aware pacing).

## Test plan

- [x] `npm test -- src/core/rsvp-engine` — 16 pass (13 prior + 3 new)
- [x] `npm test` — full suite: 110 pass on the rebased branch; 120 expected after merge with main (+10 from #87)
- [x] `npm run build` — tsc + vite OK
- [x] `npm run lint` — zero warnings
- [x] `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
