### PR TITLE
fix(activation): URL-keyed injection lock + post-resolve restricted recheck (#129)

### DIFF
--- a/src/chrome/background/activation/__tests__/collision.test.ts
+++ b/src/chrome/background/activation/__tests__/collision.test.ts
@@ -316,4 +316,31 @@ describe('dispatchActivation — OQ-2 hotkey/contextMenu collision', () => {
     expect(callArg1.target.tabId).toBe(42);
     expect(callArg2.target.tabId).toBe(99);
   });
+
+  // Issue #129 — reverse-race / cache coherence. Lock is keyed on
+  // `(tabId, url)`. Two near-simultaneous dispatches on the SAME tab but
+  // DIFFERENT URLs (tab navigated mid-flight) MUST NOT share an injection;
+  // B's URL identity differs from A's cached entry so B fires its own
+  // executeScript. Without URL keying, B silently reuses A's stale
+  // promise and hands off against a navigated page.
+  it('#129: keys dedup on (tabId, url) — URL change invalidates in-flight reuse', async () => {
+    const TAB = 42;
+    // Override the default stub.tabs.get to return a different URL per call.
+    let getCalls = 0;
+    stub.tabs.get = vi.fn(() => {
+      getCalls += 1;
+      const url = getCalls === 1 ? 'https://example.com/a' : 'https://example.com/b';
+      return Promise.resolve({ url });
+    });
+    const { dispatchActivation } = await import('../dispatch');
+
+    const intent: ActivationIntent = { source: 'command', tabId: TAB };
+    const p1 = dispatchActivation(intent);
+    const p2 = dispatchActivation(intent);
+    pending.push(p1, p2);
+    await flushMicrotasks();
+
+    // Same tab, different URL identity → two distinct injections.
+    expect(stub.scripting.executeScript).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/chrome/background/activation/__tests__/collision.test.ts
+++ b/src/chrome/background/activation/__tests__/collision.test.ts
@@ -317,6 +317,54 @@ describe('dispatchActivation — OQ-2 hotkey/contextMenu collision', () => {
     expect(callArg2.target.tabId).toBe(99);
   });
 
+  // Issue #129 follow-up (test-gap critic M1). The leader's `.finally`
+  // includes an identity guard (`current?.promise === promise`) so a
+  // leader settling AFTER a follower with a different URL has replaced
+  // the map slot does NOT erase the follower's entry. Without the guard,
+  // the leader's settle would orphan the follower's promise and force a
+  // third dispatch on the follower's URL to re-inject. This test pins
+  // that behavior: dispatch leader on url1, follower on url2 (slot
+  // replacement), settle leader's executeScript, then dispatch a third
+  // call on url2 BEFORE follower's settles. With the guard, the third
+  // call reuses follower's in-flight promise → still only 2
+  // `executeScript` calls. Drop the guard, this test would fail with 3.
+  it('#129: leader settle does NOT orphan follower slot on URL mismatch', async () => {
+    const TAB = 42;
+    let getCalls = 0;
+    stub.tabs.get = vi.fn(() => {
+      getCalls += 1;
+      // Leader (1st call) gets /a; follower (2nd call) gets /b;
+      // third dispatch (3rd call) also /b → should reuse follower.
+      const url = getCalls === 1 ? 'https://example.com/a' : 'https://example.com/b';
+      return Promise.resolve({ url });
+    });
+    const { dispatchActivation } = await import('../dispatch');
+    const intent: ActivationIntent = { source: 'command', tabId: TAB };
+
+    const pLeader = dispatchActivation(intent);
+    const pFollower = dispatchActivation(intent);
+    pending.push(pLeader, pFollower);
+    await flushMicrotasks();
+
+    // Both leader and follower fired their own executeScript (URL mismatch).
+    expect(stub.scripting.executeScript).toHaveBeenCalledTimes(2);
+    expect(executeCalls).toHaveLength(2);
+
+    // Settle leader's executeScript ONLY. Leader's .finally runs; the
+    // identity guard must prevent it from deleting the slot now owned
+    // by follower.
+    executeCalls[0]?.resolve();
+    await flushMicrotasks();
+
+    // Third dispatch on url=/b (same as follower). With guard intact,
+    // it reuses follower's still-in-flight promise → no new executeScript.
+    const pThird = dispatchActivation(intent);
+    pending.push(pThird);
+    await flushMicrotasks();
+
+    expect(stub.scripting.executeScript).toHaveBeenCalledTimes(2);
+  });
+
   // Issue #129 — reverse-race / cache coherence. Lock is keyed on
   // `(tabId, url)`. Two near-simultaneous dispatches on the SAME tab but
   // DIFFERENT URLs (tab navigated mid-flight) MUST NOT share an injection;

--- a/src/chrome/background/activation/__tests__/dispatch.test.ts
+++ b/src/chrome/background/activation/__tests__/dispatch.test.ts
@@ -306,4 +306,31 @@ describe('dispatchActivation', () => {
       overrides: { wpm: 999999 },
     });
   });
+
+  // Issue #129 — security TOCTOU. Guard runs at step 2 against URL at that
+  // moment; tab may navigate to a restricted origin between guard and
+  // handoff. A post-injection recheck before sendMessage MUST surface
+  // `restricted-page` (the typed error for this case), not silently hand
+  // off to the now-restricted page.
+  it('#129: re-checks isRestricted after injection and returns restricted-page on URL flip to chrome://', async () => {
+    stub = installChromeStub({});
+    // First call (step 2 guard) returns allowed; second call (post-inject
+    // recheck before handoff) returns restricted.
+    let getCalls = 0;
+    stub.tabs.get = vi.fn(() => {
+      getCalls += 1;
+      const url = getCalls === 1 ? 'https://example.com/article' : 'chrome://settings';
+      return Promise.resolve({ url });
+    });
+    const { dispatchActivation } = await import('../dispatch');
+    const intent: ActivationIntent = { source: 'command', tabId: 21 };
+
+    const result = await dispatchActivation(intent);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toEqual({ kind: 'restricted-page', url: 'chrome://settings' });
+    expect(stub.tabs.sendMessage).not.toHaveBeenCalled();
+    expect(stub.tabs.get).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/chrome/background/activation/__tests__/dispatch.test.ts
+++ b/src/chrome/background/activation/__tests__/dispatch.test.ts
@@ -333,4 +333,62 @@ describe('dispatchActivation', () => {
     expect(stub.tabs.sendMessage).not.toHaveBeenCalled();
     expect(stub.tabs.get).toHaveBeenCalledTimes(2);
   });
+
+  // Issue #129 follow-up (test-gap critic H1). The post-injection
+  // recheck does its own `chrome.tabs.get` — that call can reject (tab
+  // closed between executeScript settle and recheck). Without this test
+  // the catch branch around the second tabs.get is structurally
+  // unreachable from coverage; a refactor that drops it would surface
+  // as an unhandled rejection in the SW.
+  it('#129: post-recheck tabs.get rejection surfaces as tab-unavailable', async () => {
+    stub = installChromeStub({});
+    let getCalls = 0;
+    stub.tabs.get = vi.fn(() => {
+      getCalls += 1;
+      if (getCalls === 1) return Promise.resolve({ url: 'https://example.com/article' });
+      return Promise.reject(new Error('No tab with id: 21'));
+    });
+    const { dispatchActivation } = await import('../dispatch');
+    const intent: ActivationIntent = { source: 'command', tabId: 21 };
+
+    const result = await dispatchActivation(intent);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error.kind).toBe('tab-unavailable');
+    expect(stub.scripting.executeScript).toHaveBeenCalledTimes(1);
+    expect(stub.tabs.sendMessage).not.toHaveBeenCalled();
+  });
+
+  // Issue #129 follow-up (test-gap critic H2). The recheck threads
+  // `chrome.runtime.id` into `isRestricted`. Flipping to a FOREIGN
+  // `chrome-extension://` URL exercises the own-id branch of
+  // `isRestricted` — a regression that passed an empty/wrong runtime
+  // id would still pass the chrome:// flip case (that path ignores
+  // runtime id).
+  it('#129: post-recheck flip to foreign extension URL surfaces as restricted-page', async () => {
+    stub = installChromeStub({});
+    const FOREIGN_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    let getCalls = 0;
+    stub.tabs.get = vi.fn(() => {
+      getCalls += 1;
+      const url =
+        getCalls === 1
+          ? 'https://example.com/article'
+          : `chrome-extension://${FOREIGN_ID}/popup.html`;
+      return Promise.resolve({ url });
+    });
+    const { dispatchActivation } = await import('../dispatch');
+    const intent: ActivationIntent = { source: 'command', tabId: 22 };
+
+    const result = await dispatchActivation(intent);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toEqual({
+      kind: 'restricted-page',
+      url: `chrome-extension://${FOREIGN_ID}/popup.html`,
+    });
+    expect(stub.tabs.sendMessage).not.toHaveBeenCalled();
+  });
 });

--- a/src/chrome/background/activation/dispatch.ts
+++ b/src/chrome/background/activation/dispatch.ts
@@ -10,10 +10,12 @@
  *   1. tab URL lookup
  *   2. restricted-URL guard (`src/core/restricted.ts`)
  *   3. content-script injection via `chrome.scripting.executeScript`
- *   4. handoff to the CS via `chrome.tabs.sendMessage({type: 'activate-reader'})`
+ *   4. post-injection TOCTOU recheck (`isRestricted` against the
+ *      post-resolve URL — issue #129)
+ *   5. handoff to the CS via `chrome.tabs.sendMessage({type: 'activate-reader'})`
  *
  * `intent.source` is consulted ONLY for payload normalization (extracting
- * `selectionText` from the `contextMenu` variant). The four-step flow is
+ * `selectionText` from the `contextMenu` variant). The flow is
  * source-blind.
  *
  * Errors from any step are converted to `Result.err` — exceptions never
@@ -48,6 +50,12 @@ export { CONTENT_SCRIPT_FILE };
  * holds the in-flight injection promise per tab; later callers await the
  * same promise and skip a second `executeScript` call.
  *
+ * Lock is keyed on `(tabId, url)`: a follower reuses the cached promise
+ * ONLY when its observed URL matches the leader's. A tab that has
+ * navigated mid-flight presents a new URL identity, so the follower
+ * fires its own injection rather than handing off against a navigated
+ * page (issue #129 reverse race — cache coherence).
+ *
  * Entry cleared on settle (`.finally`) so the next genuine dispatch can
  * re-inject (e.g., after a CS tear-down or page navigation). The map only
  * dedups CONCURRENT injections — once an injection has completed and the
@@ -63,18 +71,26 @@ export { CONTENT_SCRIPT_FILE };
  * one `executeScript` call across two near-simultaneous dispatches for
  * the same tab.
  */
-const injectionLocks = new Map<number, Promise<void>>();
+interface InjectionLock {
+  url: string;
+  promise: Promise<void>;
+}
+const injectionLocks = new Map<number, InjectionLock>();
 
 /**
  * Idempotently inject the content script into `tabId`. Returns a `Result`
- * — never throws. Concurrent calls for the same `tabId` share one
- * underlying `chrome.scripting.executeScript` call.
+ * — never throws. Concurrent calls for the same `(tabId, url)` share one
+ * underlying `chrome.scripting.executeScript` call. A follower observing
+ * a URL different from the cached entry fires its own injection.
  */
-async function ensureContentScript(tabId: number): Promise<Result<void, ActivationError>> {
-  const inFlight = injectionLocks.get(tabId);
-  if (inFlight) {
+async function ensureContentScript(
+  tabId: number,
+  url: string,
+): Promise<Result<void, ActivationError>> {
+  const cached = injectionLocks.get(tabId);
+  if (cached && cached.url === url) {
     try {
-      await inFlight;
+      await cached.promise;
       return { ok: true, data: undefined };
     } catch (details) {
       return { ok: false, error: { kind: 'inject-failed', tabId, details } };
@@ -87,9 +103,14 @@ async function ensureContentScript(tabId: number): Promise<Result<void, Activati
       files: [CONTENT_SCRIPT_FILE],
     });
   })().finally(() => {
-    injectionLocks.delete(tabId);
+    // Only clear our own entry — a later dispatch on a different URL may
+    // have replaced the slot while we were in flight.
+    const current = injectionLocks.get(tabId);
+    if (current?.promise === promise) {
+      injectionLocks.delete(tabId);
+    }
   });
-  injectionLocks.set(tabId, promise);
+  injectionLocks.set(tabId, { url, promise });
 
   try {
     await promise;
@@ -165,16 +186,35 @@ export async function dispatchActivation(
   }
 
   // 3. Inject the content script idempotently. `ensureContentScript`
-  //    dedupes concurrent injections per tab so two near-simultaneous
-  //    activations (e.g., context-menu click + #34 hotkey) share one
-  //    underlying `chrome.scripting.executeScript` call. Rejections
-  //    (TOCTOU restricted URLs, etc.) surface as `inject-failed`.
-  const injectResult = await ensureContentScript(intent.tabId);
+  //    dedupes concurrent injections per `(tabId, url)` so two
+  //    near-simultaneous activations (e.g., context-menu click + #34
+  //    hotkey) on the same page share one `chrome.scripting.executeScript`
+  //    call. A tab that navigated mid-flight presents a different URL
+  //    identity, so a follower fires its own injection (issue #129).
+  //    Rejections (TOCTOU restricted URLs, etc.) surface as `inject-failed`.
+  const injectResult = await ensureContentScript(intent.tabId, url);
   if (!injectResult.ok) {
     return injectResult;
   }
 
-  // 4. Hand off to the CS via the `activate-reader` one-shot RPC. The
+  // 4. Post-injection TOCTOU recheck (issue #129). The tab may have
+  //    navigated between the step-2 guard and the now-resolved
+  //    `executeScript`. Re-fetch the URL and re-run `isRestricted`
+  //    before the handoff so a flip to a restricted origin surfaces as
+  //    `restricted-page` (the typed error for this case) rather than
+  //    leaking through as a silent handoff or a generic `inject-failed`.
+  let postUrl: string;
+  try {
+    const postTab = await chrome.tabs.get(intent.tabId);
+    postUrl = postTab.url ?? '';
+  } catch (details) {
+    return { ok: false, error: { kind: 'tab-unavailable', tabId: intent.tabId, details } };
+  }
+  if (isRestricted(postUrl, chrome.runtime.id)) {
+    return { ok: false, error: { kind: 'restricted-page', url: postUrl } };
+  }
+
+  // 5. Hand off to the CS via the `activate-reader` one-shot RPC. The
   //    `rsvp-session` Port is opened separately by the popup / CS per
   //    the messaging-contract spec.
   const payload = intentToActivatePayload(intent);


### PR DESCRIPTION
## Summary

Closes #129. SW-side activation funnel had a TOCTOU race: a tab navigating between the step-2 restricted-URL guard and the `activate-reader` handoff could silently land CS injection against a restricted origin, or hand off to a now-restricted page.

Two complementary fixes (both options from the issue's acceptance criteria):

- **URL-keyed injection lock** — `injectionLocks` is now `Map<number, { url; promise }>`. A follower reuses the cached promise only when its observed URL matches the leader's; a mid-flight navigation invalidates reuse and the follower fires its own `executeScript`.
- **Post-injection `isRestricted` recheck** — after the awaited `executeScript` resolves and before `chrome.tabs.sendMessage`, re-fetch the tab URL and re-run the guard. A flip to a restricted origin surfaces as the typed `restricted-page` error rather than leaking through as a silent handoff or a generic `inject-failed`.

Source: four-critic antagonistic-ring arbiter SUMMARY on PR #127, security-adversary finding #1.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 480/480 pass (23 in activation/, incl. 2 new regression tests for #129)
- [x] `npm run build` (tsc --noEmit + vite build) — clean
- [x] Regression: `dispatch.test.ts` — URL flip to `chrome://settings` between guard and handoff returns `restricted-page` and skips the handoff
- [x] Regression: `collision.test.ts` — two near-simultaneous dispatches on the same `tabId` but different URLs fire two distinct `executeScript` calls (no stale-cache reuse)
- [ ] Manual browser smoke (not run; covered by existing collision tests)

## Out of scope

- Map eviction on `chrome.tabs.onRemoved` + timeout (separate issue #128)
- Frame-id keying (no frame intents land yet)
- CS-side guards (different surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
