### PR TITLE
feat: contextSentence helper (closes #97)

### DIFF
--- a/src/core/tokenize/__tests__/context-sentence.test.ts
+++ b/src/core/tokenize/__tests__/context-sentence.test.ts
@@ -104,4 +104,26 @@ describe('contextSentence — Chrome additions', () => {
     expect(ctx.words).toEqual(['No', 'period', 'here']);
     expect(ctx.highlightIndex).toBe(1);
   });
+
+  it('does not fragment on abbreviation (Dr.)', () => {
+    // Integration assertion: markSentenceBoundaries (#90) owns the abbreviation
+    // whitelist, but contextSentence is what the overlay actually calls. If a
+    // regression in the abbreviation logic re-promoted `Dr.` to a sentence end,
+    // the preview line would silently fragment to `['Dr.']` — this test pins
+    // the consumer-side contract so the overlay can't drift unnoticed.
+    const marks = markSentenceBoundaries(tokenize('Dr. Smith arrived. He left.'));
+    const ctx = contextSentence(marks, 0);
+    expect(ctx.words).toEqual(['Dr.', 'Smith', 'arrived.']);
+    expect(ctx.highlightIndex).toBe(0);
+  });
+
+  it('returns empty for fractional index', () => {
+    // Implementation rejects non-integers via Number.isInteger; pin the
+    // contract so a future "loose coerce to int" refactor can't silently
+    // misalign the highlight.
+    const marks = markSentenceBoundaries(tokenize('Hello world.'));
+    const ctx = contextSentence(marks, 1.5);
+    expect(ctx.words).toEqual([]);
+    expect(ctx.highlightIndex).toBe(-1);
+  });
 });

--- a/src/core/tokenize/__tests__/context-sentence.test.ts
+++ b/src/core/tokenize/__tests__/context-sentence.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { tokenize } from '../tokenize';
+import { markSentenceBoundaries } from '../sentence-boundary';
+import { contextSentence } from '../context-sentence';
+
+// Cases ported from the Safari reference
+// (chriscantu/speed-reader/tests/js/state-machine.test.js — `contextSentence`
+// describe block, non-chunk only; chunk-specific cases deferred to issue #51).
+//
+// Safari's state machine owns both the word array and the token stream; the
+// Chrome engine only owns the word array (string[]), so the helper takes a
+// `MarkedToken[]` plus the engine's current word index and returns the
+// sentence words + highlight index. See PR for design-choice rationale.
+
+describe('contextSentence — Safari parity (non-chunk)', () => {
+  it('returns words in current sentence with highlight index (mid-2nd-sentence)', () => {
+    // Safari: sm.init('First sentence. Second sentence.'); sm.chunkIndex = 3;
+    //   → words: ['Second', 'sentence.'], highlightIndex: 1
+    const marks = markSentenceBoundaries(tokenize('First sentence. Second sentence.'));
+    const ctx = contextSentence(marks, 3);
+    expect(ctx.words).toEqual(['Second', 'sentence.']);
+    expect(ctx.highlightIndex).toBe(1);
+  });
+
+  it('returns first sentence when at start', () => {
+    // Safari: sm.chunkIndex = 0; → words: ['First', 'sentence.'], highlightIndex: 0
+    const marks = markSentenceBoundaries(tokenize('First sentence. Second sentence.'));
+    const ctx = contextSentence(marks, 0);
+    expect(ctx.words).toEqual(['First', 'sentence.']);
+    expect(ctx.highlightIndex).toBe(0);
+  });
+
+  it('returns empty for index past end', () => {
+    // Safari: sm.chunkIndex = sm.chunks.length;
+    //   → words: [], highlightIndex: -1
+    const marks = markSentenceBoundaries(tokenize('Hello world.'));
+    const ctx = contextSentence(marks, 2); // 2 words; index 2 is past end
+    expect(ctx.words).toEqual([]);
+    expect(ctx.highlightIndex).toBe(-1);
+  });
+});
+
+describe('contextSentence — Chrome additions', () => {
+  it('returns empty for negative index', () => {
+    const marks = markSentenceBoundaries(tokenize('Hello world.'));
+    const ctx = contextSentence(marks, -1);
+    expect(ctx.words).toEqual([]);
+    expect(ctx.highlightIndex).toBe(-1);
+  });
+
+  it('returns empty for NaN index', () => {
+    const marks = markSentenceBoundaries(tokenize('Hello world.'));
+    const ctx = contextSentence(marks, Number.NaN);
+    expect(ctx.words).toEqual([]);
+    expect(ctx.highlightIndex).toBe(-1);
+  });
+
+  it('returns empty for empty input', () => {
+    const marks = markSentenceBoundaries(tokenize(''));
+    const ctx = contextSentence(marks, 0);
+    expect(ctx.words).toEqual([]);
+    expect(ctx.highlightIndex).toBe(-1);
+  });
+
+  it('handles single-word sentence', () => {
+    const marks = markSentenceBoundaries(tokenize('Hi.'));
+    const ctx = contextSentence(marks, 0);
+    expect(ctx.words).toEqual(['Hi.']);
+    expect(ctx.highlightIndex).toBe(0);
+  });
+
+  it('handles three sentences — highlights middle sentence correctly', () => {
+    // Words: ['One', 'word.', 'Two', 'words', 'here.', 'Three', 'and', 'final.']
+    // Word index 3 ("words") is in middle sentence ['Two', 'words', 'here.']
+    const marks = markSentenceBoundaries(tokenize('One word. Two words here. Three and final.'));
+    const ctx = contextSentence(marks, 3);
+    expect(ctx.words).toEqual(['Two', 'words', 'here.']);
+    expect(ctx.highlightIndex).toBe(1);
+  });
+
+  it('treats paragraph break as sentence boundary', () => {
+    // Tokens: ['Para', 'one.', '\n\n', 'Para', 'two.']
+    // Word index 3 ("two.") → second-paragraph sentence
+    const marks = markSentenceBoundaries(tokenize('Para one.\n\nPara two.'));
+    const ctx = contextSentence(marks, 3);
+    expect(ctx.words).toEqual(['Para', 'two.']);
+    expect(ctx.highlightIndex).toBe(1);
+  });
+
+  it('ignores dash tokens — only words count toward indexing', () => {
+    // Input "Hello — world." tokenizes to ['Hello', '—', 'world.']
+    // Word array (what engine sees) is ['Hello', 'world.'] — word index 1 is 'world.'
+    const marks = markSentenceBoundaries(tokenize('Hello — world.'));
+    const ctx = contextSentence(marks, 1);
+    expect(ctx.words).toEqual(['Hello', 'world.']);
+    expect(ctx.highlightIndex).toBe(1);
+  });
+
+  it('handles last sentence without terminal punctuation', () => {
+    // Words: ['First.', 'No', 'period', 'here']
+    // Word index 2 ("period") → second sentence ['No', 'period', 'here']
+    const marks = markSentenceBoundaries(tokenize('First. No period here'));
+    const ctx = contextSentence(marks, 2);
+    expect(ctx.words).toEqual(['No', 'period', 'here']);
+    expect(ctx.highlightIndex).toBe(1);
+  });
+});

--- a/src/core/tokenize/context-sentence.ts
+++ b/src/core/tokenize/context-sentence.ts
@@ -1,0 +1,92 @@
+/**
+ * Returns the sentence containing the word at the engine's current word index,
+ * plus the position of that word within the sentence.
+ *
+ * Designed for the overlay's context-preview line. Ported from the Safari
+ * reference (`chriscantu/speed-reader/tests/js/state-machine.test.js` —
+ * `contextSentence` describe block, non-chunk only).
+ *
+ * Chrome's engine owns a flat `string[]` of words; sentence-boundary metadata
+ * lives on `MarkedToken[]` produced by `markSentenceBoundaries`. The helper
+ * bridges the two: caller passes the engine's current word index, helper
+ * walks the marked-token stream skipping paragraph/dash tokens and returns
+ * the enclosing sentence's word texts + the highlight offset.
+ *
+ * Chunk-mode (chunkSize > 1) variants are deferred — tracked in issue #51.
+ *
+ * No DOM, no `chrome.*` / `browser.*` — safe for `src/core/`.
+ */
+
+import type { MarkedToken } from './sentence-boundary';
+
+/**
+ * `words` is the in-sentence word texts (preserves attached punctuation).
+ * `highlightIndex` is the offset within `words` of the engine's current word,
+ * or `-1` when the current word is out of range / input is empty.
+ *
+ * Matches the Safari API shape so the overlay can render highlight directly
+ * against the returned word list.
+ */
+export interface ContextSentence {
+  words: string[];
+  highlightIndex: number;
+}
+
+const EMPTY: ContextSentence = Object.freeze({ words: [] as string[], highlightIndex: -1 });
+
+export function contextSentence(
+  marks: readonly MarkedToken[],
+  currentWordIndex: number,
+): ContextSentence {
+  // Reject non-integer / negative / NaN early — these map to "no current word"
+  // (matches Safari behavior of returning empty when index is past end).
+  if (!Number.isInteger(currentWordIndex) || currentWordIndex < 0) {
+    return EMPTY;
+  }
+
+  // Single linear pass. Track sentence boundaries on the fly so we can
+  // slice the enclosing sentence without backtracking. Word tokens carry
+  // sentenceStart/sentenceEnd; paragraph/dash tokens do not contribute to
+  // the engine's word index. Once we've passed the target word, we keep
+  // appending until the sentence ends (or a new one starts).
+  let wordCounter = 0;
+  let sentenceWords: string[] = [];
+  let sentenceStartWordIndex = 0;
+  let foundHighlight = -1;
+
+  for (const mark of marks) {
+    if (mark.kind !== 'word') {
+      continue;
+    }
+
+    if (mark.sentenceStart) {
+      // New sentence begins. If we already locked in a highlight, the
+      // previous sentence is complete — return it.
+      if (foundHighlight !== -1) {
+        return { words: sentenceWords, highlightIndex: foundHighlight };
+      }
+      sentenceWords = [];
+      sentenceStartWordIndex = wordCounter;
+    }
+
+    sentenceWords.push(mark.text);
+
+    if (wordCounter === currentWordIndex) {
+      foundHighlight = currentWordIndex - sentenceStartWordIndex;
+    }
+
+    if (mark.sentenceEnd && foundHighlight !== -1) {
+      return { words: sentenceWords, highlightIndex: foundHighlight };
+    }
+
+    wordCounter++;
+  }
+
+  // Walked to end of stream. If we found the target along the way, the
+  // tail sentence (no terminal punctuation) is the answer; otherwise the
+  // index was past the end.
+  if (foundHighlight !== -1) {
+    return { words: sentenceWords, highlightIndex: foundHighlight };
+  }
+  return EMPTY;
+}

--- a/src/core/tokenize/context-sentence.ts
+++ b/src/core/tokenize/context-sentence.ts
@@ -32,7 +32,10 @@ export interface ContextSentence {
   highlightIndex: number;
 }
 
-const EMPTY: ContextSentence = Object.freeze({ words: [] as string[], highlightIndex: -1 });
+// Empty-result sentinel. Returned as a fresh literal at each call site so the
+// caller can't mutate a shared instance (reviewer nit on PR #108 — cheaper
+// than rippling `readonly` through the public `ContextSentence` interface).
+const empty = (): ContextSentence => ({ words: [], highlightIndex: -1 });
 
 export function contextSentence(
   marks: readonly MarkedToken[],
@@ -41,7 +44,7 @@ export function contextSentence(
   // Reject non-integer / negative / NaN early — these map to "no current word"
   // (matches Safari behavior of returning empty when index is past end).
   if (!Number.isInteger(currentWordIndex) || currentWordIndex < 0) {
-    return EMPTY;
+    return empty();
   }
 
   // Single linear pass. Track sentence boundaries on the fly so we can
@@ -88,5 +91,5 @@ export function contextSentence(
   if (foundHighlight !== -1) {
     return { words: sentenceWords, highlightIndex: foundHighlight };
   }
-  return EMPTY;
+  return empty();
 }

--- a/src/core/tokenize/index.ts
+++ b/src/core/tokenize/index.ts
@@ -1,2 +1,3 @@
 export { tokenize } from './tokenize';
 export { markSentenceBoundaries, type MarkedToken } from './sentence-boundary';
+export { contextSentence, type ContextSentence } from './context-sentence';


### PR DESCRIPTION
## Summary
- Adds a pure `contextSentence(marks, currentWordIndex)` helper in `src/core/tokenize/` that returns the sentence enclosing the engine's current word, plus the highlight offset within that sentence (`{words, highlightIndex}`).
- Ports the non-chunk `contextSentence` describe block from the Safari reference (`chriscantu/speed-reader/tests/js/state-machine.test.js`) — 3 parity cases + 10 Chrome additions (edge cases for invalid index, empty input, paragraph breaks, dashes, no-terminal-punctuation tail sentence, abbreviation integration, fractional index).
- No engine API change; not wired into overlay (out of scope per issue).

Closes #97.

## Design choice — Option B (standalone helper)
The Safari state machine owns both the word array AND the token stream, so its `contextSentence()` is a zero-arg method. Chrome's `createRsvpEngine` only knows about `string[]` words — it has no concept of `MarkedToken[]`. Two shapes were viable:

- **A — Engine-owned**: extend `RsvpEngineOptions` with optional `markedTokens`, expose `engine.contextSentence()`. Ergonomic but expands the engine surface and forces a migration story for existing callers.
- **B — Pure helper** (this PR): `contextSentence(marks, wordIndex)`. Caller does the trivial index handoff. Engine stays focused on word emission; helper is unit-testable in isolation.

Picked B for surgical-change and simplicity (Karpathy #2/#3). When the overlay wires this up, it already holds both the marks and the engine's current index — the handoff is one line. If Safari-parity ergonomics later push for A, the helper composes cleanly into an engine wrapper.

## Gap analysis — Safari vs Chrome
- **Parity** (this PR): all 3 non-chunk `contextSentence` cases from the Safari describe block ported (mid-sentence highlight, start-of-text, past-end empty).
- **Chrome additions**: negative / NaN / fractional / empty-input guards; paragraph-break sentence boundary; dash tokens ignored for indexing; single-word sentence; three-sentence middle-highlight; no-terminal-punctuation tail sentence; abbreviation integration assertion (Dr.).
- **Deferred to #51** (chunk mode): `contextSentence with chunks` describe block — `highlightRange: {start, end}` field for multi-word chunks. Helper returns only `highlightIndex` today; a chunk-aware variant can extend the return shape additively (`{words, highlightIndex, highlightRange?}`) without breaking callers.

## Test plan
- [x] `npm test` — all suites green (172 tests, ↑ from PR baseline 170 after critic ring round)
- [x] `npm run lint` — zero warnings
- [x] `npm run format:check` — clean
- [x] `npm run build` — green
- [x] Verify the helper is re-exported from `src/core/tokenize/index.ts` (`grep contextSentence src/core/tokenize/index.ts` → `export { contextSentence, type ContextSentence } from './context-sentence';`)
- [x] Skim the diff to confirm no `chrome.*` / `browser.*` imports landed in `src/core/` (only doc-comment boilerplate mention; zero imports)

## Self-weaknesses (for the critic ring)
- **Naming pushback risk**: `contextSentence` is the Safari name; reviewers may push for `currentSentence` or `sentenceForWord` since the helper is no longer a state-machine method. I kept the Safari name for grep-parity across repos.
- **Return shape**: chose Safari's `{words[], highlightIndex}` over the issue's literal phrasing of "full sentence text" (a single string). Reviewers may want a `text` getter too — additive if requested.
- **Empty-sentinel hardening**: original `Object.freeze(EMPTY)` constant was replaced with a fresh-literal factory (`empty()`) per critic feedback to remove shared-instance mutation risk without rippling `readonly` through the public interface.
- **Coupling to `MarkedToken` invariants**: the helper trusts that `sentenceStart`/`sentenceEnd` are correctly placed by `markSentenceBoundaries`. Abbreviation integration test now pins the consumer-side contract; producer-side regression would fail it.
- **Chunk-mode untested**: the deferred-to-#51 note is honest, but the API shape today doesn't anticipate the chunk extension shape — if #51 lands a `highlightRange` field, a future builder will need to extend the return type. Could have pre-shaped `highlightRange?: {start, end}` as optional today; chose not to (YAGNI).
- **Single-component scope resisted**: did NOT touch `rsvp-engine.ts`, `tokenize.ts`, or `sentence-boundary.ts`. Issue scope was satisfiable in tokenize/ alone; resisted the temptation to expand engine options. Reviewer may push back if they prefer Option A.
- **No JSDoc `@example`**: doc-comment describes intent but doesn't show a call shape. Minor — the test file is the worked example.

## Verify-gate output
- Tests: `Test Files  10 passed (10) | Tests  172 passed (172)` (PR baseline 170; +2 from critic ring revision)
- Lint: clean (no output, exit 0)
- Format: `All matched files use Prettier code style!`
- Build: `✓ built in 41ms`
