### PR TITLE
feat: activation-dispatch funnel + restricted-URL guard (closes #122)

### DIFF
--- a/docs/superpowers/specs/2026-05-08-messaging-contract.md
+++ b/docs/superpowers/specs/2026-05-08-messaging-contract.md
@@ -63,10 +63,16 @@ Per the [Chrome docs on service worker lifecycles](https://developer.chrome.com/
 Source of truth: `src/core/messaging/types.ts` (pure TS, no `chrome.*`).
 
 ```ts
-// One-shot RPC envelope
-export type Result<T> =
+// One-shot RPC envelope. `E` defaults to a string-reason shape for the
+// pre-existing surfaces (extract-summary, restricted-url-probe, …); new
+// surfaces that want a typed discriminated error opt in by parameterizing
+// `E`. The widening is strictly additive — callers that previously
+// consumed `{ ok: false; reason: string }` see the same shape under the
+// default (intersection keeps `E`'s fields at the top level rather than
+// nesting them under an `error:` key).
+export type Result<T, E = { reason: string; details?: unknown }> =
   | { ok: true; data: T }
-  | { ok: false; reason: string; details?: unknown };
+  | ({ ok: false } & E);
 
 // Discriminated union of all messages
 export type Msg =
@@ -114,7 +120,13 @@ Notes:
 
 ## Envelope Shape
 
-All `sendMessage` responses use the `Result<T>` envelope above. Mirrors `ExtractionResult` from the extraction spec for visual and structural consistency. Errors are values, not exceptions; a handler that throws is a bug. Port frames carry the discriminated `Msg` union directly — no envelope wrapper, since a Port is a stream of typed frames rather than a request/response pair.
+All `sendMessage` responses use the `Result<T, E>` envelope above. Mirrors `ExtractionResult` from the extraction spec for visual and structural consistency. Errors are values, not exceptions; a handler that throws is a bug. Port frames carry the discriminated `Msg` union directly — no envelope wrapper, since a Port is a stream of typed frames rather than a request/response pair.
+
+### Typed errors (issue #122 amendment)
+
+`Result<T>` is parameterized as `Result<T, E = { reason: string; details?: unknown }>`. The default `E` preserves the original `{ ok: false; reason: string }` shape — pre-existing surfaces (`extract-summary`, `restricted-url-probe`, …) consume the same envelope without change. New surfaces that want a typed discriminated error opt in by parameterizing `E`.
+
+Rationale: the activation funnel (issue #122) needs popup-side error rendering to distinguish `restricted-page` (render banner) from `inject-failed` / `handoff-failed` / `tab-unavailable` (retry surfaces). Collapsing every failure to a single `kind: 'invalid-payload'` string lost that signal; typed errors enable popup-side error rendering without lossy `kind: 'invalid-payload'` mapping. Example: `Result<void, ActivationError>` carries the discriminated union verbatim.
 
 ## Lifecycle Hazards
 

--- a/src/chrome/background/__tests__/route.test.ts
+++ b/src/chrome/background/__tests__/route.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import { route, type RouteDeps, type RouteResponse } from '../route';
+import type { ActivationError } from '../activation/types';
+
+const OWN_ID = 'abcdefghijklmnopabcdefghijklmnop';
+
+function popupSender(): chrome.runtime.MessageSender {
+  return {
+    id: OWN_ID,
+    url: `chrome-extension://${OWN_ID}/src/chrome/popup/index.html`,
+    // tab intentionally undefined — popup-shaped
+  };
+}
+
+function makeDeps(
+  result: { ok: true; data: void } | { ok: false; error: ActivationError },
+): RouteDeps {
+  return {
+    dispatchActivation: vi.fn(() => Promise.resolve(result)),
+  };
+}
+
+function waitForResponse(): {
+  promise: Promise<RouteResponse>;
+  sendResponse: (r: RouteResponse) => void;
+} {
+  let resolveFn!: (r: RouteResponse) => void;
+  const promise = new Promise<RouteResponse>((resolve) => {
+    resolveFn = resolve;
+  });
+  return { promise, sendResponse: resolveFn };
+}
+
+describe('route — activate-reader handler', () => {
+  it('rejects messages without a usable tabId', () => {
+    const sendResponse = vi.fn();
+    const deps = makeDeps({ ok: true, data: undefined });
+
+    // popup sender has no sender.tab, msg.tabId missing → invalid-payload
+    route({ type: 'activate-reader' }, popupSender(), sendResponse, deps);
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: { kind: 'invalid-payload' },
+    });
+    expect(deps.dispatchActivation).not.toHaveBeenCalled();
+  });
+
+  it('returns ok envelope on successful activation', async () => {
+    const deps = makeDeps({ ok: true, data: undefined });
+    const { promise, sendResponse } = waitForResponse();
+
+    route({ type: 'activate-reader', tabId: 42 }, popupSender(), sendResponse, deps);
+
+    const resp = await promise;
+    expect(resp).toEqual({ ok: true, data: undefined });
+    expect(deps.dispatchActivation).toHaveBeenCalledWith({ source: 'popup', tabId: 42 });
+  });
+
+  it('forwards restricted-page error verbatim under activation-failed envelope', async () => {
+    const activationError: ActivationError = {
+      kind: 'restricted-page',
+      url: 'chrome://settings',
+    };
+    const deps = makeDeps({ ok: false, error: activationError });
+    const { promise, sendResponse } = waitForResponse();
+
+    route({ type: 'activate-reader', tabId: 7 }, popupSender(), sendResponse, deps);
+
+    const resp = await promise;
+    expect(resp).toEqual({
+      ok: false,
+      error: { kind: 'activation-failed', error: activationError },
+    });
+    // The popup MUST be able to distinguish restricted-page from inject-failed:
+    if (resp.ok) throw new Error('unreachable');
+    if (resp.error.kind !== 'activation-failed') throw new Error('unreachable');
+    expect(resp.error.error.kind).toBe('restricted-page');
+  });
+
+  it('forwards inject-failed error verbatim — distinguishable from restricted-page', async () => {
+    const activationError: ActivationError = {
+      kind: 'inject-failed',
+      tabId: 11,
+      details: new Error('Cannot access contents'),
+    };
+    const deps = makeDeps({ ok: false, error: activationError });
+    const { promise, sendResponse } = waitForResponse();
+
+    route({ type: 'activate-reader', tabId: 11 }, popupSender(), sendResponse, deps);
+
+    const resp = await promise;
+    if (resp.ok) throw new Error('unreachable');
+    if (resp.error.kind !== 'activation-failed') throw new Error('unreachable');
+    expect(resp.error.error.kind).toBe('inject-failed');
+    // Critical contract: NOT collapsed to invalid-payload.
+    expect(resp.error.error.kind).not.toBe('restricted-page');
+  });
+
+  it('forwards tab-unavailable and handoff-failed verbatim', async () => {
+    for (const kind of ['tab-unavailable', 'handoff-failed'] as const) {
+      const activationError: ActivationError = { kind, tabId: 1 };
+      const deps = makeDeps({ ok: false, error: activationError });
+      const { promise, sendResponse } = waitForResponse();
+
+      route({ type: 'activate-reader', tabId: 1 }, popupSender(), sendResponse, deps);
+
+      const resp = await promise;
+      if (resp.ok) throw new Error('unreachable');
+      if (resp.error.kind !== 'activation-failed') throw new Error('unreachable');
+      expect(resp.error.error.kind).toBe(kind);
+    }
+  });
+
+  it('returns invalid-payload for unknown message types', () => {
+    const sendResponse = vi.fn();
+    const deps = makeDeps({ ok: true, data: undefined });
+
+    route({ type: 'unknown-thing' }, popupSender(), sendResponse, deps);
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: { kind: 'invalid-payload' },
+    });
+    expect(deps.dispatchActivation).not.toHaveBeenCalled();
+  });
+});

--- a/src/chrome/background/__tests__/route.test.ts
+++ b/src/chrome/background/__tests__/route.test.ts
@@ -14,9 +14,12 @@ function popupSender(): chrome.runtime.MessageSender {
 
 function makeDeps(
   result: { ok: true; data: void } | { ok: false; error: ActivationError },
+  opts: { activeTabId?: number | null } = {},
 ): RouteDeps {
+  const activeTabId = opts.activeTabId;
   return {
     dispatchActivation: vi.fn(() => Promise.resolve(result)),
+    getActiveTabId: vi.fn(() => Promise.resolve(activeTabId ?? null)),
   };
 }
 
@@ -47,7 +50,7 @@ describe('route — activate-reader handler', () => {
   });
 
   it('returns ok envelope on successful activation', async () => {
-    const deps = makeDeps({ ok: true, data: undefined });
+    const deps = makeDeps({ ok: true, data: undefined }, { activeTabId: 42 });
     const { promise, sendResponse } = waitForResponse();
 
     route({ type: 'activate-reader', tabId: 42 }, popupSender(), sendResponse, deps);
@@ -62,7 +65,7 @@ describe('route — activate-reader handler', () => {
       kind: 'restricted-page',
       url: 'chrome://settings',
     };
-    const deps = makeDeps({ ok: false, error: activationError });
+    const deps = makeDeps({ ok: false, error: activationError }, { activeTabId: 7 });
     const { promise, sendResponse } = waitForResponse();
 
     route({ type: 'activate-reader', tabId: 7 }, popupSender(), sendResponse, deps);
@@ -84,7 +87,7 @@ describe('route — activate-reader handler', () => {
       tabId: 11,
       details: new Error('Cannot access contents'),
     };
-    const deps = makeDeps({ ok: false, error: activationError });
+    const deps = makeDeps({ ok: false, error: activationError }, { activeTabId: 11 });
     const { promise, sendResponse } = waitForResponse();
 
     route({ type: 'activate-reader', tabId: 11 }, popupSender(), sendResponse, deps);
@@ -100,7 +103,7 @@ describe('route — activate-reader handler', () => {
   it('forwards tab-unavailable and handoff-failed verbatim', async () => {
     for (const kind of ['tab-unavailable', 'handoff-failed'] as const) {
       const activationError: ActivationError = { kind, tabId: 1 };
-      const deps = makeDeps({ ok: false, error: activationError });
+      const deps = makeDeps({ ok: false, error: activationError }, { activeTabId: 1 });
       const { promise, sendResponse } = waitForResponse();
 
       route({ type: 'activate-reader', tabId: 1 }, popupSender(), sendResponse, deps);
@@ -110,6 +113,30 @@ describe('route — activate-reader handler', () => {
       if (resp.error.kind !== 'activation-failed') throw new Error('unreachable');
       expect(resp.error.error.kind).toBe(kind);
     }
+  });
+
+  it('rejects when popup-supplied tabId does not match the active tab', async () => {
+    const deps = makeDeps({ ok: true, data: undefined }, { activeTabId: 99 });
+    const { promise, sendResponse } = waitForResponse();
+
+    // msg.tabId = 42 but active tab = 99 → mismatch → invalid-payload, no dispatch.
+    route({ type: 'activate-reader', tabId: 42 }, popupSender(), sendResponse, deps);
+
+    const resp = await promise;
+    expect(resp).toEqual({ ok: false, error: { kind: 'invalid-payload' } });
+    expect(deps.dispatchActivation).not.toHaveBeenCalled();
+    expect(deps.getActiveTabId).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when no active tab can be resolved', async () => {
+    const deps = makeDeps({ ok: true, data: undefined }, { activeTabId: null });
+    const { promise, sendResponse } = waitForResponse();
+
+    route({ type: 'activate-reader', tabId: 42 }, popupSender(), sendResponse, deps);
+
+    const resp = await promise;
+    expect(resp).toEqual({ ok: false, error: { kind: 'invalid-payload' } });
+    expect(deps.dispatchActivation).not.toHaveBeenCalled();
   });
 
   it('returns invalid-payload for unknown message types', () => {

--- a/src/chrome/background/activation/__tests__/dispatch.test.ts
+++ b/src/chrome/background/activation/__tests__/dispatch.test.ts
@@ -6,7 +6,6 @@ import type { ActivationIntent } from '../types';
 void sinonChrome;
 
 const OWN_ID = 'abcdefghijklmnopabcdefghijklmnop';
-const CONTENT_SCRIPT_FILE = 'src/chrome/content/index.ts';
 
 interface TabsStub {
   get: ReturnType<typeof vi.fn>;
@@ -63,7 +62,7 @@ describe('dispatchActivation', () => {
   });
 
   it('returns ok and injects + hands off for an allowed URL (commands source)', async () => {
-    const { dispatchActivation } = await import('../dispatch');
+    const { dispatchActivation, CONTENT_SCRIPT_FILE } = await import('../dispatch');
     const intent: ActivationIntent = { source: 'commands', tabId: 42 };
 
     const result = await dispatchActivation(intent);
@@ -77,7 +76,16 @@ describe('dispatchActivation', () => {
     };
     expect(callArg.target.tabId).toBe(42);
     expect(callArg.files).toContain(CONTENT_SCRIPT_FILE);
-    expect(stub.tabs.sendMessage).toHaveBeenCalledTimes(1);
+    // The crxjs `?script` import resolves to the BUILT filename — must be
+    // `.js`, not the `.ts` source. `chrome.scripting.executeScript` runs
+    // against the emitted extension, not the source tree.
+    expect(CONTENT_SCRIPT_FILE.endsWith('.js')).toBe(true);
+    expect(CONTENT_SCRIPT_FILE.endsWith('.ts')).toBe(false);
+  });
+
+  it('resolves CONTENT_SCRIPT_FILE to a runtime filename, never a `.ts` source path', async () => {
+    const { CONTENT_SCRIPT_FILE } = await import('../dispatch');
+    expect(CONTENT_SCRIPT_FILE).toMatch(/\.js$/);
   });
 
   it('rejects with restricted-page error for chrome:// URLs without injecting', async () => {

--- a/src/chrome/background/activation/__tests__/dispatch.test.ts
+++ b/src/chrome/background/activation/__tests__/dispatch.test.ts
@@ -61,9 +61,9 @@ describe('dispatchActivation', () => {
     vi.resetModules();
   });
 
-  it('returns ok and injects + hands off for an allowed URL (commands source)', async () => {
+  it('returns ok and injects + hands off for an allowed URL (command source)', async () => {
     const { dispatchActivation, CONTENT_SCRIPT_FILE } = await import('../dispatch');
-    const intent: ActivationIntent = { source: 'commands', tabId: 42 };
+    const intent: ActivationIntent = { source: 'command', tabId: 42 };
 
     const result = await dispatchActivation(intent);
 
@@ -91,7 +91,7 @@ describe('dispatchActivation', () => {
   it('rejects with restricted-page error for chrome:// URLs without injecting', async () => {
     stub = installChromeStub({ tabUrl: 'chrome://settings' });
     const { dispatchActivation } = await import('../dispatch');
-    const intent: ActivationIntent = { source: 'commands', tabId: 1 };
+    const intent: ActivationIntent = { source: 'command', tabId: 1 };
 
     const result = await dispatchActivation(intent);
 
@@ -145,7 +145,7 @@ describe('dispatchActivation', () => {
   it('converts a tabs.get rejection to a tab-unavailable error', async () => {
     stub = installChromeStub({ tabsGetRejects: new Error('No tab with id: 999') });
     const { dispatchActivation } = await import('../dispatch');
-    const intent: ActivationIntent = { source: 'commands', tabId: 999 };
+    const intent: ActivationIntent = { source: 'command', tabId: 999 };
 
     const result = await dispatchActivation(intent);
 
@@ -196,10 +196,10 @@ describe('dispatchActivation', () => {
     expect(payload).toMatchObject({ type: 'activate-reader', scope: 'full' });
   });
 
-  it('commands and popup sources hand off full-scope', async () => {
+  it('command and popup sources hand off full-scope', async () => {
     const { dispatchActivation } = await import('../dispatch');
 
-    await dispatchActivation({ source: 'commands', tabId: 1 });
+    await dispatchActivation({ source: 'command', tabId: 1 });
     await dispatchActivation({ source: 'popup', tabId: 2 });
 
     expect(stub.tabs.sendMessage.mock.calls).toHaveLength(2);

--- a/src/chrome/background/activation/__tests__/dispatch.test.ts
+++ b/src/chrome/background/activation/__tests__/dispatch.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import sinonChrome from 'sinon-chrome';
 import type { ActivationIntent } from '../types';
-
-// Touch sinon-chrome import so the dep stays explicit even though we use vi-based mocks.
-void sinonChrome;
 
 const OWN_ID = 'abcdefghijklmnopabcdefghijklmnop';
 

--- a/src/chrome/background/activation/__tests__/dispatch.test.ts
+++ b/src/chrome/background/activation/__tests__/dispatch.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import sinonChrome from 'sinon-chrome';
+import type { ActivationIntent } from '../types';
+
+// Touch sinon-chrome import so the dep stays explicit even though we use vi-based mocks.
+void sinonChrome;
+
+const OWN_ID = 'abcdefghijklmnopabcdefghijklmnop';
+const CONTENT_SCRIPT_FILE = 'src/chrome/content/index.ts';
+
+interface TabsStub {
+  get: ReturnType<typeof vi.fn>;
+  sendMessage: ReturnType<typeof vi.fn>;
+}
+interface ScriptingStub {
+  executeScript: ReturnType<typeof vi.fn>;
+}
+interface ChromeStub {
+  runtime: { id: string };
+  tabs: TabsStub;
+  scripting: ScriptingStub;
+}
+
+function installChromeStub(opts: {
+  tabUrl?: string;
+  tabsGetRejects?: Error;
+  executeScriptRejects?: Error;
+  sendMessageRejects?: Error;
+}): ChromeStub {
+  const stub: ChromeStub = {
+    runtime: { id: OWN_ID },
+    tabs: {
+      get: vi.fn((_tabId: number) => {
+        if (opts.tabsGetRejects) return Promise.reject(opts.tabsGetRejects);
+        return Promise.resolve({ url: opts.tabUrl ?? 'https://example.com' });
+      }),
+      sendMessage: vi.fn(() => {
+        if (opts.sendMessageRejects) return Promise.reject(opts.sendMessageRejects);
+        return Promise.resolve({ ok: true });
+      }),
+    },
+    scripting: {
+      executeScript: vi.fn(() => {
+        if (opts.executeScriptRejects) return Promise.reject(opts.executeScriptRejects);
+        return Promise.resolve([{ frameId: 0, result: undefined }]);
+      }),
+    },
+  };
+  (globalThis as unknown as { chrome: ChromeStub }).chrome = stub;
+  return stub;
+}
+
+describe('dispatchActivation', () => {
+  let stub: ChromeStub;
+
+  beforeEach(() => {
+    stub = installChromeStub({});
+  });
+
+  afterEach(() => {
+    delete (globalThis as unknown as { chrome?: unknown }).chrome;
+    vi.resetModules();
+  });
+
+  it('returns ok and injects + hands off for an allowed URL (commands source)', async () => {
+    const { dispatchActivation } = await import('../dispatch');
+    const intent: ActivationIntent = { source: 'commands', tabId: 42 };
+
+    const result = await dispatchActivation(intent);
+
+    expect(result).toEqual({ ok: true, data: undefined });
+    expect(stub.tabs.get).toHaveBeenCalledWith(42);
+    expect(stub.scripting.executeScript).toHaveBeenCalledTimes(1);
+    const callArg = stub.scripting.executeScript.mock.calls[0]?.[0] as {
+      target: { tabId: number };
+      files: string[];
+    };
+    expect(callArg.target.tabId).toBe(42);
+    expect(callArg.files).toContain(CONTENT_SCRIPT_FILE);
+    expect(stub.tabs.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects with restricted-page error for chrome:// URLs without injecting', async () => {
+    stub = installChromeStub({ tabUrl: 'chrome://settings' });
+    const { dispatchActivation } = await import('../dispatch');
+    const intent: ActivationIntent = { source: 'commands', tabId: 1 };
+
+    const result = await dispatchActivation(intent);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toEqual({ kind: 'restricted-page', url: 'chrome://settings' });
+    expect(stub.scripting.executeScript).not.toHaveBeenCalled();
+    expect(stub.tabs.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects with restricted-page error for the Chrome Web Store', async () => {
+    stub = installChromeStub({ tabUrl: 'https://chromewebstore.google.com/category/extensions' });
+    const { dispatchActivation } = await import('../dispatch');
+    const intent: ActivationIntent = { source: 'popup', tabId: 7 };
+
+    const result = await dispatchActivation(intent);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error.kind).toBe('restricted-page');
+    expect(stub.scripting.executeScript).not.toHaveBeenCalled();
+  });
+
+  it('allows chrome-extension URLs from our own ID', async () => {
+    stub = installChromeStub({ tabUrl: `chrome-extension://${OWN_ID}/popup.html` });
+    const { dispatchActivation } = await import('../dispatch');
+    const intent: ActivationIntent = { source: 'popup', tabId: 9 };
+
+    const result = await dispatchActivation(intent);
+
+    expect(result.ok).toBe(true);
+    expect(stub.scripting.executeScript).toHaveBeenCalledTimes(1);
+  });
+
+  it('converts an executeScript rejection (TOCTOU restricted) to an inject-failed error', async () => {
+    stub = installChromeStub({
+      tabUrl: 'https://example.com',
+      executeScriptRejects: new Error('Cannot access contents of url "chrome://settings"'),
+    });
+    const { dispatchActivation } = await import('../dispatch');
+    const intent: ActivationIntent = { source: 'contextMenu', tabId: 3 };
+
+    const result = await dispatchActivation(intent);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error.kind).toBe('inject-failed');
+    expect(stub.tabs.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('converts a tabs.get rejection to a tab-unavailable error', async () => {
+    stub = installChromeStub({ tabsGetRejects: new Error('No tab with id: 999') });
+    const { dispatchActivation } = await import('../dispatch');
+    const intent: ActivationIntent = { source: 'commands', tabId: 999 };
+
+    const result = await dispatchActivation(intent);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error.kind).toBe('tab-unavailable');
+    expect(stub.scripting.executeScript).not.toHaveBeenCalled();
+  });
+
+  it('converts a tabs.sendMessage rejection to a handoff-failed error', async () => {
+    stub = installChromeStub({ sendMessageRejects: new Error('Could not establish connection') });
+    const { dispatchActivation } = await import('../dispatch');
+    const intent: ActivationIntent = { source: 'popup', tabId: 5 };
+
+    const result = await dispatchActivation(intent);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error.kind).toBe('handoff-failed');
+    expect(stub.scripting.executeScript).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards selectionText presence to the handoff for contextMenu source', async () => {
+    const { dispatchActivation } = await import('../dispatch');
+    const intent: ActivationIntent = {
+      source: 'contextMenu',
+      tabId: 11,
+      selectionText: 'hello world',
+    };
+
+    const result = await dispatchActivation(intent);
+
+    expect(result.ok).toBe(true);
+    expect(stub.tabs.sendMessage).toHaveBeenCalledTimes(1);
+    const [tabId, payload] = stub.tabs.sendMessage.mock.calls[0] ?? [];
+    expect(tabId).toBe(11);
+    expect(payload).toMatchObject({ type: 'activate-reader', scope: 'selection' });
+  });
+
+  it('treats contextMenu without selectionText as full-scope', async () => {
+    const { dispatchActivation } = await import('../dispatch');
+    const intent: ActivationIntent = { source: 'contextMenu', tabId: 12 };
+
+    const result = await dispatchActivation(intent);
+
+    expect(result.ok).toBe(true);
+    const [, payload] = stub.tabs.sendMessage.mock.calls[0] ?? [];
+    expect(payload).toMatchObject({ type: 'activate-reader', scope: 'full' });
+  });
+
+  it('commands and popup sources hand off full-scope', async () => {
+    const { dispatchActivation } = await import('../dispatch');
+
+    await dispatchActivation({ source: 'commands', tabId: 1 });
+    await dispatchActivation({ source: 'popup', tabId: 2 });
+
+    expect(stub.tabs.sendMessage.mock.calls).toHaveLength(2);
+    const [, p1] = stub.tabs.sendMessage.mock.calls[0] ?? [];
+    const [, p2] = stub.tabs.sendMessage.mock.calls[1] ?? [];
+    expect(p1).toMatchObject({ type: 'activate-reader', scope: 'full' });
+    expect(p2).toMatchObject({ type: 'activate-reader', scope: 'full' });
+  });
+});

--- a/src/chrome/background/activation/dispatch.ts
+++ b/src/chrome/background/activation/dispatch.ts
@@ -1,0 +1,102 @@
+/**
+ * Activation dispatch funnel — the single seam between activation sources
+ * (commands hotkey, context menu, popup) and the read-session wire.
+ *
+ * Per the SW-lifecycle ADR (`docs/superpowers/decisions/2026-05-22-sw-lifecycle-activation.md`)
+ * and spec (`docs/superpowers/specs/2026-05-22-sw-lifecycle-activation.md`), every
+ * source MUST normalize to an `ActivationIntent` and pass through this
+ * function. The core flow is one branchless path:
+ *
+ *   1. tab URL lookup
+ *   2. restricted-URL guard (`src/core/restricted.ts`)
+ *   3. content-script injection via `chrome.scripting.executeScript`
+ *   4. handoff to the CS via `chrome.tabs.sendMessage({type: 'activate-reader'})`
+ *
+ * `intent.source` is consulted ONLY for payload normalization (extracting
+ * `selectionText` from the `contextMenu` variant). The four-step flow is
+ * source-blind.
+ *
+ * Errors from any step are converted to `Result.err` — exceptions never
+ * leak across the funnel boundary. The Port handoff itself is owned by
+ * the messaging-contract spec (`docs/superpowers/specs/2026-05-08-messaging-contract.md`);
+ * this funnel only hands off the one-shot `activate-reader` RPC. The
+ * `rsvp-session` Port is opened separately by the popup or the CS per
+ * that spec.
+ */
+
+import { isRestricted } from '../../../core/restricted';
+import type { ActivationError, ActivationIntent, Result } from './types';
+
+/**
+ * Path to the content-script entry. Relative to the extension root; matches
+ * the manifest's expected emit target.
+ */
+const CONTENT_SCRIPT_FILE = 'src/chrome/content/index.ts';
+
+/**
+ * Payload sent to the content script on activation. Mirrors the
+ * `activate-reader` one-shot RPC added by the SW-lifecycle spec to the
+ * messaging-contract `Msg` union.
+ */
+interface ActivateReaderMessage {
+  type: 'activate-reader';
+  scope: 'selection' | 'full';
+}
+
+/**
+ * Normalize a source-specific intent into the scope payload the CS expects.
+ * This is the ONLY place `intent.source` is inspected — the rest of the
+ * funnel is source-blind.
+ */
+function intentToActivatePayload(intent: ActivationIntent): ActivateReaderMessage {
+  if (intent.source === 'contextMenu' && intent.selectionText !== undefined) {
+    return { type: 'activate-reader', scope: 'selection' };
+  }
+  return { type: 'activate-reader', scope: 'full' };
+}
+
+/**
+ * Dispatch an activation intent. Returns a `Result` — never throws.
+ */
+export async function dispatchActivation(
+  intent: ActivationIntent,
+): Promise<Result<void, ActivationError>> {
+  // 1. Resolve the tab URL. tabs.get can reject (closed tab, race).
+  let tab: chrome.tabs.Tab;
+  try {
+    tab = await chrome.tabs.get(intent.tabId);
+  } catch (details) {
+    return { ok: false, error: { kind: 'tab-unavailable', tabId: intent.tabId, details } };
+  }
+
+  const url = tab.url ?? '';
+
+  // 2. Restricted-URL guard. `chrome.runtime.id` is the call-site lookup
+  //    that keeps `isRestricted` platform-agnostic.
+  if (isRestricted(url, chrome.runtime.id)) {
+    return { ok: false, error: { kind: 'restricted-page', url } };
+  }
+
+  // 3. Inject the content script. Convert rejections (TOCTOU restricted
+  //    URLs, etc.) to a typed `inject-failed` error.
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId: intent.tabId },
+      files: [CONTENT_SCRIPT_FILE],
+    });
+  } catch (details) {
+    return { ok: false, error: { kind: 'inject-failed', tabId: intent.tabId, details } };
+  }
+
+  // 4. Hand off to the CS via the `activate-reader` one-shot RPC. The
+  //    `rsvp-session` Port is opened separately by the popup / CS per
+  //    the messaging-contract spec.
+  const payload = intentToActivatePayload(intent);
+  try {
+    await chrome.tabs.sendMessage(intent.tabId, payload);
+  } catch (details) {
+    return { ok: false, error: { kind: 'handoff-failed', tabId: intent.tabId, details } };
+  }
+
+  return { ok: true, data: undefined };
+}

--- a/src/chrome/background/activation/dispatch.ts
+++ b/src/chrome/background/activation/dispatch.ts
@@ -24,14 +24,20 @@
  * that spec.
  */
 
+/// <reference types="@crxjs/vite-plugin/client" />
+
 import { isRestricted } from '../../../core/restricted';
 import type { ActivationError, ActivationIntent, Result } from './types';
 
-/**
- * Path to the content-script entry. Relative to the extension root; matches
- * the manifest's expected emit target.
- */
-const CONTENT_SCRIPT_FILE = 'src/chrome/content/index.ts';
+// `?script` is the crxjs vite-plugin pattern for referencing a script entry
+// from another extension surface. The default export is the filename of the
+// emitted loader (e.g., `assets/index.ts-<hash>.js`) — i.e., the path that
+// `chrome.scripting.executeScript({ files })` resolves against the BUILT
+// extension. At dev / build time crxjs registers the entry with Rollup and
+// emits the corresponding chunk; the `.ts` source is never referenced at
+// runtime. See `node_modules/@crxjs/vite-plugin/client.d.ts`.
+import CONTENT_SCRIPT_FILE from '../../content/index.ts?script';
+export { CONTENT_SCRIPT_FILE };
 
 /**
  * Payload sent to the content script on activation. Mirrors the

--- a/src/chrome/background/activation/types.ts
+++ b/src/chrome/background/activation/types.ts
@@ -1,0 +1,78 @@
+/**
+ * Activation-intent types — the normalized shape produced by the dispatch
+ * funnel for every activation source (commands hotkey, context menu, popup).
+ *
+ * Discriminated union: switch on `intent.source` ONLY for payload
+ * normalization (e.g., extracting `selectionText` from the context-menu
+ * variant). The core dispatch flow (restricted-URL guard → inject CS →
+ * handoff to `rsvp-session` Port) is one branchless path.
+ *
+ * See:
+ * - `docs/superpowers/specs/2026-05-22-sw-lifecycle-activation.md`
+ *   §"Unified Activation Dispatch"
+ * - `docs/superpowers/specs/2026-05-08-messaging-contract.md`
+ *   §"Envelope Shape" — `Result<T, E>` is the canonical wire envelope.
+ *
+ * The messaging-contract spec defines `Result<T>` with a string `reason`;
+ * this file widens it to `Result<T, E>` so the activation layer can carry
+ * a typed `ActivationError` discriminated union without losing the spec's
+ * envelope shape (a string `reason` still satisfies the wider parameter).
+ */
+
+/**
+ * Source of an activation attempt.
+ *
+ * NOTE: this uses `'commands'` (plural) to match the `chrome.commands` API
+ * surface. The SW-lifecycle spec uses `'command'` (singular) in its
+ * pseudocode; we follow the issue #122 task contract verbatim. The string
+ * is internal — not on the wire — so the rename is a local choice.
+ */
+export type ActivationSource = 'commands' | 'contextMenu' | 'popup';
+
+/** Activation triggered by a `chrome.commands` hotkey. */
+export interface CommandsActivationIntent {
+  source: 'commands';
+  tabId: number;
+}
+
+/** Activation triggered by a `chrome.contextMenus` click. */
+export interface ContextMenuActivationIntent {
+  source: 'contextMenu';
+  tabId: number;
+  /**
+   * Selection text from `info.selectionText`, if any. This is
+   * page-controlled and untrusted; the dispatch funnel passes the boolean
+   * intent ("was a selection present?") downstream, but the CS re-reads
+   * `window.getSelection().toString()` for the authoritative value. See
+   * the SW-lifecycle spec §"Context-Menu Selection Trust".
+   */
+  selectionText?: string;
+}
+
+/** Activation triggered by the popup. */
+export interface PopupActivationIntent {
+  source: 'popup';
+  tabId: number;
+}
+
+/** Normalized activation intent — discriminated union over `source`. */
+export type ActivationIntent =
+  | CommandsActivationIntent
+  | ContextMenuActivationIntent
+  | PopupActivationIntent;
+
+/**
+ * Result envelope. Mirrors the messaging-contract spec's `Result<T>` with
+ * a typed error parameter so activation can carry an `ActivationError`
+ * discriminated union without an `as` cast.
+ */
+export type Result<T, E = { reason: string; details?: unknown }> =
+  | { ok: true; data: T }
+  | { ok: false; error: E };
+
+/** Errors that the activation funnel can surface. */
+export type ActivationError =
+  | { kind: 'restricted-page'; url: string }
+  | { kind: 'tab-unavailable'; tabId: number; details?: unknown }
+  | { kind: 'inject-failed'; tabId: number; details?: unknown }
+  | { kind: 'handoff-failed'; tabId: number; details?: unknown };

--- a/src/chrome/background/activation/types.ts
+++ b/src/chrome/background/activation/types.ts
@@ -22,16 +22,15 @@
 /**
  * Source of an activation attempt.
  *
- * NOTE: this uses `'commands'` (plural) to match the `chrome.commands` API
- * surface. The SW-lifecycle spec uses `'command'` (singular) in its
- * pseudocode; we follow the issue #122 task contract verbatim. The string
- * is internal — not on the wire — so the rename is a local choice.
+ * Uses `'command'` (singular) per the SW-lifecycle ADR pseudocode. The
+ * string is internal — not on the wire — so any future bridge to the
+ * `chrome.commands` API surface lives at the listener layer, not here.
  */
-export type ActivationSource = 'commands' | 'contextMenu' | 'popup';
+export type ActivationSource = 'command' | 'contextMenu' | 'popup';
 
 /** Activation triggered by a `chrome.commands` hotkey. */
 export interface CommandsActivationIntent {
-  source: 'commands';
+  source: 'command';
   tabId: number;
 }
 

--- a/src/chrome/background/index.ts
+++ b/src/chrome/background/index.ts
@@ -1,17 +1,90 @@
 /**
  * SpeedReader — Background Service Worker (Manifest V3)
  *
- * This file serves as the extension's service worker.  It handles:
- * - Messaging between content scripts, popup, and options page
- * - Persistent state management via chrome.storage
- * - Keyboard shortcut activation (issue #34)
+ * This module is the SW entry point. It registers `chrome.*` listeners
+ * synchronously at top-level — the load-bearing MV3 invariant. A listener
+ * registered inside an async callback after the first `await` is invisible
+ * to Chrome on subsequent wakes.
  *
- * See manifest.ts for the service_worker entry point.
+ * Listener-registration discipline:
+ * - All `addListener` calls happen at module top-level, before any `await`.
+ * - No `init()` wrapper. No top-level `await`.
+ * - Conditional behaviour lives inside the listener body, never gating
+ *   the `addListener` call itself.
+ *
+ * Scope of this file (issue #122):
+ * - Install the unified `chrome.runtime.onMessage` listener with sender-
+ *   provenance validation.
+ * - Export `dispatchActivation` so commands / contextMenu / popup paths
+ *   (issues #34, #72, #75) can wire their listeners in follow-up PRs
+ *   WITHOUT touching the funnel.
+ *
+ * Out of scope (deliberately):
+ * - `chrome.commands.onCommand` listener (issue #34).
+ * - `chrome.contextMenus` registration + `onClicked` listener (issue #72).
+ * - The `rsvp-session` Port `onConnect` handler — owned by the messaging-
+ *   contract spec; lands with the read-session implementation.
+ *
+ * See:
+ * - `docs/superpowers/specs/2026-05-22-sw-lifecycle-activation.md`
+ * - `docs/superpowers/decisions/2026-05-22-sw-lifecycle-activation.md`
+ * - `docs/superpowers/specs/2026-05-08-messaging-contract.md`
  */
 
-// TODO(#4): Implement service worker logic
-// - Listen for messages from content scripts
-// - Manage reading state (current article, position, speed)
-// - Handle shortcut activation
+import { dispatchActivation } from './activation/dispatch';
+import { handleOnMessage, type OnMessageError } from './messaging/on-message';
+import type { ActivationIntent } from './activation/types';
 
-console.log('[SpeedReader] Background service worker loaded');
+// Re-export so follow-up issues (#34, #72) can wire their source-specific
+// listeners against the funnel without reaching into the activation
+// subdirectory.
+export { dispatchActivation };
+export type { ActivationIntent };
+
+/**
+ * Route a validated message to its handler. The sender-provenance gate
+ * in `handleOnMessage` has already rejected foreign senders and shape
+ * mismatches before we reach here.
+ *
+ * Today only `activate-reader` is routed. The Port-based read-session
+ * messages travel over `chrome.runtime.connect` per the messaging-contract
+ * spec — they do NOT pass through `onMessage`.
+ */
+function route(
+  msg: { type: string } & Record<string, unknown>,
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (resp: { ok: false; error: OnMessageError } | { ok: true; data: unknown }) => void,
+): void {
+  if (msg.type === 'activate-reader') {
+    const tabId = sender.tab?.id;
+    // The popup is the only legitimate sender of `activate-reader` over
+    // `onMessage`; it has no `sender.tab.id`, and the popup payload must
+    // carry the resolved tab id explicitly. The provenance gate has
+    // already enforced popup-shape for this type.
+    const intentTabId = typeof msg.tabId === 'number' ? msg.tabId : tabId;
+    if (typeof intentTabId !== 'number') {
+      sendResponse({ ok: false, error: { kind: 'invalid-payload' } });
+      return;
+    }
+    const intent: ActivationIntent = { source: 'popup', tabId: intentTabId };
+    void dispatchActivation(intent).then((result) => {
+      if (result.ok) {
+        sendResponse({ ok: true, data: result.data });
+      } else {
+        // Map ActivationError → OnMessageError envelope. The popup will
+        // re-render based on this; downstream surfaces (restricted page
+        // banner, retry) are owned by the popup UI.
+        sendResponse({ ok: false, error: { kind: 'invalid-payload' } });
+      }
+    });
+    return;
+  }
+
+  // Unknown message types fall through with an invalid-payload error.
+  sendResponse({ ok: false, error: { kind: 'invalid-payload' } });
+}
+
+// Top-level synchronous listener registration. MUST run on every wake.
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  return handleOnMessage(msg, sender, sendResponse, { route });
+});

--- a/src/chrome/background/index.ts
+++ b/src/chrome/background/index.ts
@@ -32,7 +32,8 @@
  */
 
 import { dispatchActivation } from './activation/dispatch';
-import { handleOnMessage, type OnMessageError } from './messaging/on-message';
+import { handleOnMessage } from './messaging/on-message';
+import { route } from './route';
 import type { ActivationIntent } from './activation/types';
 
 // Re-export so follow-up issues (#34, #72) can wire their source-specific
@@ -40,49 +41,6 @@ import type { ActivationIntent } from './activation/types';
 // subdirectory.
 export { dispatchActivation };
 export type { ActivationIntent };
-
-/**
- * Route a validated message to its handler. The sender-provenance gate
- * in `handleOnMessage` has already rejected foreign senders and shape
- * mismatches before we reach here.
- *
- * Today only `activate-reader` is routed. The Port-based read-session
- * messages travel over `chrome.runtime.connect` per the messaging-contract
- * spec — they do NOT pass through `onMessage`.
- */
-function route(
-  msg: { type: string } & Record<string, unknown>,
-  sender: chrome.runtime.MessageSender,
-  sendResponse: (resp: { ok: false; error: OnMessageError } | { ok: true; data: unknown }) => void,
-): void {
-  if (msg.type === 'activate-reader') {
-    const tabId = sender.tab?.id;
-    // The popup is the only legitimate sender of `activate-reader` over
-    // `onMessage`; it has no `sender.tab.id`, and the popup payload must
-    // carry the resolved tab id explicitly. The provenance gate has
-    // already enforced popup-shape for this type.
-    const intentTabId = typeof msg.tabId === 'number' ? msg.tabId : tabId;
-    if (typeof intentTabId !== 'number') {
-      sendResponse({ ok: false, error: { kind: 'invalid-payload' } });
-      return;
-    }
-    const intent: ActivationIntent = { source: 'popup', tabId: intentTabId };
-    void dispatchActivation(intent).then((result) => {
-      if (result.ok) {
-        sendResponse({ ok: true, data: result.data });
-      } else {
-        // Map ActivationError → OnMessageError envelope. The popup will
-        // re-render based on this; downstream surfaces (restricted page
-        // banner, retry) are owned by the popup UI.
-        sendResponse({ ok: false, error: { kind: 'invalid-payload' } });
-      }
-    });
-    return;
-  }
-
-  // Unknown message types fall through with an invalid-payload error.
-  sendResponse({ ok: false, error: { kind: 'invalid-payload' } });
-}
 
 // Top-level synchronous listener registration. MUST run on every wake.
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {

--- a/src/chrome/background/messaging/__tests__/on-message.test.ts
+++ b/src/chrome/background/messaging/__tests__/on-message.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import sinonChrome from 'sinon-chrome';
+
+void sinonChrome;
+
+const OWN_ID = 'abcdefghijklmnopabcdefghijklmnop';
+const FOREIGN_ID = 'foreignforeignforeignforeignforei';
+
+interface ChromeStub {
+  runtime: { id: string; getURL: (path: string) => string };
+}
+
+function installChromeStub(): ChromeStub {
+  const stub: ChromeStub = {
+    runtime: {
+      id: OWN_ID,
+      getURL: (path: string) => `chrome-extension://${OWN_ID}/${path}`,
+    },
+  };
+  (globalThis as unknown as { chrome: ChromeStub }).chrome = stub;
+  return stub;
+}
+
+function popupSender(): chrome.runtime.MessageSender {
+  return {
+    id: OWN_ID,
+    url: `chrome-extension://${OWN_ID}/src/chrome/popup/index.html`,
+    // tab intentionally undefined — popup-shaped
+  };
+}
+
+function contentScriptSender(tabId = 42): chrome.runtime.MessageSender {
+  return {
+    id: OWN_ID,
+    url: 'https://example.com/article',
+    tab: { id: tabId } as chrome.tabs.Tab,
+    frameId: 0,
+  };
+}
+
+describe('handleOnMessage — sender-provenance validation', () => {
+  beforeEach(() => {
+    installChromeStub();
+  });
+  afterEach(() => {
+    delete (globalThis as unknown as { chrome?: unknown }).chrome;
+    vi.resetModules();
+  });
+
+  it('rejects messages from foreign sender.id without further processing', async () => {
+    const { handleOnMessage } = await import('../on-message');
+    const sendResponse = vi.fn();
+    const route = vi.fn();
+
+    const handled = handleOnMessage(
+      { type: 'activate-reader', scope: 'full' },
+      { ...popupSender(), id: FOREIGN_ID },
+      sendResponse,
+      { route },
+    );
+
+    expect(handled).toBe(false);
+    expect(route).not.toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: { kind: 'sender-rejected' },
+    });
+  });
+
+  it('rejects messages whose sender.id is missing', async () => {
+    const { handleOnMessage } = await import('../on-message');
+    const sendResponse = vi.fn();
+    const route = vi.fn();
+
+    handleOnMessage(
+      { type: 'activate-reader', scope: 'full' },
+      { url: 'https://attacker.example' } as chrome.runtime.MessageSender,
+      sendResponse,
+      { route },
+    );
+
+    expect(route).not.toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: { kind: 'sender-rejected' },
+    });
+  });
+
+  it('accepts a popup-shaped sender for popup-only message types', async () => {
+    const { handleOnMessage } = await import('../on-message');
+    const sendResponse = vi.fn();
+    const route = vi.fn();
+
+    handleOnMessage({ type: 'activate-reader', scope: 'full' }, popupSender(), sendResponse, {
+      route,
+    });
+
+    expect(route).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a popup-only message type from a content-script-shaped sender', async () => {
+    const { handleOnMessage } = await import('../on-message');
+    const sendResponse = vi.fn();
+    const route = vi.fn();
+
+    handleOnMessage(
+      { type: 'activate-reader', scope: 'full' },
+      contentScriptSender(),
+      sendResponse,
+      { route },
+    );
+
+    expect(route).not.toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: { kind: 'sender-shape-mismatch', expected: 'popup', got: 'content-script' },
+    });
+  });
+
+  it('rejects a content-script-only message type from a popup-shaped sender', async () => {
+    const { handleOnMessage } = await import('../on-message');
+    const sendResponse = vi.fn();
+    const route = vi.fn();
+
+    handleOnMessage({ type: 'cs-progress', positionIndex: 12 }, popupSender(), sendResponse, {
+      route,
+    });
+
+    expect(route).not.toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: { kind: 'sender-shape-mismatch', expected: 'content-script', got: 'popup' },
+    });
+  });
+
+  it('rejects subframe content-script senders (frameId !== 0)', async () => {
+    const { handleOnMessage } = await import('../on-message');
+    const sendResponse = vi.fn();
+    const route = vi.fn();
+
+    const subframeSender: chrome.runtime.MessageSender = {
+      ...contentScriptSender(),
+      frameId: 7,
+    };
+
+    handleOnMessage({ type: 'cs-progress', positionIndex: 1 }, subframeSender, sendResponse, {
+      route,
+    });
+
+    expect(route).not.toHaveBeenCalled();
+    // The subframe sender still has a `tab`, so it reports as content-script
+    // by shape; the gate refuses it because `frameId !== 0` fails the
+    // top-frame-only requirement.
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: { kind: 'sender-shape-mismatch', expected: 'content-script', got: 'content-script' },
+    });
+  });
+
+  it('rejects malformed messages (non-object / no type)', async () => {
+    const { handleOnMessage } = await import('../on-message');
+    const sendResponse = vi.fn();
+    const route = vi.fn();
+
+    handleOnMessage('not an object', popupSender(), sendResponse, { route });
+    handleOnMessage({ noType: true }, popupSender(), sendResponse, { route });
+
+    expect(route).not.toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenNthCalledWith(1, {
+      ok: false,
+      error: { kind: 'invalid-payload' },
+    });
+    expect(sendResponse).toHaveBeenNthCalledWith(2, {
+      ok: false,
+      error: { kind: 'invalid-payload' },
+    });
+  });
+
+  it('forwards a validated message + sender to the router', async () => {
+    const { handleOnMessage } = await import('../on-message');
+    const sendResponse = vi.fn();
+    const route = vi.fn();
+
+    const msg = { type: 'activate-reader', scope: 'full' };
+    const sender = popupSender();
+    handleOnMessage(msg, sender, sendResponse, { route });
+
+    expect(route).toHaveBeenCalledWith(msg, sender, sendResponse);
+  });
+});

--- a/src/chrome/background/messaging/on-message.ts
+++ b/src/chrome/background/messaging/on-message.ts
@@ -43,6 +43,8 @@ const POPUP_ONLY_TYPES = new Set<string>([
  */
 const CS_ONLY_TYPES = new Set<string>(['cs-progress', 'overlay-state']);
 
+import type { ActivationError } from '../activation/types';
+
 export type OnMessageError =
   | { kind: 'sender-rejected' }
   | {
@@ -50,7 +52,8 @@ export type OnMessageError =
       expected: 'popup' | 'content-script';
       got: 'popup' | 'content-script';
     }
-  | { kind: 'invalid-payload' };
+  | { kind: 'invalid-payload' }
+  | { kind: 'activation-failed'; error: ActivationError };
 
 export interface OnMessageDeps {
   /**

--- a/src/chrome/background/messaging/on-message.ts
+++ b/src/chrome/background/messaging/on-message.ts
@@ -1,0 +1,142 @@
+/**
+ * Unified `chrome.runtime.onMessage` handler — single front door for all
+ * extension-internal RPCs.
+ *
+ * Sender-provenance discipline per the SW-lifecycle spec
+ * (`docs/superpowers/specs/2026-05-22-sw-lifecycle-activation.md`
+ * §"Sender-Provenance Validation"):
+ *
+ * 1. Reject `sender.id !== chrome.runtime.id` (other extensions, no
+ *    further processing).
+ * 2. Per-message-type sender-shape assertions: popup messages must
+ *    arrive with `sender.tab === undefined`; content-script messages
+ *    must have `sender.tab.id` defined AND `sender.frameId === 0`
+ *    (top frame only).
+ * 3. The manifest MUST NOT declare `externally_connectable` — web
+ *    origins MUST NOT reach `onMessage` / `onConnect`. (Default MV3
+ *    behavior is to deny; the comment in `manifest.ts` guards future
+ *    churn.)
+ *
+ * Payload validation here is minimal — exhaustive `validateMsg`
+ * narrowing lives in `src/core/messaging/validate.ts` per the spec.
+ * This file owns the sender-shape gate; payload validation is forwarded
+ * to the router via the `route` callback.
+ */
+
+/**
+ * Message types that may only arrive from the popup (extension page).
+ *
+ * `activate-reader`, `extract-summary`, and `restricted-url-probe` are
+ * popup-originated per the messaging-contract spec; the SW-lifecycle
+ * spec adds `activate-reader` to this set.
+ */
+const POPUP_ONLY_TYPES = new Set<string>([
+  'activate-reader',
+  'extract-summary',
+  'restricted-url-probe',
+]);
+
+/**
+ * Message types that may only arrive from a content script (post-MVP
+ * CS→SW signals). Listed here so the gate refuses popup-shaped senders
+ * for these types.
+ */
+const CS_ONLY_TYPES = new Set<string>(['cs-progress', 'overlay-state']);
+
+export type OnMessageError =
+  | { kind: 'sender-rejected' }
+  | {
+      kind: 'sender-shape-mismatch';
+      expected: 'popup' | 'content-script';
+      got: 'popup' | 'content-script';
+    }
+  | { kind: 'invalid-payload' };
+
+export interface OnMessageDeps {
+  /**
+   * Forward a validated message to the router. Implementations dispatch
+   * by `msg.type` to the appropriate handler (dispatchActivation for
+   * `activate-reader`, etc.).
+   */
+  route: (
+    msg: { type: string } & Record<string, unknown>,
+    sender: chrome.runtime.MessageSender,
+    sendResponse: (
+      resp: { ok: false; error: OnMessageError } | { ok: true; data: unknown },
+    ) => void,
+  ) => void;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isPopupShape(sender: chrome.runtime.MessageSender): boolean {
+  // Popup messages come from an extension page; no `sender.tab`.
+  return sender.tab === undefined;
+}
+
+function isContentScriptShape(sender: chrome.runtime.MessageSender): boolean {
+  // Content-script messages have a tab id AND must be from the top frame.
+  return sender.tab?.id !== undefined && sender.frameId === 0;
+}
+
+/**
+ * Handle a single `chrome.runtime.onMessage` event. Returns a boolean
+ * intended for use as the listener return value: `true` indicates the
+ * message was accepted for async processing (matches Chrome's contract
+ * for keeping `sendResponse` alive). `false` means the message was
+ * rejected at the provenance gate.
+ *
+ * The `deps.route` callback receives validated messages — implementations
+ * are responsible for per-type payload validation and response delivery.
+ */
+export function handleOnMessage(
+  rawMsg: unknown,
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (resp: { ok: false; error: OnMessageError } | { ok: true; data: unknown }) => void,
+  deps: OnMessageDeps,
+): boolean {
+  // 1. Sender ID gate. Foreign extensions and missing IDs hit the floor.
+  if (sender.id !== chrome.runtime.id) {
+    sendResponse({ ok: false, error: { kind: 'sender-rejected' } });
+    return false;
+  }
+
+  // 2. Payload shape gate (just enough to read the discriminator).
+  if (!isObject(rawMsg) || typeof rawMsg.type !== 'string') {
+    sendResponse({ ok: false, error: { kind: 'invalid-payload' } });
+    return false;
+  }
+
+  const msg = rawMsg as { type: string } & Record<string, unknown>;
+
+  // 3. Per-type sender-shape assertion.
+  const senderIsPopup = isPopupShape(sender);
+  const senderIsCs = isContentScriptShape(sender);
+  // `got` describes what the sender LOOKS like by tab presence; the actual
+  // gate uses the stricter `senderIsCs` (top-frame only). A subframe
+  // content-script reports `got: 'content-script'` even though it fails
+  // the gate.
+  const got: 'popup' | 'content-script' = sender.tab === undefined ? 'popup' : 'content-script';
+
+  if (POPUP_ONLY_TYPES.has(msg.type) && !senderIsPopup) {
+    sendResponse({
+      ok: false,
+      error: { kind: 'sender-shape-mismatch', expected: 'popup', got },
+    });
+    return false;
+  }
+  if (CS_ONLY_TYPES.has(msg.type) && !senderIsCs) {
+    sendResponse({
+      ok: false,
+      error: { kind: 'sender-shape-mismatch', expected: 'content-script', got },
+    });
+    return false;
+  }
+
+  // 4. Hand off to the router. Async response is the router's contract;
+  //    returning true tells Chrome to keep `sendResponse` alive.
+  deps.route(msg, sender, sendResponse);
+  return true;
+}

--- a/src/chrome/background/route.ts
+++ b/src/chrome/background/route.ts
@@ -1,0 +1,76 @@
+/**
+ * Router for validated `onMessage` requests. Separated from `index.ts`
+ * so it can be unit-tested without touching the top-level listener
+ * registration.
+ *
+ * The sender-provenance gate in `handleOnMessage` has already rejected
+ * foreign senders and shape mismatches before `route` is called. This
+ * module dispatches by `msg.type` to the appropriate handler.
+ *
+ * Today only `activate-reader` is routed. The Port-based read-session
+ * messages travel over `chrome.runtime.connect` per the messaging-contract
+ * spec — they do NOT pass through `onMessage`.
+ */
+
+import { dispatchActivation } from './activation/dispatch';
+import type { ActivationError, ActivationIntent } from './activation/types';
+import type { OnMessageError } from './messaging/on-message';
+
+export type RouteResponse =
+  | { ok: false; error: OnMessageError }
+  | { ok: true; data: unknown };
+
+/**
+ * Injection hooks. `index.ts` wires the real chrome bindings; tests
+ * supply stubs. The shape is intentionally minimal — only the bits the
+ * router actually touches.
+ */
+export interface RouteDeps {
+  dispatchActivation: (
+    intent: ActivationIntent,
+  ) => Promise<{ ok: true; data: void } | { ok: false; error: ActivationError }>;
+}
+
+const defaultDeps: RouteDeps = {
+  dispatchActivation: (intent) => dispatchActivation(intent),
+};
+
+export function route(
+  msg: { type: string } & Record<string, unknown>,
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (resp: RouteResponse) => void,
+  deps: RouteDeps = defaultDeps,
+): void {
+  if (msg.type === 'activate-reader') {
+    const tabId = sender.tab?.id;
+    // The popup is the only legitimate sender of `activate-reader` over
+    // `onMessage`; it has no `sender.tab.id`, so the popup payload must
+    // carry the resolved tab id explicitly. The provenance gate has
+    // already enforced popup-shape for this type.
+    const intentTabId = typeof msg.tabId === 'number' ? msg.tabId : tabId;
+    if (typeof intentTabId !== 'number') {
+      sendResponse({ ok: false, error: { kind: 'invalid-payload' } });
+      return;
+    }
+    const intent: ActivationIntent = { source: 'popup', tabId: intentTabId };
+    void deps.dispatchActivation(intent).then((result) => {
+      if (result.ok) {
+        sendResponse({ ok: true, data: result.data });
+      } else {
+        // Forward the typed ActivationError verbatim. The popup
+        // distinguishes `restricted-page` (render banner) from
+        // `inject-failed` / `handoff-failed` / `tab-unavailable`
+        // (retry surfaces) — collapsing to `invalid-payload` would
+        // lose that distinction.
+        sendResponse({
+          ok: false,
+          error: { kind: 'activation-failed', error: result.error },
+        });
+      }
+    });
+    return;
+  }
+
+  // Unknown message types fall through with an invalid-payload error.
+  sendResponse({ ok: false, error: { kind: 'invalid-payload' } });
+}

--- a/src/chrome/background/route.ts
+++ b/src/chrome/background/route.ts
@@ -16,9 +16,7 @@ import { dispatchActivation } from './activation/dispatch';
 import type { ActivationError, ActivationIntent } from './activation/types';
 import type { OnMessageError } from './messaging/on-message';
 
-export type RouteResponse =
-  | { ok: false; error: OnMessageError }
-  | { ok: true; data: unknown };
+export type RouteResponse = { ok: false; error: OnMessageError } | { ok: true; data: unknown };
 
 /**
  * Injection hooks. `index.ts` wires the real chrome bindings; tests

--- a/src/chrome/background/route.ts
+++ b/src/chrome/background/route.ts
@@ -27,10 +27,21 @@ export interface RouteDeps {
   dispatchActivation: (
     intent: ActivationIntent,
   ) => Promise<{ ok: true; data: void } | { ok: false; error: ActivationError }>;
+  /**
+   * Returns the id of the currently active tab in the last-focused
+   * window, or `null` when none can be resolved. Used as a
+   * defense-in-depth cross-check: the popup-supplied `msg.tabId` must
+   * match the actually-active tab.
+   */
+  getActiveTabId: () => Promise<number | null>;
 }
 
 const defaultDeps: RouteDeps = {
   dispatchActivation: (intent) => dispatchActivation(intent),
+  getActiveTabId: async () => {
+    const [active] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+    return typeof active?.id === 'number' ? active.id : null;
+  },
 };
 
 export function route(
@@ -50,8 +61,20 @@ export function route(
       sendResponse({ ok: false, error: { kind: 'invalid-payload' } });
       return;
     }
-    const intent: ActivationIntent = { source: 'popup', tabId: intentTabId };
-    void deps.dispatchActivation(intent).then((result) => {
+
+    void (async () => {
+      // Defense-in-depth: the popup-supplied tabId must match the
+      // actually-active tab. The provenance gate already enforced
+      // popup-shape, but a buggy / compromised popup could still
+      // hand us a stale tabId from a previous focus window.
+      const activeTabId = await deps.getActiveTabId();
+      if (activeTabId === null || activeTabId !== intentTabId) {
+        sendResponse({ ok: false, error: { kind: 'invalid-payload' } });
+        return;
+      }
+
+      const intent: ActivationIntent = { source: 'popup', tabId: intentTabId };
+      const result = await deps.dispatchActivation(intent);
       if (result.ok) {
         sendResponse({ ok: true, data: result.data });
       } else {
@@ -65,7 +88,7 @@ export function route(
           error: { kind: 'activation-failed', error: result.error },
         });
       }
-    });
+    })();
     return;
   }
 

--- a/src/chrome/background/state/__tests__/session-state.test.ts
+++ b/src/chrome/background/state/__tests__/session-state.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import sinonChrome from 'sinon-chrome';
+
+void sinonChrome;
+
+interface SessionStub {
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+}
+interface ChromeStub {
+  storage: { session: SessionStub };
+}
+
+let store: Record<string, unknown>;
+
+function installChromeStub(): ChromeStub {
+  store = {};
+  const stub: ChromeStub = {
+    storage: {
+      session: {
+        get: vi.fn((key: string) => Promise.resolve({ [key]: store[key] })),
+        set: vi.fn((items: Record<string, unknown>) => {
+          Object.assign(store, items);
+          return Promise.resolve();
+        }),
+        remove: vi.fn((key: string) => {
+          delete store[key];
+          return Promise.resolve();
+        }),
+      },
+    },
+  };
+  (globalThis as unknown as { chrome: ChromeStub }).chrome = stub;
+  return stub;
+}
+
+const VALID_STATE = {
+  tabId: 42,
+  scope: 'full' as const,
+  wpm: 350,
+  positionIndex: 17,
+  sourceHash: 'abc1234567890def',
+};
+
+describe('session-state', () => {
+  beforeEach(() => {
+    installChromeStub();
+  });
+  afterEach(() => {
+    delete (globalThis as unknown as { chrome?: unknown }).chrome;
+    vi.resetModules();
+  });
+
+  describe('round-trip save/load', () => {
+    it('saves and loads a valid state', async () => {
+      const { saveSession, loadSession } = await import('../session-state');
+      await saveSession(VALID_STATE);
+      const loaded = await loadSession(42);
+      expect(loaded).toEqual(VALID_STATE);
+    });
+
+    it('returns null when no session is stored for the tab', async () => {
+      const { loadSession } = await import('../session-state');
+      const loaded = await loadSession(999);
+      expect(loaded).toBeNull();
+    });
+
+    it('isolates sessions per-tab', async () => {
+      const { saveSession, loadSession } = await import('../session-state');
+      await saveSession(VALID_STATE);
+      await saveSession({ ...VALID_STATE, tabId: 99, positionIndex: 3 });
+
+      const a = await loadSession(42);
+      const b = await loadSession(99);
+
+      expect(a?.positionIndex).toBe(17);
+      expect(b?.positionIndex).toBe(3);
+    });
+  });
+
+  describe('validateSession', () => {
+    it('returns null on shape mismatch (missing fields)', async () => {
+      const { validateSession } = await import('../session-state');
+      expect(validateSession({ tabId: 1 }, 'abc1234567890def')).toBeNull();
+      expect(validateSession(null, 'abc1234567890def')).toBeNull();
+      expect(validateSession('not an object', 'abc1234567890def')).toBeNull();
+    });
+
+    it('returns null on wrong field types', async () => {
+      const { validateSession } = await import('../session-state');
+      const bad = { ...VALID_STATE, wpm: 'fast' };
+      expect(validateSession(bad, VALID_STATE.sourceHash)).toBeNull();
+    });
+
+    it('returns null on invalid scope literal', async () => {
+      const { validateSession } = await import('../session-state');
+      const bad = { ...VALID_STATE, scope: 'other' };
+      expect(validateSession(bad, VALID_STATE.sourceHash)).toBeNull();
+    });
+
+    it('returns null on sourceHash mismatch (content changed under the user)', async () => {
+      const { validateSession } = await import('../session-state');
+      const stored = { ...VALID_STATE, sourceHash: 'oldhash0000000000' };
+      const result = validateSession(stored, 'newhash1111111111');
+      expect(result).toBeNull();
+    });
+
+    it('returns the validated state on success', async () => {
+      const { validateSession } = await import('../session-state');
+      const result = validateSession(VALID_STATE, VALID_STATE.sourceHash);
+      expect(result).toEqual(VALID_STATE);
+    });
+
+    it('rejects negative or non-integer positionIndex', async () => {
+      const { validateSession } = await import('../session-state');
+      expect(
+        validateSession({ ...VALID_STATE, positionIndex: -1 }, VALID_STATE.sourceHash),
+      ).toBeNull();
+      expect(
+        validateSession({ ...VALID_STATE, positionIndex: 1.5 }, VALID_STATE.sourceHash),
+      ).toBeNull();
+      expect(
+        validateSession({ ...VALID_STATE, positionIndex: Number.NaN }, VALID_STATE.sourceHash),
+      ).toBeNull();
+    });
+  });
+
+  describe('loadSession integration', () => {
+    it('returns null when stored payload is corrupt (shape mismatch)', async () => {
+      const { saveSession, loadSession } = await import('../session-state');
+      await saveSession(VALID_STATE);
+      // Hand-corrupt the store after the save.
+      const keys = Object.keys(store);
+      expect(keys).toHaveLength(1);
+      const key = keys[0] ?? '';
+      store[key] = { tabId: 42, oops: true };
+
+      const loaded = await loadSession(42);
+      expect(loaded).toBeNull();
+    });
+  });
+});

--- a/src/chrome/background/state/__tests__/session-state.test.ts
+++ b/src/chrome/background/state/__tests__/session-state.test.ts
@@ -53,16 +53,16 @@ describe('session-state', () => {
   });
 
   describe('round-trip save/load', () => {
-    it('saves and loads a valid state', async () => {
+    it('saves and loads a valid state when expectedSourceHash matches', async () => {
       const { saveSession, loadSession } = await import('../session-state');
       await saveSession(VALID_STATE);
-      const loaded = await loadSession(42);
+      const loaded = await loadSession(42, VALID_STATE.sourceHash);
       expect(loaded).toEqual(VALID_STATE);
     });
 
     it('returns null when no session is stored for the tab', async () => {
       const { loadSession } = await import('../session-state');
-      const loaded = await loadSession(999);
+      const loaded = await loadSession(999, 'whatever');
       expect(loaded).toBeNull();
     });
 
@@ -71,8 +71,8 @@ describe('session-state', () => {
       await saveSession(VALID_STATE);
       await saveSession({ ...VALID_STATE, tabId: 99, positionIndex: 3 });
 
-      const a = await loadSession(42);
-      const b = await loadSession(99);
+      const a = await loadSession(42, VALID_STATE.sourceHash);
+      const b = await loadSession(99, VALID_STATE.sourceHash);
 
       expect(a?.positionIndex).toBe(17);
       expect(b?.positionIndex).toBe(3);
@@ -136,8 +136,24 @@ describe('session-state', () => {
       const key = keys[0] ?? '';
       store[key] = { tabId: 42, oops: true };
 
-      const loaded = await loadSession(42);
+      const loaded = await loadSession(42, VALID_STATE.sourceHash);
       expect(loaded).toBeNull();
+    });
+
+    it('returns null when the stored sourceHash mismatches the expected one', async () => {
+      const { saveSession, loadSession } = await import('../session-state');
+      await saveSession(VALID_STATE);
+      const loaded = await loadSession(42, 'differenthash000000');
+      expect(loaded).toBeNull();
+    });
+
+    it('requires callers to supply an expectedSourceHash (compile-time guarantee)', async () => {
+      const { loadSession } = await import('../session-state');
+      // Type-level assertion via runtime: the second argument is required.
+      // The previous signature allowed `loadSession(tabId)` which silently
+      // self-compared the stored hash to itself — defeating the resume
+      // guard. We assert structurally that the function has arity 2.
+      expect(loadSession.length).toBe(2);
     });
   });
 });

--- a/src/chrome/background/state/session-state.ts
+++ b/src/chrome/background/state/session-state.ts
@@ -76,22 +76,27 @@ export async function saveSession(state: SessionState): Promise<void> {
 }
 
 /**
- * Load and shape-validate a session for a given tab. Returns `null` if
- * absent or the stored payload fails shape validation (caller must
- * `sourceHash`-verify via `validateSession` separately when it has the
- * expected hash from the CS).
+ * Load and validate a session for a given tab.
+ *
+ * `expectedSourceHash` is REQUIRED — the caller must obtain it from the
+ * CS-side hash computation per the SW-lifecycle spec §"sourceHash resume
+ * gate". Self-comparing the stored hash to itself is a no-op and would
+ * defeat the resume guard (the whole point: detect content change under
+ * the user). Making the parameter required closes the silent-skip path
+ * that the prior signature allowed.
+ *
+ * Returns `null` if the slot is absent, the payload fails shape
+ * validation, OR the stored `sourceHash` does not match
+ * `expectedSourceHash`. Callers that receive `null` MUST treat the slot
+ * as empty and start fresh.
  */
-export async function loadSession(tabId: number): Promise<SessionState | null> {
+export async function loadSession(
+  tabId: number,
+  expectedSourceHash: string,
+): Promise<SessionState | null> {
   const key = keyFor(tabId);
   const result = await chrome.storage.session.get(key);
   const raw = (result as Record<string, unknown>)[key];
   if (raw === undefined) return null;
-
-  // Shape-only validation here — sourceHash is verified on the resume
-  // path (see SW-lifecycle spec §"sourceHash resume gate"). We pass the
-  // stored hash to itself so `validateSession` short-circuits on shape
-  // failure without enforcing a mismatch the caller hasn't asked for.
-  if (!isObject(raw)) return null;
-  const storedHash = typeof raw.sourceHash === 'string' ? raw.sourceHash : '';
-  return validateSession(raw, storedHash);
+  return validateSession(raw, expectedSourceHash);
 }

--- a/src/chrome/background/state/session-state.ts
+++ b/src/chrome/background/state/session-state.ts
@@ -1,0 +1,97 @@
+/**
+ * Per-tab reader session state persisted in `chrome.storage.session`.
+ *
+ * Per the SW-lifecycle spec (`docs/superpowers/specs/2026-05-22-sw-lifecycle-activation.md`
+ * §"State Recovery After SW Idle-Kill"):
+ *
+ * - `chrome.storage.session` is the correct tier — cleared on browser
+ *   restart (yesterday's position is meaningless). Requires Chrome 102+.
+ * - Persisted shape carries `{tabId, scope, wpm, positionIndex, sourceHash}`
+ *   ONLY. No raw selection text (PII risk; CS re-extracts on resume).
+ * - Schema MUST be re-validated on every read — disk contents are
+ *   untrusted (storage extension, browser sync, manual edit).
+ * - `sourceHash` mismatch on resume → discard, start fresh. The CS owns
+ *   the hash computation per the spec.
+ *
+ * Keys are namespaced `session:v1:<tabId>` so a future schema bump can
+ * coexist with old data.
+ */
+
+export interface SessionState {
+  tabId: number;
+  scope: 'selection' | 'full';
+  wpm: number;
+  positionIndex: number;
+  sourceHash: string;
+}
+
+const KEY_PREFIX = 'session:v1:';
+
+function keyFor(tabId: number): string {
+  return `${KEY_PREFIX}${tabId}`;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Validate a raw payload (read from storage) against the `SessionState`
+ * schema AND against the expected `sourceHash`. Returns the validated
+ * state on success, `null` on any failure (shape, types, or hash
+ * mismatch). Callers that receive `null` MUST treat the slot as empty
+ * and start fresh.
+ *
+ * Bounds-checking notes:
+ * - `positionIndex` must be a non-negative integer (NaN, negatives, and
+ *   non-integers are rejected).
+ * - `wpm` is type-checked (number) only — full bounds-checking against
+ *   settings (100–600) lives in the caller; this validator stays narrow.
+ */
+export function validateSession(raw: unknown, expectedSourceHash: string): SessionState | null {
+  if (!isObject(raw)) return null;
+
+  const { tabId, scope, wpm, positionIndex, sourceHash } = raw;
+
+  if (typeof tabId !== 'number' || !Number.isInteger(tabId)) return null;
+  if (scope !== 'selection' && scope !== 'full') return null;
+  if (typeof wpm !== 'number' || !Number.isFinite(wpm)) return null;
+  if (typeof positionIndex !== 'number' || !Number.isInteger(positionIndex) || positionIndex < 0) {
+    return null;
+  }
+  if (typeof sourceHash !== 'string' || sourceHash.length === 0) return null;
+
+  if (sourceHash !== expectedSourceHash) return null;
+
+  return { tabId, scope, wpm, positionIndex, sourceHash };
+}
+
+/**
+ * Persist a session state. The caller owns ordering / debouncing; this
+ * function is a thin write. The full CAS-on-positionIndex semantics live
+ * in the (separate) session-locks layer per the spec.
+ */
+export async function saveSession(state: SessionState): Promise<void> {
+  await chrome.storage.session.set({ [keyFor(state.tabId)]: state });
+}
+
+/**
+ * Load and shape-validate a session for a given tab. Returns `null` if
+ * absent or the stored payload fails shape validation (caller must
+ * `sourceHash`-verify via `validateSession` separately when it has the
+ * expected hash from the CS).
+ */
+export async function loadSession(tabId: number): Promise<SessionState | null> {
+  const key = keyFor(tabId);
+  const result = await chrome.storage.session.get(key);
+  const raw = (result as Record<string, unknown>)[key];
+  if (raw === undefined) return null;
+
+  // Shape-only validation here — sourceHash is verified on the resume
+  // path (see SW-lifecycle spec §"sourceHash resume gate"). We pass the
+  // stored hash to itself so `validateSession` short-circuits on shape
+  // failure without enforcing a mismatch the caller hasn't asked for.
+  if (!isObject(raw)) return null;
+  const storedHash = typeof raw.sourceHash === 'string' ? raw.sourceHash : '';
+  return validateSession(raw, storedHash);
+}

--- a/src/chrome/manifest.ts
+++ b/src/chrome/manifest.ts
@@ -94,6 +94,11 @@ export default {
     },
   },
 
+  // --- externally_connectable: intentionally omitted ----------------------
+  // NO externally_connectable. Web origins MUST NOT reach our onMessage/onConnect.
+  // MV3 default is closed; this comment exists to surface the invariant for future PRs.
+  // See ADR docs/superpowers/decisions/2026-05-22-sw-lifecycle-activation.md §5.
+
   // --- Icons --------------------------------------------------------------
   // Used by Chrome Web Store and the extension toolbar.  See issue #11.
   icons: {

--- a/src/core/__tests__/restricted.test.ts
+++ b/src/core/__tests__/restricted.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { isRestricted } from '../restricted';
+
+const OWN_ID = 'abcdefghijklmnopabcdefghijklmnop';
+
+describe('isRestricted', () => {
+  describe('restricted schemes', () => {
+    const restrictedSchemeFixtures: ReadonlyArray<readonly [string, string]> = [
+      ['chrome://settings', 'chrome:'],
+      ['chrome-untrusted://terminal', 'chrome-untrusted:'],
+      ['chrome-search://local-ntp', 'chrome-search:'],
+      ['devtools://devtools/bundled/devtools_app.html', 'devtools:'],
+      ['view-source:https://example.com', 'view-source:'],
+      ['about:blank', 'about:'],
+      ['about:config', 'about:'],
+      ['data:text/html,<p>x</p>', 'data:'],
+      ['javascript:void(0)', 'javascript:'],
+      ['file:///tmp/x.html', 'file:'],
+      ['blob:https://example.com/abc', 'blob:'],
+      ['edge://settings', 'edge:'],
+    ];
+
+    for (const [url, scheme] of restrictedSchemeFixtures) {
+      it(`rejects ${scheme} (${url})`, () => {
+        expect(isRestricted(url, OWN_ID)).toBe(true);
+      });
+    }
+  });
+
+  describe('chrome-extension scheme', () => {
+    it('rejects chrome-extension URLs from other extension IDs', () => {
+      expect(isRestricted('chrome-extension://other-extension-id/popup.html', OWN_ID)).toBe(true);
+    });
+
+    it('allows chrome-extension URLs from our own extension ID', () => {
+      expect(isRestricted(`chrome-extension://${OWN_ID}/popup.html`, OWN_ID)).toBe(false);
+    });
+
+    it('rejects all chrome-extension URLs when own ID is not provided', () => {
+      expect(isRestricted(`chrome-extension://${OWN_ID}/popup.html`)).toBe(true);
+      expect(isRestricted('chrome-extension://other/popup.html')).toBe(true);
+    });
+  });
+
+  describe('Chrome Web Store hosts', () => {
+    it('rejects chromewebstore.google.com', () => {
+      expect(isRestricted('https://chromewebstore.google.com/', OWN_ID)).toBe(true);
+      expect(isRestricted('https://chromewebstore.google.com/category/extensions', OWN_ID)).toBe(
+        true,
+      );
+    });
+
+    it('rejects chrome.google.com/webstore (legacy host path)', () => {
+      expect(isRestricted('https://chrome.google.com/webstore', OWN_ID)).toBe(true);
+      expect(isRestricted('https://chrome.google.com/webstore/category/extensions', OWN_ID)).toBe(
+        true,
+      );
+    });
+
+    it('does NOT reject chrome.google.com on non-webstore paths', () => {
+      // Only the /webstore path on chrome.google.com is restricted; the host
+      // itself serves other (non-restricted) Google content historically.
+      expect(isRestricted('https://chrome.google.com/', OWN_ID)).toBe(false);
+      expect(isRestricted('https://chrome.google.com/intl/en/index.html', OWN_ID)).toBe(false);
+    });
+  });
+
+  describe('allowed URLs', () => {
+    const allowed = [
+      'https://example.com',
+      'https://example.com/path?q=1#frag',
+      'https://en.wikipedia.org/wiki/RSVP',
+      'http://localhost:3000/',
+    ];
+
+    for (const url of allowed) {
+      it(`allows ${url}`, () => {
+        expect(isRestricted(url, OWN_ID)).toBe(false);
+      });
+    }
+  });
+
+  describe('malformed input', () => {
+    it('rejects an empty string', () => {
+      expect(isRestricted('', OWN_ID)).toBe(true);
+    });
+
+    it('rejects unparseable URLs', () => {
+      expect(isRestricted('not a url', OWN_ID)).toBe(true);
+    });
+  });
+});

--- a/src/core/__tests__/restricted.test.ts
+++ b/src/core/__tests__/restricted.test.ts
@@ -27,6 +27,27 @@ describe('isRestricted', () => {
     }
   });
 
+  describe('novel schemes (allow-list default-deny)', () => {
+    // These schemes either don't ship in stable Chromium yet, are
+    // proposed, or are obscure. An allow-list approach rejects them
+    // all by default — a deny-list approach would silently allow them
+    // until each is enumerated. Drives the design choice in #122.
+    const novelSchemeFixtures: ReadonlyArray<readonly [string, string]> = [
+      ['isolated-app://aaaaaaaaaaaaaaaa/index.html', 'isolated-app:'],
+      ['chrome-distiller://abc123', 'chrome-distiller:'],
+      ['filesystem:https://example.com/temporary/foo.txt', 'filesystem:'],
+      ['ws://example.com/socket', 'ws:'],
+      ['wss://example.com/socket', 'wss:'],
+      ['ftp://example.com/file', 'ftp:'],
+    ];
+
+    for (const [url, scheme] of novelSchemeFixtures) {
+      it(`rejects ${scheme} (${url}) under allow-list default-deny`, () => {
+        expect(isRestricted(url, OWN_ID)).toBe(true);
+      });
+    }
+  });
+
   describe('chrome-extension scheme', () => {
     it('rejects chrome-extension URLs from other extension IDs', () => {
       expect(isRestricted('chrome-extension://other-extension-id/popup.html', OWN_ID)).toBe(true);

--- a/src/core/restricted.ts
+++ b/src/core/restricted.ts
@@ -9,25 +9,22 @@
  * No `chrome.*` / `browser.*` imports — this file MUST live under
  * `src/core/` per the boundary contract in `src/core/README.md`.
  *
+ * Allow-list discipline (see issue #122 review):
+ *   The predicate is restricted UNLESS the URL parses cleanly AND its
+ *   scheme is on a small, explicit allow list:
+ *     - `http:` / `https:` (web content, minus Web Store hosts)
+ *     - `chrome-extension:` AND `hostname === ownExtensionId` (our own
+ *       extension surfaces)
+ *   Every other scheme — known-restricted (`chrome:`, `devtools:`,
+ *   `file:`, …) AND future schemes Chromium hasn't shipped yet
+ *   (`isolated-app:`, `chrome-distiller:`, `filesystem:`, …) — falls
+ *   to the default-deny branch. A deny-list misses any scheme not yet
+ *   enumerated; the allow-list flip closes that gap.
+ *
  * See `docs/superpowers/specs/2026-05-22-sw-lifecycle-activation.md`
  * §"Restricted-URL Guard" and the ADR
  * `docs/superpowers/decisions/2026-05-22-sw-lifecycle-activation.md`.
  */
-
-/** URL schemes Chrome forbids (or that have no useful injection target). */
-const RESTRICTED_SCHEMES = new Set<string>([
-  'chrome:',
-  'chrome-untrusted:',
-  'chrome-search:',
-  'devtools:',
-  'view-source:',
-  'about:',
-  'data:',
-  'javascript:',
-  'file:',
-  'blob:',
-  'edge:',
-]);
 
 /** Hosts whose entire surface is off-limits (Chrome Web Store). */
 const RESTRICTED_HOSTS = new Set<string>(['chromewebstore.google.com']);
@@ -39,7 +36,7 @@ const LEGACY_WEBSTORE_PATH_PREFIX = '/webstore';
 /**
  * Returns true if SpeedReader must not inject into the given URL.
  *
- * `chrome-extension:` URLs are restricted EXCEPT when their hostname (the
+ * `chrome-extension:` URLs are allowed ONLY when their hostname (the
  * extension ID) matches `ownExtensionId`. Pass `chrome.runtime.id` from
  * the call site — this function refuses to make that lookup itself to
  * stay platform-agnostic.
@@ -58,13 +55,7 @@ export function isRestricted(url: string, ownExtensionId?: string): boolean {
     return true;
   }
 
-  if (RESTRICTED_SCHEMES.has(parsed.protocol)) return true;
-
-  if (parsed.protocol === 'chrome-extension:') {
-    if (!ownExtensionId) return true;
-    return parsed.hostname !== ownExtensionId;
-  }
-
+  // Allow http(s), minus the Web Store hosts.
   if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
     if (RESTRICTED_HOSTS.has(parsed.hostname)) return true;
     if (
@@ -73,7 +64,16 @@ export function isRestricted(url: string, ownExtensionId?: string): boolean {
     ) {
       return true;
     }
+    return false;
   }
 
-  return false;
+  // Allow our own extension's `chrome-extension://` pages.
+  if (parsed.protocol === 'chrome-extension:') {
+    if (!ownExtensionId) return true;
+    return parsed.hostname !== ownExtensionId;
+  }
+
+  // Every other scheme — known-restricted AND future schemes Chromium
+  // hasn't shipped yet — defaults to restricted.
+  return true;
 }

--- a/src/core/restricted.ts
+++ b/src/core/restricted.ts
@@ -1,0 +1,79 @@
+/**
+ * Restricted-URL classification.
+ *
+ * Pure, platform-agnostic predicate used by the activation dispatch funnel
+ * (and other call sites — context-menu URL patterns, post-injection
+ * fallbacks, CS-side self-checks) to decide whether SpeedReader can
+ * legally inject into a given page.
+ *
+ * No `chrome.*` / `browser.*` imports — this file MUST live under
+ * `src/core/` per the boundary contract in `src/core/README.md`.
+ *
+ * See `docs/superpowers/specs/2026-05-22-sw-lifecycle-activation.md`
+ * §"Restricted-URL Guard" and the ADR
+ * `docs/superpowers/decisions/2026-05-22-sw-lifecycle-activation.md`.
+ */
+
+/** URL schemes Chrome forbids (or that have no useful injection target). */
+const RESTRICTED_SCHEMES = new Set<string>([
+  'chrome:',
+  'chrome-untrusted:',
+  'chrome-search:',
+  'devtools:',
+  'view-source:',
+  'about:',
+  'data:',
+  'javascript:',
+  'file:',
+  'blob:',
+  'edge:',
+]);
+
+/** Hosts whose entire surface is off-limits (Chrome Web Store). */
+const RESTRICTED_HOSTS = new Set<string>(['chromewebstore.google.com']);
+
+/** Legacy Chrome Web Store path on chrome.google.com — restricted by path prefix. */
+const LEGACY_WEBSTORE_HOST = 'chrome.google.com';
+const LEGACY_WEBSTORE_PATH_PREFIX = '/webstore';
+
+/**
+ * Returns true if SpeedReader must not inject into the given URL.
+ *
+ * `chrome-extension:` URLs are restricted EXCEPT when their hostname (the
+ * extension ID) matches `ownExtensionId`. Pass `chrome.runtime.id` from
+ * the call site — this function refuses to make that lookup itself to
+ * stay platform-agnostic.
+ *
+ * When `ownExtensionId` is omitted, all `chrome-extension:` URLs are
+ * treated as restricted (the safe default for boundary code that does
+ * not have the runtime ID handy).
+ */
+export function isRestricted(url: string, ownExtensionId?: string): boolean {
+  if (!url) return true;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return true;
+  }
+
+  if (RESTRICTED_SCHEMES.has(parsed.protocol)) return true;
+
+  if (parsed.protocol === 'chrome-extension:') {
+    if (!ownExtensionId) return true;
+    return parsed.hostname !== ownExtensionId;
+  }
+
+  if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+    if (RESTRICTED_HOSTS.has(parsed.hostname)) return true;
+    if (
+      parsed.hostname === LEGACY_WEBSTORE_HOST &&
+      parsed.pathname.startsWith(LEGACY_WEBSTORE_PATH_PREFIX)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
       // state modules. Rest of src/chrome/** stays excluded — those surfaces
       // are integration-tested via Playwright (#38).
       'src/chrome/settings/**/__tests__/**/*.test.ts',
+      'src/chrome/background/__tests__/**/*.test.ts',
       'src/chrome/background/activation/**/__tests__/**/*.test.ts',
       'src/chrome/background/messaging/**/__tests__/**/*.test.ts',
       'src/chrome/background/state/**/__tests__/**/*.test.ts',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,9 +7,13 @@ export default defineConfig({
     include: [
       'src/core/**/*.test.ts',
       'src/core/**/__tests__/**/*.test.ts',
-      // Narrow inclusion: settings adapter only. Rest of src/chrome/** stays
-      // excluded — those surfaces are integration-tested via Playwright (#38).
+      // Narrow inclusion: settings adapter + background activation/messaging/
+      // state modules. Rest of src/chrome/** stays excluded — those surfaces
+      // are integration-tested via Playwright (#38).
       'src/chrome/settings/**/__tests__/**/*.test.ts',
+      'src/chrome/background/activation/**/__tests__/**/*.test.ts',
+      'src/chrome/background/messaging/**/__tests__/**/*.test.ts',
+      'src/chrome/background/state/**/__tests__/**/*.test.ts',
     ],
     exclude: ['node_modules/**', 'dist/**'],
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,47 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, type Plugin } from 'vitest/config';
+
+/**
+ * Tiny Vite plugin that resolves `*?script` imports (the crxjs vite-plugin
+ * pattern for referencing a script entry from another extension surface)
+ * to a string default-export carrying the file's basename. The real plugin
+ * is registered by `vite.config.ts` for production builds; vitest runs
+ * without the crx plugin, so without this stub the bare `import x from
+ * './foo.ts?script'` fails to resolve. The stub is intentionally inert —
+ * tests assert on the resolved string itself (e.g., "must end in `.js`").
+ */
+const SCRIPT_STUB_PREFIX = 'virtual:script-stub/';
+
+function scriptQueryStub(): Plugin {
+  return {
+    name: 'speedreader-test:script-query-stub',
+    enforce: 'pre',
+    resolveId(id) {
+      // Match `*?script`, `*?script&loader`, `*?script&iife`, `*?script&module`.
+      const match = id.match(/^(.+?)\?script(?:&[a-z]+)?$/);
+      if (!match) return null;
+      const raw = match[1] ?? '';
+      // Strip leading `./` / `../` segments so the encoded id has no path
+      // chars vitest/rolldown will try to re-resolve. The recovered path is
+      // only used to derive a basename in `load`.
+      const encoded = raw.replace(/[./]/g, '_');
+      return `${SCRIPT_STUB_PREFIX}${encoded}|${encodeURIComponent(raw)}`;
+    },
+    load(id) {
+      if (!id.startsWith(SCRIPT_STUB_PREFIX)) return null;
+      const tail = id.slice(SCRIPT_STUB_PREFIX.length);
+      const sep = tail.lastIndexOf('|');
+      const raw = sep === -1 ? tail : decodeURIComponent(tail.slice(sep + 1));
+      // Swap `.ts` for `.js` so tests observe the same emitted-name shape
+      // crxjs produces in real builds (filename with a `.js` extension,
+      // not `.ts`).
+      const filename = raw.replace(/\.ts$/, '.js');
+      return `export default ${JSON.stringify(filename)};`;
+    },
+  };
+}
 
 export default defineConfig({
+  plugins: [scriptQueryStub()],
   test: {
     environment: 'node',
     globals: false,


### PR DESCRIPTION
## Summary

Implements the activation-dispatch funnel + restricted-URL guard designed by ADR `2026-05-22-sw-lifecycle-activation.md` (#105, merged via #106). Foundation for #34 (`chrome.commands`) and #72 (`chrome.contextMenus`) — both can now wire their source-specific listeners against `dispatchActivation()` without colliding.

Closes #122.

## What lands

**Code (new):**
- `src/core/restricted.ts` — `isRestricted(url, ownExtensionId?)` allow-list predicate (http/https + own `chrome-extension`; everything else rejected). Core boundary clean — no `chrome.*` imports.
- `src/chrome/background/activation/types.ts` — `ActivationIntent` discriminated union (`command` | `contextMenu` | `popup`) + `ActivationError` + `Result<T,E>`.
- `src/chrome/background/activation/dispatch.ts` — single `dispatchActivation(intent)` funnel: restricted-URL guard → `chrome.scripting.executeScript` → Result envelope. Source-blind core flow; only payload normalization branches on `intent.source`. Content script ref resolved via crxjs `?script` virtual import (vite + Rolldown compatible).
- `src/chrome/background/messaging/on-message.ts` — unified `onMessage` listener with sender-provenance gate (`sender.id !== chrome.runtime.id` rejection) + per-type sender-shape assertions (popup vs CS) + top-frame-only enforcement.
- `src/chrome/background/state/session-state.ts` — `chrome.storage.session` schema `{tabId, scope, wpm, positionIndex, sourceHash}`. `loadSession` REQUIRES `expectedSourceHash` — no silent skip.
- `src/chrome/background/route.ts` — message-type router extracted from `index.ts` for unit testability of typed-error forwarding.

**Code (modified):**
- `src/chrome/background/index.ts` — stub replaced with top-level synchronous listener registration (MV3 invariant). Re-exports `dispatchActivation` + `ActivationIntent` so #34/#72 can wire their listeners without reaching into subdirs. Popup `activate-reader` payload cross-checks `msg.tabId` against the active tab.
- `src/chrome/manifest.ts` — explicit invariant comment block: `// NO externally_connectable. Web origins MUST NOT reach our onMessage/onConnect.` No permission changes.
- `vitest.config.ts` — `include` broadened to cover new background subtrees; virtual-id stub for crxjs `?script` import.

**Spec (additive amendment):**
- `docs/superpowers/specs/2026-05-08-messaging-contract.md` — `Result<T>` widened to `Result<T, E = { reason: string; details?: unknown }>` via intersection-form generic. Strictly backward compatible (callers using default `E` see the original flat shape). Enables typed error forwarding from `ActivationError` through `OnMessageError` without lossy `kind: 'invalid-payload'` collapse.

## Out of scope (by design)

- `chrome.commands.onCommand` listener → #34
- `chrome.contextMenus` registration + `onClicked` → #72
- `rsvp-session` Port `onConnect` handler → ships with read-session impl (messaging-contract spec)

## Review trail

Builder + two independent reviewers (security-reviewer, reviewer) — converged on 4 substantive findings, all addressed in commits `06a1d7d` through `44b8bbd`. Convergence map:

| Finding | Severity | Status |
|---|---|---|
| `.ts` path in `executeScript({files})` would fail at runtime | BLOCKER (reviewer N3) | fixed `06a1d7d` |
| restricted.ts deny-list inverted vs ADR intent | sec-MED | fixed `3bc3b9e` (flipped to allow-list) |
| `route()` collapsed all `ActivationError` to `invalid-payload`, hiding restricted-page from popup | reviewer H2 | fixed `3bc3b9e` (typed-error envelope) |
| manifest.ts missing `externally_connectable` invariant comment | reviewer H1 | fixed `7f7cc91` |
| `loadSession` self-comparison made `sourceHash` check a no-op | converged sec-LOW + reviewer M3 | fixed `bc08dd0` (required param) |
| `'commands'` → `'command'` per ADR pseudocode | reviewer M1 | fixed `4d36f6f` |
| `Result<T,E>` widening needed spec amendment | reviewer M2 | fixed `05cac92` (Decision A) |
| popup `msg.tabId` defense-in-depth | sec-LOW | fixed `44b8bbd` (active-tab cross-check) |

Known minor divergence (deferred): activation-internal `Result<T,E>` uses nested `{ok:false, error:E}` shape; spec uses intersection `{ok:false} & E`. Internal type does not escape the funnel module — conversion happens at `route()`. Reconcile in a future PR if it becomes load-bearing.

## Test plan

- [x] `npm run lint` — 0 warnings (executed locally, clean)
- [x] `npm run format:check` — all files Prettier-clean (executed locally, clean)
- [x] `npm test` — 381/381 tests across 20 files (executed locally, green)
- [x] `npm run build` — `dist/` emits manifest + content-script chunk; SW bundle inlines built `.js` path in `files:[...]` (executed locally, green; verified `dist/assets/index.ts-pn9lhiIX.js` referenced from SW bundle)
- [x] `npm run test:d10` — Playwright SW-boot regression (T1 manifest shape, T2 action handler, T3 SW listener registration); 3/3 pass against the reproducer manifest (executed locally, green)
- [ ] Manual smoke: load `dist/` as unpacked extension in Chrome ≥ 116, confirm SW boots without console errors. **Cannot be executed by automation in this environment** — flagging per `rules/pr-validation.md`. Reviewer to verify before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
