### PR TITLE
feat(settings): pin migrate signature + document save semantics + flushSettings (closes #66 #67 #68)

### DIFF
--- a/docs/superpowers/specs/2026-05-08-settings-schema.md
+++ b/docs/superpowers/specs/2026-05-08-settings-schema.md
@@ -108,6 +108,36 @@ Behavior:
 
 Adding a v2 later: drop a migrator into the `MIGRATIONS` table keyed by `1`, bump `CURRENT_VERSION` in `schema.ts`, ship a new `SettingsSchemaV2`. The hook ships now so v2 lands cheap later.
 
+#### Signature: one-arg is canonical (#66)
+
+`migrate` takes a single `rawValue: unknown` argument. The migrator owns version
+detection by reading `rawValue.version`; the sole caller (`loadSettings` in
+`src/chrome/settings/storage.ts`) does not need to — and should not have to —
+know the source version. A `fromVersion` second argument was considered and
+explicitly rejected: it would split the contract across the call site and
+duplicate the version-detection logic. If a second caller ever lands needing to
+assert `fromVersion` (e.g. a future export/import flow that rejects
+forward-incompat blobs), add an _optional_ second argument rather than
+overloading; do not break the existing single-caller contract.
+
+#### Missing-field repair (#67)
+
+A shallow-merge `{ ...DEFAULT_SETTINGS, ...value, version: CURRENT_VERSION }`
+runs immediately before `safeParse`. The merge is intentional forward-compat:
+
+- A stored payload that is current-version but missing a field (e.g. a partial
+  sync payload, or a schema revision that adds a non-required field) acquires
+  the default for the missing field instead of failing validation.
+- The merge is shallow, not deep — nested objects (none today, but possible in
+  a future schema) are replaced wholesale, not merged. If a future revision
+  introduces nested settings, the migration step is the place to deep-merge;
+  the repair step stays shallow.
+- The canonical pin is the test
+  `'migrates v3 blob with missing field by filling defaults (explicit repair
+behavior)'` in `src/core/settings/__tests__/migrations.test.ts`. A future
+  policy change to reject-missing-fields instead of repair must update that
+  test as an intentional surface.
+
 ### Read/write/subscribe API
 
 Source of truth: `src/chrome/settings/storage.ts`. This is the only file in the project that imports `chrome.storage.*` for settings.
@@ -115,6 +145,7 @@ Source of truth: `src/chrome/settings/storage.ts`. This is the only file in the 
 ```ts
 export async function loadSettings(): Promise<SettingsV1>;
 export function saveSettings(partial: Partial<SettingsV1>): Promise<void>;
+export function flushSettings(): Promise<void>;
 export function subscribeSettings(listener: (s: SettingsV1) => void): () => void;
 ```
 
@@ -123,6 +154,37 @@ Behavior:
 - `loadSettings` reads `speedreader.settings` from `chrome.storage.sync`. **On first install (`raw === undefined`) it seeds `DEFAULT_SETTINGS` and writes the canonical seed back** so the next read is a fast pass-through. It also writes back when migration reshapes the stored value (version bump or partial-payload repair). The seed write is unconditional on `raw === undefined` — there is no falsy short-circuit.
 - `saveSettings(partial)` coalesces calls within a **300 ms trailing-edge** window into one write. Sliders that fire at 60 Hz produce one write, not 60. Each call returns a Promise that resolves when its containing flush completes.
 - `subscribeSettings(listener)` wires `chrome.storage.onChanged`, filters to area `'sync'` and key `speedreader.settings`, runs the new value through `migrate`, and forwards. Live updates from a sibling tab, the options page, or a different signed-in device all flow through the same path. Returns an unsubscribe function.
+
+#### Debounce window resolution contract (#68)
+
+`saveSettings` returns a Promise tied to the **current debounce window**, not
+to a unique underlying `set`:
+
+- All `saveSettings` calls that arrive within one 300 ms window share the
+  resolution of that window's single `chrome.storage.sync.set`. Their Promises
+  resolve (or reject) together when that set completes.
+- A late `saveSettings` call that lands **during an in-flight flush** (after
+  the timer fired but before `chrome.storage.sync.set` completed) does NOT
+  join the in-flight write — its window's pending state was already cleared at
+  the top of `flushPendingSave`. The late call starts a fresh 300 ms window
+  and resolves on a different, later set. Two distinct resolutions, two
+  distinct underlying sets.
+- Consumers that need to deterministically `await` the persisted write (e.g.
+  an options-page "Save" button followed by navigation) should call
+  `flushSettings()` after their last `saveSettings` to collapse the pending
+  window into an immediate flush.
+
+`flushSettings()` semantics:
+
+- No pending save (no timer scheduled, no buffered partial) → resolves
+  immediately.
+- Pending timer scheduled → cancels the timer and calls the flush path
+  synchronously (no `setTimeout`). Returns a Promise that resolves when the
+  underlying `chrome.storage.sync.set` completes. The pending state is cleared
+  at the top of the flush, so any `saveSettings` call that lands while the
+  forced flush is in-flight starts a fresh window — there is no double-flush
+  path. Callers that need to await that subsequent window must call
+  `flushSettings()` again.
 
 ### File layout
 

--- a/src/chrome/settings/__tests__/storage.test.ts
+++ b/src/chrome/settings/__tests__/storage.test.ts
@@ -235,7 +235,11 @@ describe('chrome settings storage adapter', () => {
     expect(stub.storage.sync.set).not.toHaveBeenCalled();
 
     // flushSettings before the 300ms timer would fire on its own.
+    let flushPromiseResolved = false;
     const flushPromise = flushSettings();
+    void flushPromise.then(() => {
+      flushPromiseResolved = true;
+    });
 
     // The flush itself awaits chrome.storage.sync.get + .set, which under the
     // default stub resolve in microtasks. Await both and confirm the write
@@ -243,6 +247,7 @@ describe('chrome settings storage adapter', () => {
     await flushPromise;
     await p;
 
+    expect(flushPromiseResolved).toBe(true);
     expect(savePromiseResolved).toBe(true);
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
     expect((storedRaw as SettingsV3).wpm).toBe(410);

--- a/src/chrome/settings/__tests__/storage.test.ts
+++ b/src/chrome/settings/__tests__/storage.test.ts
@@ -118,6 +118,162 @@ describe('chrome settings storage adapter', () => {
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
   });
 
+  // #68 — debounce window resolution contract.
+  it('saveSettings: 3 calls in one window share resolution, all resolve on one set', async () => {
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV3;
+    const { saveSettings } = await import('../storage');
+    const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
+
+    const resolved: boolean[] = [false, false, false];
+    const p1 = saveSettings({ wpm: 260 }).then(() => {
+      resolved[0] = true;
+    });
+    const p2 = saveSettings({ wpm: 270 }).then(() => {
+      resolved[1] = true;
+    });
+    const p3 = saveSettings({ wpm: 280 }).then(() => {
+      resolved[2] = true;
+    });
+
+    // No set yet, no resolutions yet.
+    expect(stub.storage.sync.set).not.toHaveBeenCalled();
+    expect(resolved).toEqual([false, false, false]);
+
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    await Promise.all([p1, p2, p3]);
+
+    // All three resolved together, and exactly one set fired.
+    expect(resolved).toEqual([true, true, true]);
+    expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
+    expect((storedRaw as SettingsV3).wpm).toBe(280);
+  });
+
+  // #68 — late call landing during in-flight flush queues for next window.
+  it('saveSettings: call landing during in-flight flush queues for next window (distinct resolutions)', async () => {
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV3;
+    const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
+
+    // Replace `get` with a controllable Promise so we can park the in-flight
+    // flush mid-await and inject a saveSettings call before it completes.
+    let releaseFirstGet: (value: { [k: string]: unknown }) => void = () => {};
+    const firstGet = new Promise<{ [k: string]: unknown }>((resolve) => {
+      releaseFirstGet = resolve;
+    });
+    let getCallCount = 0;
+    stub.storage.sync.get.mockImplementation((key: string) => {
+      getCallCount += 1;
+      if (getCallCount === 1) return firstGet;
+      return Promise.resolve({ [key]: storedRaw });
+    });
+
+    const { saveSettings } = await import('../storage');
+
+    // First window.
+    const pFirst = saveSettings({ wpm: 260 });
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    // Timer fired; flushPendingSave is now awaiting our parked `get`. Pending
+    // state has already been cleared at the top of flushPendingSave, so the
+    // next saveSettings starts a fresh window.
+    await Promise.resolve(); // yield so the timer callback has entered flushPendingSave
+
+    let firstResolved = false;
+    let secondResolved = false;
+    void pFirst.then(() => {
+      firstResolved = true;
+    });
+
+    // Second saveSettings lands mid-flight — must NOT join the in-flight flush.
+    const pSecond = saveSettings({ wpm: 380 });
+    void pSecond.then(() => {
+      secondResolved = true;
+    });
+
+    // Still parked; no set has fired yet.
+    expect(stub.storage.sync.set).not.toHaveBeenCalled();
+    expect(firstResolved).toBe(false);
+    expect(secondResolved).toBe(false);
+
+    // Release the first get → first flush completes → first set fires.
+    releaseFirstGet({ [KEY]: storedRaw });
+    await pFirst;
+    expect(firstResolved).toBe(true);
+    expect(secondResolved).toBe(false);
+    expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
+
+    // Advance the second window's debounce to flush the late call.
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    await pSecond;
+    expect(secondResolved).toBe(true);
+
+    // Two distinct sets — late call did not coalesce into the in-flight write.
+    expect(stub.storage.sync.set).toHaveBeenCalledTimes(2);
+    expect((storedRaw as SettingsV3).wpm).toBe(380);
+  });
+
+  // #68 — flushSettings semantics.
+  it('flushSettings resolves immediately when no pending save', async () => {
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV3;
+    const { flushSettings } = await import('../storage');
+    const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
+
+    await flushSettings();
+    expect(stub.storage.sync.set).not.toHaveBeenCalled();
+  });
+
+  it('flushSettings cancels debounce timer and forces an immediate flush', async () => {
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV3;
+    const { saveSettings, flushSettings } = await import('../storage');
+    const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
+
+    let savePromiseResolved = false;
+    const p = saveSettings({ wpm: 410 });
+    void p.then(() => {
+      savePromiseResolved = true;
+    });
+
+    // Debounce is pending — no set yet.
+    expect(stub.storage.sync.set).not.toHaveBeenCalled();
+
+    // flushSettings before the 300ms timer would fire on its own.
+    const flushPromise = flushSettings();
+
+    // The flush itself awaits chrome.storage.sync.get + .set, which under the
+    // default stub resolve in microtasks. Await both and confirm the write
+    // landed without the 300ms timer ever firing.
+    await flushPromise;
+    await p;
+
+    expect(savePromiseResolved).toBe(true);
+    expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
+    expect((storedRaw as SettingsV3).wpm).toBe(410);
+
+    // Confirm there is no zombie timer left behind — advancing past 300ms
+    // must not produce a second set.
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS * 2);
+    expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushSettings rejects when the forced flush fails', async () => {
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV3;
+    const { saveSettings, flushSettings } = await import('../storage');
+    const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
+    const setErr = new Error('quota exceeded');
+    stub.storage.sync.set.mockImplementationOnce(() => Promise.reject(setErr));
+
+    let saveErr: unknown;
+    let flushErr: unknown;
+    const pSave = saveSettings({ wpm: 290 }).catch((e: unknown) => {
+      saveErr = e;
+    });
+    const pFlush = flushSettings().catch((e: unknown) => {
+      flushErr = e;
+    });
+    await pFlush;
+    await pSave;
+    expect(flushErr).toBe(setErr);
+    expect(saveErr).toBe(setErr);
+  });
+
   it('saveSettings preserves the version field', async () => {
     storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV3;
     const { saveSettings } = await import('../storage');

--- a/src/chrome/settings/storage.ts
+++ b/src/chrome/settings/storage.ts
@@ -62,6 +62,21 @@ async function flushPendingSave(): Promise<void> {
  * Save a partial settings update. Calls within 300 ms are coalesced into a
  * single trailing-edge write to stay under `chrome.storage.sync`'s 120
  * writes/minute rate limit when wired to slider-style controls.
+ *
+ * Debounce resolution semantics (#68):
+ * - A 300 ms trailing-edge debounce coalesces calls. The timer is reset on
+ *   every call within the window.
+ * - All callers within ONE debounce window share the resolution of that
+ *   window's `chrome.storage.sync.set`: the returned Promises resolve (or
+ *   reject) together when that single set completes.
+ * - A late call that lands during an in-flight flush (after the timer has
+ *   fired and `flushPendingSave` is mid-`await`) starts a NEW window. Its
+ *   Promise resolves on a different set than the in-flight one — two distinct
+ *   resolutions, not coalesced into the in-flight write.
+ * - Consumers that need to deterministically `await` the write (e.g. an
+ *   options-page "Save" click followed by a navigation) should call
+ *   `flushSettings()` which collapses the pending window into an immediate
+ *   flush.
  */
 export function saveSettings(partial: SaveSettingsInput): Promise<void> {
   pendingPartial = { ...(pendingPartial ?? {}), ...partial };
@@ -72,6 +87,30 @@ export function saveSettings(partial: SaveSettingsInput): Promise<void> {
     pendingTimer = setTimeout(() => {
       void flushPendingSave();
     }, DEBOUNCE_MS);
+  });
+}
+
+/**
+ * Force any pending `saveSettings` window to flush immediately and resolve
+ * once the underlying `chrome.storage.sync.set` completes.
+ *
+ * - No pending save: resolves immediately on a microtask.
+ * - Pending timer scheduled: cancels the timer and calls `flushPendingSave`
+ *   directly (no `setTimeout`). The returned Promise awaits that flush.
+ *
+ * The pending state is cleared at the top of `flushPendingSave`, so any
+ * `saveSettings` call that lands while the forced flush is in-flight starts a
+ * fresh window — there is no double-flush path. Callers that need to await
+ * THAT subsequent window must call `flushSettings()` again.
+ */
+export function flushSettings(): Promise<void> {
+  if (pendingTimer === null) return Promise.resolve();
+  clearTimeout(pendingTimer);
+  pendingTimer = null;
+  return new Promise<void>((resolve, reject) => {
+    pendingResolvers.push(resolve);
+    pendingRejectors.push(reject);
+    void flushPendingSave();
   });
 }
 

--- a/src/core/settings/__tests__/migrations.test.ts
+++ b/src/core/settings/__tests__/migrations.test.ts
@@ -60,6 +60,32 @@ describe('migrate', () => {
     expect(result.theme).toBe(DEFAULT_SETTINGS.theme);
     expect(result.fontSize).toBe(DEFAULT_SETTINGS.fontSize);
   });
+
+  // Canonical missing-field repair pin (#67). Other tests cover repair as a
+  // side effect of version-chain migration; this one isolates the v3-with-
+  // missing-field case so the policy is explicit: missing fields in an
+  // already-current-version blob acquire defaults rather than failing parse.
+  it('migrates v3 blob with missing field by filling defaults (explicit repair behavior)', () => {
+    // Valid v3 in every respect except `punctuationPacing` is absent — e.g.
+    // a partial sync payload, or a future schema revision where this field
+    // was added and an older device's blob lacks it.
+    const v3MissingField = {
+      version: 3,
+      wpm: 300,
+      theme: 'dark' as const,
+      font: 'system-ui',
+      fontSize: 20,
+      openDyslexic: false,
+      alignment: 'orp' as const,
+      // punctuationPacing intentionally omitted
+    };
+    const result = migrate(v3MissingField);
+    expect(result.punctuationPacing).toBe(DEFAULT_SETTINGS.punctuationPacing);
+    // And the rest of the user's values survive the repair.
+    expect(result.version).toBe(3);
+    expect(result.wpm).toBe(300);
+    expect(result.theme).toBe('dark');
+  });
 });
 
 // V1 -> V2 alignment migration — issue #93,

--- a/src/core/settings/migrations.ts
+++ b/src/core/settings/migrations.ts
@@ -29,6 +29,22 @@ const MIGRATIONS: Record<number, Migrator> = {
  * Best-effort migration. Never throws — corrupt or schema-incompatible input
  * falls back to a fresh copy of `DEFAULT_SETTINGS` so a malformed payload
  * cannot crash the service worker on cold start.
+ *
+ * Signature is intentionally one-arg (#66): the migrator owns version detection
+ * by reading `rawValue.version`, and the sole caller (`loadSettings` in
+ * `src/chrome/settings/storage.ts`) does not know — and should not have to know
+ * — the source version. If a second caller ever needs to assert `fromVersion`
+ * (e.g. a future export/import flow rejecting forward-incompat blobs), revisit
+ * by adding an optional second arg rather than overloading; do not break the
+ * existing single-caller contract.
+ *
+ * Missing-field repair is intentional forward-compat (#67): after the
+ * version-chain loop runs, the result is shallow-merged onto `DEFAULT_SETTINGS`
+ * before `safeParse`, so a stored payload missing a field added in a later
+ * schema revision (or one truncated by a partial sync) acquires the default
+ * value instead of failing validation. The test pinning this behavior is
+ * `'migrates v3 blob with missing field by filling defaults (explicit repair
+ * behavior)'` in `__tests__/migrations.test.ts`.
  */
 export function migrate(rawValue: unknown): SettingsV3 {
   if (rawValue == null || typeof rawValue !== 'object' || Array.isArray(rawValue)) {


### PR DESCRIPTION
## Summary

Three architect follow-ups to PR #65 (settings schema) settled as one focused PR:

- **#66** — Pin `migrate(rawValue): SettingsV3` (one-arg) as canonical. Migrator owns version detection. Doc + spec updated. No code change to the function.
- **#67** — Pin missing-field repair as intentional forward-compat. Canonical regression test added. Spec § Missing-field repair documents the policy.
- **#68** — Document `saveSettings` debounce resolution semantics. Add `flushSettings(): Promise<void>` escape hatch for callers needing deterministic await (e.g., options-page "Saved" indicator before navigation).

## Why grouped

All three are architect's flags from PR #65's spec-recreation report. Same module, same review session, same docs file. One PR keeps the spec edits coherent.

## Process

Swarm dispatch — single builder (`chrome-extension-engineer`) + critic ring (`scope-adversary`, `test-gap-adversary`).

Critic ring caught a real bug: initial `flushSettings` returned `flushPendingSave()` directly, which silently swallowed rejections via its internal try/catch. Fixed by registering as a window participant (push to `pendingResolvers` / `pendingRejectors`) before triggering flush — symmetric with `saveSettings`'s hook into the same window.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 312/312 pass (4 new in `storage.test.ts`, 1 new in `migrations.test.ts`)
- [x] `npm run format:check` — clean
- [x] `npm run build` — succeeds
- [x] Reject path verified — `flushSettings` rejects when `chrome.storage.sync.set` rejects, AND the in-flight `saveSettings` Promise rejects with the same error
- [x] Scope check — diff touches only the 5 files in scope (`git diff --stat`)

## Files changed

```
docs/superpowers/specs/2026-05-08-settings-schema.md  | +62
src/chrome/settings/__tests__/storage.test.ts          | +156
src/chrome/settings/storage.ts                         | +39
src/core/settings/__tests__/migrations.test.ts         | +26
src/core/settings/migrations.ts                        | +16
```

closes #66
closes #67
closes #68
