### PR TITLE
docs(perf): accept residuals on injection timeout + CS listener fan-out (closes #139, #142)

### DIFF
--- a/src/chrome/background/activation/dispatch.ts
+++ b/src/chrome/background/activation/dispatch.ts
@@ -118,6 +118,31 @@ const inFlightByTab = new Map<number, Set<InjectionLock>>();
  * entry for the SW lifetime and silently deadlock subsequent dispatches
  * on the same tab. The race timer surfaces a hung injection as
  * `inject-failed` and clears the slot.
+ *
+ * Accepted residuals (issue #139, surfaced by the antagonistic-ring
+ * arbiter on PR #137 — see issues #128, #137, #139):
+ *
+ *   1. SW idle-shutdown inversion. Every dispatch arms a 5 s timer.
+ *      MV3 idle-shutdown is ~30 s of no events / no pending timers, so
+ *      the SW stays alive at least 5 s past the last `executeScript`
+ *      settle even on the happy path. A stream of one dispatch every
+ *      ~4 s effectively pins the SW awake indefinitely.
+ *
+ *   2. Inner-promise long-tail retention. On the timeout reject path
+ *      below, `withInjectionTimeout` rejects the outer promise but the
+ *      `inner` IIFE keeps running and retains `tabId`, the file-path
+ *      argument, and a microtask-queue slot until Chrome eventually
+ *      settles `executeScript`. In the pathological never-settles case
+ *      this defensive timer exists to defend against, retention lasts
+ *      until SW restart.
+ *
+ * Decision: residuals ACCEPTED. We do not wrap `inner` in an
+ * `AbortController` because `chrome.scripting.executeScript` does not
+ * honor abort signals today — a wrapper would drop our reference but
+ * not stop the underlying call, adding code for no observable win.
+ * Removing the 5 s ceiling is out of scope per issue #128 (it is the
+ * defensive bound against silent activation deadlock). Revisit if/when
+ * `chrome.scripting` grows real cancellation.
  */
 const INJECTION_TIMEOUT_MS = 5000;
 

--- a/src/chrome/content/index.ts
+++ b/src/chrome/content/index.ts
@@ -33,6 +33,30 @@ import { handleActivateReader } from './activate-handler';
 
 console.log('[SpeedReader] Content script loaded');
 
+/**
+ * Issue #142 — resident-cost trade-off (surfaced by the antagonistic-ring
+ * arbiter on PR #140, perf finding #1).
+ *
+ * This listener registers at CS module load on every matched top-level
+ * document. At N open tabs that means:
+ * - N resident listener closures
+ * - N copies of the `handleActivateReader` import graph
+ *   (`activate-handler.ts` -> `core/restricted.ts`)
+ * - The `msg.type !== 'activate-reader'` early-return runs on EVERY
+ *   `runtime.onMessage` event routed to each tab (future feature
+ *   messages, devtools probes, etc.).
+ *
+ * Decision: trade ACCEPTED. The cliff is non-catastrophic at typical
+ * browsing scale, and the CS-side gate is load-bearing for #134's
+ * residual TOCTOU closure between the SW's post-injection recheck
+ * (PR #133) and the `chrome.tabs.sendMessage` handoff — removing it
+ * reintroduces the race. Lazy registration would require a different
+ * handshake protocol since the listener wouldn't exist at
+ * `sendMessage` time; non-trivial design change, deferred. Flagged
+ * for future hot-path expansion (auto-activate-on-scroll, etc.).
+ *
+ * Refs: #134 (gate rationale), #140 (review), #142 (this note).
+ */
 if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
   chrome.runtime.onMessage.addListener((msg: unknown, sender, sendResponse) => {
     // Sender authorization (review H2). `chrome.runtime.onMessage` in a


### PR DESCRIPTION
## Summary

Closes #139 and #142 — both perf residuals surfaced by the four-critic antagonistic-ring arbiter on PRs #137 / #140. Each issue's acceptance criteria explicitly allow inline-doc + accept-residual as a valid completion path; this PR takes that path for both.

### #139 — `dispatch.ts` injection timeout

Documents two residuals near `INJECTION_TIMEOUT_MS`:
- **SW idle-shutdown inversion** — 5 s timer vs MV3's ~30 s idle window pins SW under burst activation
- **Inner-promise long-tail retention** — timeout reject path leaves `inner` running with retained closure refs

Decision: residuals **accepted**. `chrome.scripting.executeScript` does not honor `AbortController` today; wrapping `inner` adds code with no observable win. Removing the 5 s ceiling is out of scope per #128 (defensive bound against silent activation deadlock).

### #142 — `content/index.ts` listener fan-out

Documents the per-tab resident cost (N closures + N import-graph copies + early-return tax on every routed `runtime.onMessage`).

Decision: trade **accepted**. The CS-side gate is load-bearing for #134's residual TOCTOU closure between SW post-injection recheck (#133) and the `sendMessage` handoff. Lazy registration would require a different handshake protocol since the listener wouldn't exist at `sendMessage` time — non-trivial design change, deferred.

## Out of scope (explicit)

- Heap snapshot / SW-lifetime measurement (manual Chrome work; not part of this PR)
- `AbortController` wrapper / lazy-registration refactor
- Removing the 5 s timeout or the CS-side gate

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 514/514 pass
- [x] `npm run build` — clean (tsc + vite)
- [x] Diff confirmed comment-only (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
