### PR TITLE
feat: alignment field + schema V1->V2 bump (#93)

### DIFF
--- a/src/chrome/settings/__tests__/storage.test.ts
+++ b/src/chrome/settings/__tests__/storage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import sinonChrome from 'sinon-chrome';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
-import type { SettingsV1 } from '../../../core/settings/schema';
+import type { SettingsV2 } from '../../../core/settings/schema';
 import { DEBOUNCE_MS } from '../storage';
 
 const KEY = 'speedreader.settings';
@@ -81,7 +81,7 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('loadSettings returns valid stored payload as-is', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS, wpm: 380 } satisfies SettingsV1;
+    storedRaw = { ...DEFAULT_SETTINGS, wpm: 380 } satisfies SettingsV2;
     const { loadSettings } = await import('../storage');
     const settings = await loadSettings();
     expect(settings.wpm).toBe(380);
@@ -96,7 +96,7 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('saveSettings coalesces 10 calls within 300ms into one write', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV1;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV2;
     const { saveSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
@@ -113,19 +113,19 @@ describe('chrome settings storage adapter', () => {
     // Exactly one set call (the trailing-edge write); set may also fire from
     // an internal load() canonicalisation if storedRaw mismatched, so assert
     // the *final* persisted wpm rather than count alone.
-    const finalStored = storedRaw as SettingsV1;
+    const finalStored = storedRaw as SettingsV2;
     expect(finalStored.wpm).toBe(340);
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
   });
 
   it('saveSettings preserves the version field', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV1;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV2;
     const { saveSettings } = await import('../storage');
     const p = saveSettings({ theme: 'dark' });
     await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
     await p;
-    const stored = storedRaw as SettingsV1;
-    expect(stored.version).toBe(1);
+    const stored = storedRaw as SettingsV2;
+    expect(stored.version).toBe(2);
     expect(stored.theme).toBe('dark');
   });
 
@@ -134,7 +134,7 @@ describe('chrome settings storage adapter', () => {
     const listener = vi.fn();
     const unsubscribe = subscribeSettings(listener);
 
-    const next: SettingsV1 = { ...DEFAULT_SETTINGS, wpm: 420 };
+    const next: SettingsV2 = { ...DEFAULT_SETTINGS, wpm: 420 };
     emitChange(next, 'sync');
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith(next);

--- a/src/chrome/settings/storage.ts
+++ b/src/chrome/settings/storage.ts
@@ -1,10 +1,10 @@
-import type { SettingsV1 } from '../../core/settings/schema';
+import type { SettingsV2 } from '../../core/settings/schema';
 import { migrate } from '../../core/settings/migrations';
 
 const KEY = 'speedreader.settings';
 export const DEBOUNCE_MS = 300;
 
-export type SaveSettingsInput = Omit<Partial<SettingsV1>, 'version'>;
+export type SaveSettingsInput = Omit<Partial<SettingsV2>, 'version'>;
 
 /**
  * Read settings from `chrome.storage.sync`, migrating + validating the raw
@@ -12,7 +12,7 @@ export type SaveSettingsInput = Omit<Partial<SettingsV1>, 'version'>;
  * or repair of a partial payload), the canonical form is written back so the
  * next read is a fast pass-through.
  */
-export async function loadSettings(): Promise<SettingsV1> {
+export async function loadSettings(): Promise<SettingsV2> {
   const result = await chrome.storage.sync.get(KEY);
   const raw = result[KEY];
   const settings = migrate(raw);
@@ -50,7 +50,7 @@ async function flushPendingSave(): Promise<void> {
   pendingRejectors = [];
   try {
     const current = await loadSettings();
-    const next: SettingsV1 = { ...current, ...partial, version: current.version };
+    const next: SettingsV2 = { ...current, ...partial, version: current.version };
     await chrome.storage.sync.set({ [KEY]: next });
     resolvers.forEach((r) => r());
   } catch (err) {
@@ -80,7 +80,7 @@ export function saveSettings(partial: SaveSettingsInput): Promise<void> {
  * the options page, or a different signed-in device via Chrome sync. Returns
  * an unsubscribe function.
  */
-export function subscribeSettings(listener: (s: SettingsV1) => void): () => void {
+export function subscribeSettings(listener: (s: SettingsV2) => void): () => void {
   const handler = (
     changes: Record<string, chrome.storage.StorageChange>,
     area: chrome.storage.AreaName,

--- a/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
+++ b/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
@@ -204,7 +204,7 @@ describe('createRsvpEngine', () => {
   //     (`init('Hello world.', { wpm: 50 })` → `sm.wpm === 100`). Chrome
   //     keeps the engine permissive — any positive finite number is
   //     accepted — and enforces the [100, 600] product range at the
-  //     persistence layer via `SettingsSchemaV1`. This separates
+  //     persistence layer via `SettingsSchemaV2`. This separates
   //     control-surface validation from engine cadence math.
   //
   //   - Safari ships a `togglePlayPause()` helper on the state machine.

--- a/src/core/settings/__tests__/migrations.test.ts
+++ b/src/core/settings/__tests__/migrations.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { migrate } from '../migrations';
 import { DEFAULT_SETTINGS } from '../defaults';
-import { SettingsSchemaV1 } from '../schema';
+import { SettingsSchemaV2 } from '../schema';
 
 describe('migrate', () => {
   it('returns a fresh defaults clone for undefined input (first install)', () => {
@@ -27,7 +27,7 @@ describe('migrate', () => {
     expect(migrate({ ...DEFAULT_SETTINGS, wpm: 9999 })).toEqual(DEFAULT_SETTINGS);
   });
 
-  it('passes through a valid v1 payload', () => {
+  it('passes through a valid v2 payload', () => {
     const valid = { ...DEFAULT_SETTINGS, wpm: 380, theme: 'dark' as const };
     expect(migrate(valid)).toEqual(valid);
   });
@@ -37,14 +37,14 @@ describe('migrate', () => {
     const written = JSON.parse(JSON.stringify(modified)); // simulate storage round-trip
     const read = migrate(written);
     expect(read).toEqual(modified);
-    expect(SettingsSchemaV1.safeParse(read).success).toBe(true);
+    expect(SettingsSchemaV2.safeParse(read).success).toBe(true);
   });
 
-  it('migrates a synthetic v0 payload up to v1 via the migration hook', () => {
+  it('migrates a synthetic v0 payload up to v2 via the migration chain', () => {
     // v0 lacks an explicit version field; defaults fill in the rest.
     const v0 = { wpm: 300, theme: 'dark', font: 'Georgia', fontSize: 22 };
     const result = migrate(v0);
-    expect(result.version).toBe(1);
+    expect(result.version).toBe(2);
     expect(result.wpm).toBe(300);
     expect(result.theme).toBe('dark');
     // Fields absent in v0 come from defaults.
@@ -52,11 +52,80 @@ describe('migrate', () => {
     expect(result.punctuationPacing).toBe(DEFAULT_SETTINGS.punctuationPacing);
   });
 
-  it('fills in missing fields from defaults when partial v1 is stored', () => {
-    const partial = { version: 1, wpm: 350 };
+  it('fills in missing fields from defaults when partial v2 is stored', () => {
+    const partial = { version: 2, wpm: 350 };
     const result = migrate(partial);
     expect(result.wpm).toBe(350);
     expect(result.theme).toBe(DEFAULT_SETTINGS.theme);
     expect(result.fontSize).toBe(DEFAULT_SETTINGS.fontSize);
+  });
+});
+
+// V1 -> V2 alignment migration — issue #93,
+// spec docs/superpowers/specs/2026-05-23-alignment-field-v2.md.
+// Pins the 4 cases the spec calls out explicitly. Existing test above
+// ("migrates a synthetic v0 payload up to v2 via the migration chain")
+// already covers the V0 -> V2 chain reaching version 2; the V0 case
+// below adds the explicit alignment === 'orp' assertion the spec
+// requires alongside the corrupt-data branch coverage.
+describe('migrate — V1 -> V2 alignment field', () => {
+  it('V1 payload (no alignment) -> V2 stamps alignment: orp, preserves wpm/theme/etc', () => {
+    const v1 = {
+      version: 1,
+      wpm: 300,
+      theme: 'dark' as const,
+      font: 'system-ui',
+      fontSize: 20,
+      openDyslexic: false,
+      punctuationPacing: true,
+    };
+    const result = migrate(v1);
+    expect(result.version).toBe(2);
+    expect(result.alignment).toBe('orp');
+    expect(result.wpm).toBe(300);
+    expect(result.theme).toBe('dark');
+    expect(result.font).toBe('system-ui');
+    expect(result.fontSize).toBe(20);
+    expect(result.openDyslexic).toBe(false);
+    expect(result.punctuationPacing).toBe(true);
+  });
+
+  it('V0 payload (no version) -> V2 via chained 0->1->2 with alignment: orp', () => {
+    const v0 = { wpm: 280, theme: 'light' as const };
+    const result = migrate(v0);
+    expect(result.version).toBe(2);
+    expect(result.alignment).toBe('orp');
+    expect(result.wpm).toBe(280);
+    expect(result.theme).toBe('light');
+  });
+
+  it('V2 already-present idempotency: user-set alignment: center is preserved (NOT clobbered)', () => {
+    const v2 = {
+      version: 2,
+      wpm: 300,
+      theme: 'dark' as const,
+      font: 'system-ui',
+      fontSize: 20,
+      openDyslexic: false,
+      punctuationPacing: true,
+      alignment: 'center' as const,
+    };
+    const result = migrate(v2);
+    expect(result).toEqual(v2);
+    expect(result.alignment).toBe('center');
+  });
+
+  it("V2 payload with invalid alignment ('left') falls back to DEFAULT_SETTINGS", () => {
+    const v2Invalid = {
+      version: 2,
+      wpm: 300,
+      theme: 'dark' as const,
+      font: 'system-ui',
+      fontSize: 20,
+      openDyslexic: false,
+      punctuationPacing: true,
+      alignment: 'left',
+    };
+    expect(migrate(v2Invalid)).toEqual(DEFAULT_SETTINGS);
   });
 });

--- a/src/core/settings/__tests__/schema.test.ts
+++ b/src/core/settings/__tests__/schema.test.ts
@@ -1,46 +1,47 @@
 import { describe, it, expect } from 'vitest';
-import { SettingsSchemaV1 } from '../schema';
+import { SettingsSchemaV2, VALID_ALIGNMENTS } from '../schema';
 import { DEFAULT_SETTINGS } from '../defaults';
 
-describe('SettingsSchemaV1', () => {
+describe('SettingsSchemaV2', () => {
   it('accepts the canonical defaults', () => {
-    const parsed = SettingsSchemaV1.safeParse(DEFAULT_SETTINGS);
+    const parsed = SettingsSchemaV2.safeParse(DEFAULT_SETTINGS);
     expect(parsed.success).toBe(true);
   });
 
   it('accepts a known-good payload', () => {
-    const parsed = SettingsSchemaV1.safeParse({
-      version: 1,
+    const parsed = SettingsSchemaV2.safeParse({
+      version: 2,
       wpm: 400,
       theme: 'dark',
       font: 'Georgia',
       fontSize: 24,
       openDyslexic: true,
       punctuationPacing: false,
+      alignment: 'orp',
     });
     expect(parsed.success).toBe(true);
   });
 
   it('rejects wpm outside [100, 600]', () => {
-    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, wpm: 50 }).success).toBe(false);
-    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, wpm: 9999 }).success).toBe(false);
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, wpm: 50 }).success).toBe(false);
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, wpm: 9999 }).success).toBe(false);
   });
 
   it('rejects wpm not multiples of 10', () => {
-    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, wpm: 255 }).success).toBe(false);
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, wpm: 255 }).success).toBe(false);
   });
 
   it('rejects fontSize outside [12, 48]', () => {
-    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, fontSize: 8 }).success).toBe(false);
-    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, fontSize: 64 }).success).toBe(false);
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, fontSize: 8 }).success).toBe(false);
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, fontSize: 64 }).success).toBe(false);
   });
 
   it('rejects an unknown theme', () => {
-    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, theme: 'sepia' }).success).toBe(false);
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, theme: 'sepia' }).success).toBe(false);
   });
 
   it('rejects a wrong version literal', () => {
-    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, version: 2 }).success).toBe(false);
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, version: 1 }).success).toBe(false);
   });
 });
 
@@ -50,41 +51,41 @@ describe('SettingsSchemaV1', () => {
 // input. Chrome rejects-on-parse via Zod instead. Both strategies protect
 // downstream code from invalid values; these tests assert the rejection
 // behavior at the same boundaries Safari clamps to.
-describe('SettingsSchemaV1 — boundary cases (Safari parity)', () => {
+describe('SettingsSchemaV2 — boundary cases (Safari parity)', () => {
   it('accepts fontSize at lower boundary 12 (parity: clampFontSize accepts FONT_SIZE_MIN)', () => {
-    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, fontSize: 12 }).success).toBe(true);
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, fontSize: 12 }).success).toBe(true);
   });
 
   it('accepts fontSize at upper boundary 48 (parity: clampFontSize accepts FONT_SIZE_MAX)', () => {
-    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, fontSize: 48 }).success).toBe(true);
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, fontSize: 48 }).success).toBe(true);
   });
 
   it('accepts wpm at lower boundary 100', () => {
-    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, wpm: 100 }).success).toBe(true);
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, wpm: 100 }).success).toBe(true);
   });
 
   it('accepts wpm at upper boundary 600', () => {
-    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, wpm: 600 }).success).toBe(true);
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, wpm: 600 }).success).toBe(true);
   });
 
   it('rejects fontSize NaN (parity: clampFontSize returns FONT_SIZE_DEFAULT)', () => {
-    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, fontSize: NaN }).success).toBe(false);
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, fontSize: NaN }).success).toBe(false);
   });
 
   it('rejects fontSize string (parity: clampFontSize returns FONT_SIZE_DEFAULT)', () => {
-    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, fontSize: 'big' }).success).toBe(
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, fontSize: 'big' }).success).toBe(
       false,
     );
   });
 
   it('rejects wpm NaN', () => {
-    expect(SettingsSchemaV1.safeParse({ ...DEFAULT_SETTINGS, wpm: NaN }).success).toBe(false);
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, wpm: NaN }).success).toBe(false);
   });
 
   it('rejects missing wpm key', () => {
     const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
     delete partial.wpm;
-    expect(SettingsSchemaV1.safeParse(partial).success).toBe(false);
+    expect(SettingsSchemaV2.safeParse(partial).success).toBe(false);
   });
 });
 
@@ -92,19 +93,82 @@ describe('SettingsSchemaV1 — boundary cases (Safari parity)', () => {
 // Safari maintains a flat key list constant; Chrome derives the key set
 // from the Zod schema shape. Chrome's design intentionally diverges:
 //   - Chrome KEEPS `theme` (light/dark/system). Safari removed it.
-//   - Chrome lacks `paper`, `alignment`, `chunkSize` — `paper` adjudicated
-//     against Chrome's theme system (#74), `alignment` and `chunkSize`
-//     tracked in their own follow-up issues.
+//   - Chrome lacks `paper`, `chunkSize` — `paper` adjudicated against
+//     Chrome's theme system (#74), `chunkSize` tracked in its own follow-up.
 //   - Chrome has `font`, `openDyslexic`, `punctuationPacing` — not in Safari.
+//   - As of V2, Chrome now mirrors Safari's `alignment` field (orp/center).
 describe('DEFAULT_SETTINGS covers every schema field (Safari parity)', () => {
   it('DEFAULT_SETTINGS round-trips through the schema', () => {
-    expect(SettingsSchemaV1.safeParse(DEFAULT_SETTINGS).success).toBe(true);
+    expect(SettingsSchemaV2.safeParse(DEFAULT_SETTINGS).success).toBe(true);
   });
 
   it('DEFAULT_SETTINGS has a value for every schema key', () => {
-    const shapeKeys = Object.keys(SettingsSchemaV1.shape);
+    const shapeKeys = Object.keys(SettingsSchemaV2.shape);
     for (const key of shapeKeys) {
       expect(DEFAULT_SETTINGS).toHaveProperty(key);
     }
+  });
+});
+
+// Alignment field — Safari `validateAlignment` parity (issue #93,
+// spec docs/superpowers/specs/2026-05-23-alignment-field-v2.md).
+// Target: 7 cases (2 accept + 5 reject). Type-mismatch cases (42, true)
+// are paired into a single parameterized it.each per spec author note.
+describe('SettingsSchemaV2 — alignment field (Safari parity)', () => {
+  it("ACCEPTS alignment: 'orp'", () => {
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, alignment: 'orp' }).success).toBe(
+      true,
+    );
+  });
+
+  it("ACCEPTS alignment: 'center'", () => {
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, alignment: 'center' }).success).toBe(
+      true,
+    );
+  });
+
+  it("REJECTS alignment: 'left' (string outside enum)", () => {
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, alignment: 'left' }).success).toBe(
+      false,
+    );
+  });
+
+  it("REJECTS alignment: '' (empty string)", () => {
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, alignment: '' }).success).toBe(false);
+  });
+
+  it('REJECTS alignment: undefined (missing required key)', () => {
+    const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
+    delete partial.alignment;
+    expect(SettingsSchemaV2.safeParse(partial).success).toBe(false);
+  });
+
+  it('REJECTS alignment: null', () => {
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, alignment: null }).success).toBe(
+      false,
+    );
+  });
+
+  it.each([
+    { label: 'number 42', value: 42 },
+    { label: 'boolean true', value: true },
+  ])('REJECTS alignment: $label (type mismatch)', ({ value }) => {
+    expect(SettingsSchemaV2.safeParse({ ...DEFAULT_SETTINGS, alignment: value }).success).toBe(
+      false,
+    );
+  });
+});
+
+// Defaults / VALID_ALIGNMENTS export — pins the Safari mirror at the
+// constant layer so accidental enum widening surfaces immediately.
+describe('alignment defaults and VALID_ALIGNMENTS export', () => {
+  it("DEFAULT_SETTINGS.alignment === 'orp' AND version === 2", () => {
+    expect(DEFAULT_SETTINGS.alignment).toBe('orp');
+    expect(DEFAULT_SETTINGS.version).toBe(2);
+  });
+
+  it("VALID_ALIGNMENTS has length 2 and equals ['orp', 'center']", () => {
+    expect(VALID_ALIGNMENTS).toHaveLength(2);
+    expect(VALID_ALIGNMENTS).toEqual(['orp', 'center']);
   });
 });

--- a/src/core/settings/defaults.ts
+++ b/src/core/settings/defaults.ts
@@ -1,11 +1,12 @@
-import type { SettingsV1 } from './schema';
+import type { SettingsV2 } from './schema';
 
-export const DEFAULT_SETTINGS: SettingsV1 = {
-  version: 1,
+export const DEFAULT_SETTINGS: SettingsV2 = {
+  version: 2,
   wpm: 250,
   theme: 'system',
   font: 'system-ui',
   fontSize: 20,
   openDyslexic: false,
   punctuationPacing: true,
+  alignment: 'orp',
 };

--- a/src/core/settings/index.ts
+++ b/src/core/settings/index.ts
@@ -1,3 +1,3 @@
-export { SettingsSchemaV1, CURRENT_VERSION, type SettingsV1 } from './schema';
+export { SettingsSchemaV2, CURRENT_VERSION, VALID_ALIGNMENTS, type SettingsV2 } from './schema';
 export { DEFAULT_SETTINGS } from './defaults';
 export { migrate } from './migrations';

--- a/src/core/settings/migrations.ts
+++ b/src/core/settings/migrations.ts
@@ -1,17 +1,22 @@
-import { SettingsSchemaV1, CURRENT_VERSION, type SettingsV1 } from './schema';
+import { SettingsSchemaV2, CURRENT_VERSION, type SettingsV2 } from './schema';
 import { DEFAULT_SETTINGS } from './defaults';
 
 type Migrator = (raw: Record<string, unknown>) => Record<string, unknown>;
 
 /**
- * Sequential migrators keyed by source version. To add a 1->2 migration in
- * the future, drop in `1: m1to2` and bump `CURRENT_VERSION` in `schema.ts`.
+ * Sequential migrators keyed by source version. Forward-only chain:
+ * `0 -> 1 -> 2 -> ...`. To add a 2->3 migration in the future (e.g., the
+ * theme enum widening tracked in #101), drop in `2: m2to3` and bump
+ * `CURRENT_VERSION` in `schema.ts`.
  *
- * Identity hook for v0->v1 keeps the composition path exercised in tests
- * even while v1 is current.
+ * Spread order is load-bearing: `...raw` first, then literals. New
+ * payloads get the literal `alignment: 'orp'` stamp; V2-already-present
+ * payloads bypass this map entirely because the `while (v < CURRENT_VERSION)`
+ * loop in `migrate()` short-circuits when `v === 2`.
  */
 const MIGRATIONS: Record<number, Migrator> = {
   0: (raw) => ({ ...raw, version: 1 }),
+  1: (raw) => ({ ...raw, alignment: 'orp', version: 2 }),
 };
 
 /**
@@ -19,7 +24,7 @@ const MIGRATIONS: Record<number, Migrator> = {
  * falls back to a fresh copy of `DEFAULT_SETTINGS` so a malformed payload
  * cannot crash the service worker on cold start.
  */
-export function migrate(rawValue: unknown): SettingsV1 {
+export function migrate(rawValue: unknown): SettingsV2 {
   if (rawValue == null || typeof rawValue !== 'object' || Array.isArray(rawValue)) {
     return { ...DEFAULT_SETTINGS };
   }
@@ -35,7 +40,7 @@ export function migrate(rawValue: unknown): SettingsV1 {
   }
 
   const merged = { ...DEFAULT_SETTINGS, ...value, version: CURRENT_VERSION };
-  const parsed = SettingsSchemaV1.safeParse(merged);
+  const parsed = SettingsSchemaV2.safeParse(merged);
   if (!parsed.success) {
     console.warn(
       '[speedreader] settings failed validation, falling back to defaults',

--- a/src/core/settings/schema.ts
+++ b/src/core/settings/schema.ts
@@ -1,15 +1,25 @@
 import { z } from 'zod';
 
-export const SettingsSchemaV1 = z.object({
-  version: z.literal(1),
+export const SettingsSchemaV2 = z.object({
+  version: z.literal(2),
   wpm: z.number().int().min(100).max(600).multipleOf(10),
   theme: z.enum(['light', 'dark', 'system']),
   font: z.string(),
   fontSize: z.number().int().min(12).max(48),
   openDyslexic: z.boolean(),
   punctuationPacing: z.boolean(),
+  alignment: z.enum(['orp', 'center']),
 });
 
-export type SettingsV1 = z.infer<typeof SettingsSchemaV1>;
+export type SettingsV2 = z.infer<typeof SettingsSchemaV2>;
 
-export const CURRENT_VERSION = 1 as const;
+export const CURRENT_VERSION = 2 as const;
+
+/**
+ * Cardinality-pinned constant mirroring Safari's `VALID_ALIGNMENTS`.
+ * Used by tests today; consumed by the future Options-page UI radio
+ * group (#30 follow-up) and overlay rendering wiring (pairs with #19).
+ * Widening the enum is a future ADR — keep this in lockstep with the
+ * `alignment` field in `SettingsSchemaV2` above.
+ */
+export const VALID_ALIGNMENTS = ['orp', 'center'] as const;


### PR DESCRIPTION
Closes #93.

## Summary

- Adds `alignment: 'orp' | 'center'` to the persisted settings schema, defaulting to `'orp'` (Safari `ALIGNMENT_DEFAULT` mirror); bumps `CURRENT_VERSION` 1 → 2 and removes the V1 exports per spec (no install base outside dev machines).
- Adds the V1 → V2 migrator (`{ ...raw, alignment: 'orp', version: 2 }`) — spread order is load-bearing: literal `'orp'` stamps NEW payloads; V2-already-present payloads bypass the map entirely because the `while (v < CURRENT_VERSION)` loop in `migrate()` short-circuits when `v === 2`, so a user's chosen `'center'` survives reload.
- Exports `VALID_ALIGNMENTS = ['orp', 'center']` for tests today and the future Options-page UI (#30 follow-up) + overlay-rendering wiring (pairs with #19).

## Implementation notes

- **Spec source of truth:** [`docs/superpowers/specs/2026-05-23-alignment-field-v2.md`](https://github.com/chriscantu/speedreader-chrome/blob/main/docs/superpowers/specs/2026-05-23-alignment-field-v2.md) (spec PR #109).
- **Schema-bump note for the #101 builder:** this PR lands V2. The theme-enum expansion (#101, gated on #74) becomes V2 → V3 per the migrator sketch at spec §V2→V3 sketch — identity-with-version-bump since the theme enum *widens* and every V2 theme value remains valid in V3.
- **Cascading rename — scope note:** the spec scopes changes to `src/core/settings/`, but `src/chrome/settings/storage.ts` and its test import `SettingsV1` from `src/core/settings/schema.ts`. The V1 → V2 rename forces mechanical type-rename updates there (and one comment in `src/core/rsvp-engine/__tests__/rsvp-engine.test.ts`) to keep the build green. Zero behavior change in those files — purely the new type name. Confined the touch to the minimum needed to keep `tsc --noEmit` clean.
- **Test count:** spec target was ~13 cases (7 schema + 4 migration + 2 defaults). My alignment-area additions: 7 `it()` declarations in the alignment-field describe — the last is `it.each` with 2 rows (number 42, boolean true), which vitest counts as 2 individual tests. So reported count rises from 172 → 186 (14 added: 8 alignment-schema at vitest level + 4 migration + 2 defaults). Per spec author's explicit note on the type-mismatch pair: "pair the two type-mismatch cases into a single parameterized `it.each` or count as 5 in the suite tally — adjust to whichever the impl PR's vitest convention prefers" — I picked the `it.each` option.

## Test plan

Spec test cases (13 of 13 covered):

Schema (7 `it()` declarations in `__tests__/schema.test.ts` → 8 vitest counter rows):

- [x] `SettingsSchemaV2.safeParse` ACCEPTS `alignment: 'orp'`
- [x] `SettingsSchemaV2.safeParse` ACCEPTS `alignment: 'center'`
- [x] `SettingsSchemaV2.safeParse` REJECTS `alignment: 'left'`
- [x] `SettingsSchemaV2.safeParse` REJECTS `alignment: ''`
- [x] `SettingsSchemaV2.safeParse` REJECTS missing `alignment` (undefined)
- [x] `SettingsSchemaV2.safeParse` REJECTS `alignment: null`
- [x] `SettingsSchemaV2.safeParse` REJECTS `alignment: 42` AND `true` (parameterized `it.each`)

Migration (4 cases in `__tests__/migrations.test.ts`):

- [x] V1 payload (no alignment) → V2 with `alignment: 'orp'`, preserves `wpm`/`theme`/`font`/`fontSize`/`openDyslexic`/`punctuationPacing`
- [x] V0 payload (no version) → V2 via chained 0→1→2 with `alignment: 'orp'`
- [x] V2 already-present idempotency: input with `alignment: 'center'` returns unchanged (`'center'` NOT clobbered to `'orp'`)
- [x] V2 payload with invalid `alignment: 'left'` falls back to `DEFAULT_SETTINGS`

Defaults (2 cases):

- [x] `DEFAULT_SETTINGS.alignment === 'orp'` AND `DEFAULT_SETTINGS.version === 2`
- [x] `VALID_ALIGNMENTS.length === 2` AND `toEqual(['orp', 'center'])`

Verify gates (project-level):

- [x] `npm test` — 186 passed (172 baseline + 14 new)
- [x] `npm run lint` — zero warnings
- [x] `npm run format:check` — clean
- [x] `npm run build` — green (`✓ built in 39ms`)

## References

- Spec: [`docs/superpowers/specs/2026-05-23-alignment-field-v2.md`](https://github.com/chriscantu/speedreader-chrome/blob/main/docs/superpowers/specs/2026-05-23-alignment-field-v2.md)
- Spec PR: #109
- Issue: #93
- Future schema bumps: #101 (theme expansion, gated on #74) — becomes V2 → V3 per spec sketch.
