### PR TITLE
feat(options): wire options page to SettingsV4 storage (closes #31)

### DIFF
--- a/src/chrome/options/__tests__/controller.test.ts
+++ b/src/chrome/options/__tests__/controller.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
 import type { SettingsV4 } from '../../../core/settings/schema';
 
 const HTML = `
+  <div id="load-error-banner"></div>
   <input type="number" id="${FIELD_IDS.wpm}" />
   <select id="${FIELD_IDS.theme}">
     <option value="system"></option>
@@ -25,6 +26,7 @@ const HTML = `
   <input type="checkbox" id="${FIELD_IDS.contextLine}" />
   <input type="checkbox" id="${FIELD_IDS.startFromWordOne}" />
   <div id="saved"></div>
+  <div id="save-error"></div>
 `;
 
 interface Stub extends SettingsApi {
@@ -69,160 +71,339 @@ function fire(el: HTMLElement, type: string): void {
   el.dispatchEvent(new Event(type, { bubbles: true }));
 }
 
+function setVisibility(state: 'visible' | 'hidden'): void {
+  Object.defineProperty(document, 'visibilityState', {
+    value: state,
+    configurable: true,
+  });
+}
+
 describe('options controller', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     setBody(HTML);
+    setVisibility('visible');
   });
   afterEach(() => {
     vi.useRealTimers();
     document.body.innerHTML = '';
   });
 
-  it('populates every editable field from loaded settings', async () => {
-    const stub = makeStub({
-      ...DEFAULT_SETTINGS,
-      wpm: 350,
-      theme: 'nord',
-      font: 'Georgia',
-      fontSize: 22,
-      openDyslexic: true,
-      punctuationPacing: false,
-      alignment: 'center',
-      contextLine: true,
-      startFromWordOne: true,
+  describe('populate', () => {
+    it('populates every editable field from loaded settings', async () => {
+      const stub = makeStub({
+        ...DEFAULT_SETTINGS,
+        wpm: 350,
+        theme: 'nord',
+        font: 'Georgia',
+        fontSize: 22,
+        openDyslexic: true,
+        punctuationPacing: false,
+        alignment: 'center',
+        contextLine: true,
+        startFromWordOne: true,
+      });
+      await bindOptionsForm(document, window, stub);
+
+      expect((document.getElementById(FIELD_IDS.wpm) as HTMLInputElement).value).toBe('350');
+      expect((document.getElementById(FIELD_IDS.theme) as HTMLSelectElement).value).toBe('nord');
+      expect((document.getElementById(FIELD_IDS.font) as HTMLInputElement).value).toBe('Georgia');
+      expect((document.getElementById(FIELD_IDS.fontSize) as HTMLInputElement).value).toBe('22');
+      expect((document.getElementById(FIELD_IDS.alignment) as HTMLSelectElement).value).toBe(
+        'center',
+      );
+      expect((document.getElementById(FIELD_IDS.openDyslexic) as HTMLInputElement).checked).toBe(
+        true,
+      );
+      expect(
+        (document.getElementById(FIELD_IDS.punctuationPacing) as HTMLInputElement).checked,
+      ).toBe(false);
+      expect((document.getElementById(FIELD_IDS.contextLine) as HTMLInputElement).checked).toBe(
+        true,
+      );
+      expect(
+        (document.getElementById(FIELD_IDS.startFromWordOne) as HTMLInputElement).checked,
+      ).toBe(true);
     });
-    await bindOptionsForm(document, window, stub);
-
-    expect((document.getElementById(FIELD_IDS.wpm) as HTMLInputElement).value).toBe('350');
-    expect((document.getElementById(FIELD_IDS.theme) as HTMLSelectElement).value).toBe('nord');
-    expect((document.getElementById(FIELD_IDS.font) as HTMLInputElement).value).toBe('Georgia');
-    expect((document.getElementById(FIELD_IDS.fontSize) as HTMLInputElement).value).toBe('22');
-    expect((document.getElementById(FIELD_IDS.alignment) as HTMLSelectElement).value).toBe(
-      'center',
-    );
-    expect((document.getElementById(FIELD_IDS.openDyslexic) as HTMLInputElement).checked).toBe(
-      true,
-    );
-    expect((document.getElementById(FIELD_IDS.punctuationPacing) as HTMLInputElement).checked).toBe(
-      false,
-    );
-    expect((document.getElementById(FIELD_IDS.contextLine) as HTMLInputElement).checked).toBe(true);
-    expect((document.getElementById(FIELD_IDS.startFromWordOne) as HTMLInputElement).checked).toBe(
-      true,
-    );
   });
 
-  it('falls back to defaults when load rejects', async () => {
-    const stub = makeStub();
-    stub.loadMock.mockRejectedValueOnce(new Error('boom'));
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    await bindOptionsForm(document, window, stub);
-    expect((document.getElementById(FIELD_IDS.wpm) as HTMLInputElement).value).toBe(
-      String(DEFAULT_SETTINGS.wpm),
-    );
-    expect(warn).toHaveBeenCalled();
-    warn.mockRestore();
-  });
+  describe('load failure (degraded mode)', () => {
+    it('shows load-error banner and suppresses save when load rejects', async () => {
+      const stub = makeStub();
+      stub.loadMock.mockRejectedValueOnce(new Error('quota'));
+      const err = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      await bindOptionsForm(document, window, stub);
 
-  it('saves partial update on number change', async () => {
-    const stub = makeStub();
-    await bindOptionsForm(document, window, stub);
-    const wpm = document.getElementById(FIELD_IDS.wpm) as HTMLInputElement;
-    wpm.value = '400';
-    fire(wpm, 'change');
-    // Save call is sync-dispatched; resolution is microtask.
-    await Promise.resolve();
-    expect(stub.saveMock).toHaveBeenCalledWith({ wpm: 400 });
-  });
+      expect(document.getElementById('load-error-banner')?.classList.contains('visible')).toBe(
+        true,
+      );
+      // Defaults shown for orientation.
+      expect((document.getElementById(FIELD_IDS.wpm) as HTMLInputElement).value).toBe(
+        String(DEFAULT_SETTINGS.wpm),
+      );
 
-  it('saves partial update on checkbox toggle', async () => {
-    const stub = makeStub();
-    await bindOptionsForm(document, window, stub);
-    const cb = document.getElementById(FIELD_IDS.openDyslexic) as HTMLInputElement;
-    cb.checked = true;
-    fire(cb, 'change');
-    await Promise.resolve();
-    expect(stub.saveMock).toHaveBeenCalledWith({ openDyslexic: true });
-  });
-
-  it('saves partial update on select change', async () => {
-    const stub = makeStub();
-    await bindOptionsForm(document, window, stub);
-    const theme = document.getElementById(FIELD_IDS.theme) as HTMLSelectElement;
-    theme.value = 'sepia';
-    fire(theme, 'change');
-    await Promise.resolve();
-    expect(stub.saveMock).toHaveBeenCalledWith({ theme: 'sepia' });
-  });
-
-  it('does NOT save when number input is NaN', async () => {
-    const stub = makeStub();
-    await bindOptionsForm(document, window, stub);
-    const wpm = document.getElementById(FIELD_IDS.wpm) as HTMLInputElement;
-    wpm.value = '';
-    fire(wpm, 'change');
-    await Promise.resolve();
-    expect(stub.saveMock).not.toHaveBeenCalled();
-  });
-
-  it('repopulates from subscribe callback on external change', async () => {
-    const stub = makeStub();
-    await bindOptionsForm(document, window, stub);
-    stub.emit({ ...DEFAULT_SETTINGS, wpm: 500, theme: 'dark' });
-    expect((document.getElementById(FIELD_IDS.wpm) as HTMLInputElement).value).toBe('500');
-    expect((document.getElementById(FIELD_IDS.theme) as HTMLSelectElement).value).toBe('dark');
-  });
-
-  it('flushes pending saves when document becomes hidden', async () => {
-    const stub = makeStub();
-    await bindOptionsForm(document, window, stub);
-    Object.defineProperty(document, 'visibilityState', {
-      value: 'hidden',
-      configurable: true,
+      const wpm = document.getElementById(FIELD_IDS.wpm) as HTMLInputElement;
+      wpm.value = '420';
+      fire(wpm, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).not.toHaveBeenCalled();
+      expect(err).toHaveBeenCalled();
+      err.mockRestore();
     });
-    document.dispatchEvent(new Event('visibilitychange'));
-    expect(stub.flushMock).toHaveBeenCalledTimes(1);
   });
 
-  it('does NOT flush when document is still visible', async () => {
-    const stub = makeStub();
-    await bindOptionsForm(document, window, stub);
-    Object.defineProperty(document, 'visibilityState', {
-      value: 'visible',
-      configurable: true,
+  describe('save (per-field)', () => {
+    it('saves wpm on valid in-range step-aligned change', async () => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      const wpm = document.getElementById(FIELD_IDS.wpm) as HTMLInputElement;
+      wpm.value = '400';
+      fire(wpm, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).toHaveBeenCalledWith({ wpm: 400 });
     });
-    document.dispatchEvent(new Event('visibilitychange'));
-    expect(stub.flushMock).not.toHaveBeenCalled();
+
+    it('saves checkbox toggle', async () => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      const cb = document.getElementById(FIELD_IDS.openDyslexic) as HTMLInputElement;
+      cb.checked = true;
+      fire(cb, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).toHaveBeenCalledWith({ openDyslexic: true });
+    });
+
+    it('saves theme select change', async () => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      const theme = document.getElementById(FIELD_IDS.theme) as HTMLSelectElement;
+      theme.value = 'sepia';
+      fire(theme, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).toHaveBeenCalledWith({ theme: 'sepia' });
+    });
+
+    it('saves alignment select change', async () => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      const align = document.getElementById(FIELD_IDS.alignment) as HTMLSelectElement;
+      align.value = 'center';
+      fire(align, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).toHaveBeenCalledWith({ alignment: 'center' });
+    });
+
+    it('saves font text change', async () => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      const font = document.getElementById(FIELD_IDS.font) as HTMLInputElement;
+      font.value = 'Georgia';
+      fire(font, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).toHaveBeenCalledWith({ font: 'Georgia' });
+    });
   });
 
-  it('shows the saved indicator briefly after save resolves', async () => {
-    const stub = makeStub();
-    await bindOptionsForm(document, window, stub);
-    const wpm = document.getElementById(FIELD_IDS.wpm) as HTMLInputElement;
-    wpm.value = '300';
-    fire(wpm, 'change');
-    // Await the save mock's returned promise + one extra microtask turn so the
-    // `.then(() => showSaved)` chain runs before assertions.
-    const saveResult = stub.saveMock.mock.results[0]?.value as Promise<void>;
-    await saveResult;
-    await Promise.resolve();
-    expect(document.getElementById('saved')?.classList.contains('visible')).toBe(true);
-    vi.advanceTimersByTime(1600);
-    expect(document.getElementById('saved')?.classList.contains('visible')).toBe(false);
+  describe('input validation (reject on invalid)', () => {
+    it.each([
+      ['empty string', ''],
+      ['non-numeric', 'abc'],
+      ['below min', '50'],
+      ['above max', '999'],
+      ['not step-aligned', '425'],
+      ['non-integer', '250.5'],
+    ])('rejects wpm: %s', async (_, raw) => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      const wpm = document.getElementById(FIELD_IDS.wpm) as HTMLInputElement;
+      wpm.value = raw;
+      fire(wpm, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['below min', '8'],
+      ['above max', '99'],
+      ['non-integer', '14.5'],
+      ['empty', ''],
+    ])('rejects fontSize: %s', async (_, raw) => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      const fs = document.getElementById(FIELD_IDS.fontSize) as HTMLInputElement;
+      fs.value = raw;
+      fire(fs, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects theme value outside the V4 enum', async () => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      const theme = document.getElementById(FIELD_IDS.theme) as HTMLSelectElement;
+      // Inject an option to simulate HTML drift; controller must reject.
+      const option = document.createElement('option');
+      option.value = 'rainbow';
+      theme.appendChild(option);
+      theme.value = 'rainbow';
+      fire(theme, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects alignment value outside the V4 enum', async () => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      const align = document.getElementById(FIELD_IDS.alignment) as HTMLSelectElement;
+      const option = document.createElement('option');
+      option.value = 'left';
+      align.appendChild(option);
+      align.value = 'left';
+      fire(align, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects empty font (avoids accidental clobber)', async () => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      const font = document.getElementById(FIELD_IDS.font) as HTMLInputElement;
+      font.value = '   ';
+      fire(font, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).not.toHaveBeenCalled();
+    });
   });
 
-  it('teardown removes change listeners and unsubscribes', async () => {
-    const stub = makeStub();
-    const teardown = await bindOptionsForm(document, window, stub);
-    teardown();
-    const wpm = document.getElementById(FIELD_IDS.wpm) as HTMLInputElement;
-    wpm.value = '450';
-    fire(wpm, 'change');
-    await Promise.resolve();
-    expect(stub.saveMock).not.toHaveBeenCalled();
-    // Emitting a subscribe update after teardown must be a no-op (listener cleared).
-    stub.emit({ ...DEFAULT_SETTINGS, wpm: 600 });
-    expect((document.getElementById(FIELD_IDS.wpm) as HTMLInputElement).value).toBe('450');
+  describe('save failure UX', () => {
+    it('flashes the save-error indicator when save rejects', async () => {
+      const stub = makeStub();
+      stub.saveMock.mockRejectedValueOnce(new Error('quota'));
+      const err = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      await bindOptionsForm(document, window, stub);
+      const wpm = document.getElementById(FIELD_IDS.wpm) as HTMLInputElement;
+      wpm.value = '300';
+      fire(wpm, 'change');
+      const saveResult = stub.saveMock.mock.results[0]?.value as Promise<unknown>;
+      await saveResult.catch(() => undefined);
+      await Promise.resolve();
+      expect(document.getElementById('save-error')?.classList.contains('visible')).toBe(true);
+      expect(document.getElementById('saved')?.classList.contains('visible')).toBe(false);
+      expect(err).toHaveBeenCalled();
+      err.mockRestore();
+    });
+
+    it('flashes the saved indicator and clears it after the timeout', async () => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      const wpm = document.getElementById(FIELD_IDS.wpm) as HTMLInputElement;
+      wpm.value = '300';
+      fire(wpm, 'change');
+      const saveResult = stub.saveMock.mock.results[0]?.value as Promise<void>;
+      await saveResult;
+      await Promise.resolve();
+      expect(document.getElementById('saved')?.classList.contains('visible')).toBe(true);
+      vi.advanceTimersByTime(1600);
+      expect(document.getElementById('saved')?.classList.contains('visible')).toBe(false);
+    });
+  });
+
+  describe('subscribe', () => {
+    it('repopulates from subscribe callback on external change', async () => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      stub.emit({ ...DEFAULT_SETTINGS, wpm: 500, theme: 'dark' });
+      expect((document.getElementById(FIELD_IDS.wpm) as HTMLInputElement).value).toBe('500');
+      expect((document.getElementById(FIELD_IDS.theme) as HTMLSelectElement).value).toBe('dark');
+    });
+  });
+
+  describe('flush triggers', () => {
+    it('flushes when document becomes hidden', async () => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      setVisibility('hidden');
+      document.dispatchEvent(new Event('visibilitychange'));
+      expect(stub.flushMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT flush on visibilitychange when still visible', async () => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      setVisibility('visible');
+      document.dispatchEvent(new Event('visibilitychange'));
+      expect(stub.flushMock).not.toHaveBeenCalled();
+    });
+
+    it('flushes on pagehide regardless of visibility', async () => {
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      window.dispatchEvent(new Event('pagehide'));
+      expect(stub.flushMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs an error when flush rejects on visibility-hidden', async () => {
+      const stub = makeStub();
+      stub.flushMock.mockRejectedValueOnce(new Error('quota'));
+      const err = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      await bindOptionsForm(document, window, stub);
+      setVisibility('hidden');
+      document.dispatchEvent(new Event('visibilitychange'));
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(err).toHaveBeenCalled();
+      err.mockRestore();
+    });
+
+    it('logs an error when flush rejects on pagehide', async () => {
+      const stub = makeStub();
+      stub.flushMock.mockRejectedValueOnce(new Error('quota'));
+      const err = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      await bindOptionsForm(document, window, stub);
+      window.dispatchEvent(new Event('pagehide'));
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(err).toHaveBeenCalled();
+      err.mockRestore();
+    });
+  });
+
+  describe('HTML drift surfacing', () => {
+    it('console-errors when a FIELD_IDS element is missing from the DOM', async () => {
+      // Remove the wpm input to simulate HTML drift.
+      document.getElementById(FIELD_IDS.wpm)?.remove();
+      const err = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const stub = makeStub();
+      await bindOptionsForm(document, window, stub);
+      expect(err).toHaveBeenCalledWith(
+        expect.stringContaining('HTML missing field elements'),
+        expect.arrayContaining(['wpm']),
+      );
+      err.mockRestore();
+    });
+  });
+
+  describe('teardown', () => {
+    it('removes listeners and unsubscribes', async () => {
+      const stub = makeStub();
+      const teardown = await bindOptionsForm(document, window, stub);
+      teardown();
+
+      const wpm = document.getElementById(FIELD_IDS.wpm) as HTMLInputElement;
+      wpm.value = '450';
+      fire(wpm, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).not.toHaveBeenCalled();
+
+      stub.emit({ ...DEFAULT_SETTINGS, wpm: 600 });
+      expect((document.getElementById(FIELD_IDS.wpm) as HTMLInputElement).value).toBe('450');
+
+      setVisibility('hidden');
+      document.dispatchEvent(new Event('visibilitychange'));
+      expect(stub.flushMock).not.toHaveBeenCalled();
+
+      window.dispatchEvent(new Event('pagehide'));
+      expect(stub.flushMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/chrome/options/__tests__/controller.test.ts
+++ b/src/chrome/options/__tests__/controller.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { bindOptionsForm, FIELD_IDS, type SettingsApi } from '../controller';
+import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
+import type { SettingsV4 } from '../../../core/settings/schema';
+
+const HTML = `
+  <input type="number" id="${FIELD_IDS.wpm}" />
+  <select id="${FIELD_IDS.theme}">
+    <option value="system"></option>
+    <option value="light"></option>
+    <option value="dark"></option>
+    <option value="sepia"></option>
+    <option value="paper"></option>
+    <option value="cream"></option>
+    <option value="nord"></option>
+  </select>
+  <input type="text" id="${FIELD_IDS.font}" />
+  <input type="number" id="${FIELD_IDS.fontSize}" />
+  <select id="${FIELD_IDS.alignment}">
+    <option value="orp"></option>
+    <option value="center"></option>
+  </select>
+  <input type="checkbox" id="${FIELD_IDS.openDyslexic}" />
+  <input type="checkbox" id="${FIELD_IDS.punctuationPacing}" />
+  <input type="checkbox" id="${FIELD_IDS.contextLine}" />
+  <input type="checkbox" id="${FIELD_IDS.startFromWordOne}" />
+  <div id="saved"></div>
+`;
+
+interface Stub extends SettingsApi {
+  loadMock: ReturnType<typeof vi.fn>;
+  saveMock: ReturnType<typeof vi.fn>;
+  flushMock: ReturnType<typeof vi.fn>;
+  subscribeMock: ReturnType<typeof vi.fn>;
+  emit(s: SettingsV4): void;
+}
+
+function makeStub(initial: SettingsV4 = DEFAULT_SETTINGS): Stub {
+  let listener: ((s: SettingsV4) => void) | null = null;
+  const loadMock = vi.fn(async () => initial);
+  const saveMock = vi.fn(async () => undefined);
+  const flushMock = vi.fn(async () => undefined);
+  const subscribeMock = vi.fn((cb: (s: SettingsV4) => void) => {
+    listener = cb;
+    return () => {
+      listener = null;
+    };
+  });
+  return {
+    load: loadMock,
+    save: saveMock,
+    flush: flushMock,
+    subscribe: subscribeMock,
+    loadMock,
+    saveMock,
+    flushMock,
+    subscribeMock,
+    emit(s) {
+      listener?.(s);
+    },
+  };
+}
+
+function setBody(html: string): void {
+  document.body.innerHTML = html;
+}
+
+function fire(el: HTMLElement, type: string): void {
+  el.dispatchEvent(new Event(type, { bubbles: true }));
+}
+
+describe('options controller', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setBody(HTML);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('populates every editable field from loaded settings', async () => {
+    const stub = makeStub({
+      ...DEFAULT_SETTINGS,
+      wpm: 350,
+      theme: 'nord',
+      font: 'Georgia',
+      fontSize: 22,
+      openDyslexic: true,
+      punctuationPacing: false,
+      alignment: 'center',
+      contextLine: true,
+      startFromWordOne: true,
+    });
+    await bindOptionsForm(document, window, stub);
+
+    expect((document.getElementById(FIELD_IDS.wpm) as HTMLInputElement).value).toBe('350');
+    expect((document.getElementById(FIELD_IDS.theme) as HTMLSelectElement).value).toBe('nord');
+    expect((document.getElementById(FIELD_IDS.font) as HTMLInputElement).value).toBe('Georgia');
+    expect((document.getElementById(FIELD_IDS.fontSize) as HTMLInputElement).value).toBe('22');
+    expect((document.getElementById(FIELD_IDS.alignment) as HTMLSelectElement).value).toBe(
+      'center',
+    );
+    expect((document.getElementById(FIELD_IDS.openDyslexic) as HTMLInputElement).checked).toBe(
+      true,
+    );
+    expect((document.getElementById(FIELD_IDS.punctuationPacing) as HTMLInputElement).checked).toBe(
+      false,
+    );
+    expect((document.getElementById(FIELD_IDS.contextLine) as HTMLInputElement).checked).toBe(true);
+    expect((document.getElementById(FIELD_IDS.startFromWordOne) as HTMLInputElement).checked).toBe(
+      true,
+    );
+  });
+
+  it('falls back to defaults when load rejects', async () => {
+    const stub = makeStub();
+    stub.loadMock.mockRejectedValueOnce(new Error('boom'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await bindOptionsForm(document, window, stub);
+    expect((document.getElementById(FIELD_IDS.wpm) as HTMLInputElement).value).toBe(
+      String(DEFAULT_SETTINGS.wpm),
+    );
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('saves partial update on number change', async () => {
+    const stub = makeStub();
+    await bindOptionsForm(document, window, stub);
+    const wpm = document.getElementById(FIELD_IDS.wpm) as HTMLInputElement;
+    wpm.value = '400';
+    fire(wpm, 'change');
+    // Save call is sync-dispatched; resolution is microtask.
+    await Promise.resolve();
+    expect(stub.saveMock).toHaveBeenCalledWith({ wpm: 400 });
+  });
+
+  it('saves partial update on checkbox toggle', async () => {
+    const stub = makeStub();
+    await bindOptionsForm(document, window, stub);
+    const cb = document.getElementById(FIELD_IDS.openDyslexic) as HTMLInputElement;
+    cb.checked = true;
+    fire(cb, 'change');
+    await Promise.resolve();
+    expect(stub.saveMock).toHaveBeenCalledWith({ openDyslexic: true });
+  });
+
+  it('saves partial update on select change', async () => {
+    const stub = makeStub();
+    await bindOptionsForm(document, window, stub);
+    const theme = document.getElementById(FIELD_IDS.theme) as HTMLSelectElement;
+    theme.value = 'sepia';
+    fire(theme, 'change');
+    await Promise.resolve();
+    expect(stub.saveMock).toHaveBeenCalledWith({ theme: 'sepia' });
+  });
+
+  it('does NOT save when number input is NaN', async () => {
+    const stub = makeStub();
+    await bindOptionsForm(document, window, stub);
+    const wpm = document.getElementById(FIELD_IDS.wpm) as HTMLInputElement;
+    wpm.value = '';
+    fire(wpm, 'change');
+    await Promise.resolve();
+    expect(stub.saveMock).not.toHaveBeenCalled();
+  });
+
+  it('repopulates from subscribe callback on external change', async () => {
+    const stub = makeStub();
+    await bindOptionsForm(document, window, stub);
+    stub.emit({ ...DEFAULT_SETTINGS, wpm: 500, theme: 'dark' });
+    expect((document.getElementById(FIELD_IDS.wpm) as HTMLInputElement).value).toBe('500');
+    expect((document.getElementById(FIELD_IDS.theme) as HTMLSelectElement).value).toBe('dark');
+  });
+
+  it('flushes pending saves when document becomes hidden', async () => {
+    const stub = makeStub();
+    await bindOptionsForm(document, window, stub);
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      configurable: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(stub.flushMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT flush when document is still visible', async () => {
+    const stub = makeStub();
+    await bindOptionsForm(document, window, stub);
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(stub.flushMock).not.toHaveBeenCalled();
+  });
+
+  it('shows the saved indicator briefly after save resolves', async () => {
+    const stub = makeStub();
+    await bindOptionsForm(document, window, stub);
+    const wpm = document.getElementById(FIELD_IDS.wpm) as HTMLInputElement;
+    wpm.value = '300';
+    fire(wpm, 'change');
+    // Await the save mock's returned promise + one extra microtask turn so the
+    // `.then(() => showSaved)` chain runs before assertions.
+    const saveResult = stub.saveMock.mock.results[0]?.value as Promise<void>;
+    await saveResult;
+    await Promise.resolve();
+    expect(document.getElementById('saved')?.classList.contains('visible')).toBe(true);
+    vi.advanceTimersByTime(1600);
+    expect(document.getElementById('saved')?.classList.contains('visible')).toBe(false);
+  });
+
+  it('teardown removes change listeners and unsubscribes', async () => {
+    const stub = makeStub();
+    const teardown = await bindOptionsForm(document, window, stub);
+    teardown();
+    const wpm = document.getElementById(FIELD_IDS.wpm) as HTMLInputElement;
+    wpm.value = '450';
+    fire(wpm, 'change');
+    await Promise.resolve();
+    expect(stub.saveMock).not.toHaveBeenCalled();
+    // Emitting a subscribe update after teardown must be a no-op (listener cleared).
+    stub.emit({ ...DEFAULT_SETTINGS, wpm: 600 });
+    expect((document.getElementById(FIELD_IDS.wpm) as HTMLInputElement).value).toBe('450');
+  });
+});

--- a/src/chrome/options/controller.ts
+++ b/src/chrome/options/controller.ts
@@ -1,11 +1,6 @@
 import type { SettingsV4 } from '../../core/settings/schema';
 import { DEFAULT_SETTINGS } from '../../core/settings/defaults';
 
-/**
- * Settings surface the controller depends on. Mirrors the chrome storage
- * adapter (`src/chrome/settings/storage.ts`) but typed as an interface so the
- * options page can be unit-tested with a stub.
- */
 export interface SettingsApi {
   load(): Promise<SettingsV4>;
   save(partial: Partial<Omit<SettingsV4, 'version' | 'lastUsedWpm'>>): Promise<void>;
@@ -31,9 +26,25 @@ export const FIELD_IDS = {
 } as const;
 
 const SAVED_INDICATOR_ID = 'saved';
+const SAVE_ERROR_ID = 'save-error';
+const LOAD_ERROR_BANNER_ID = 'load-error-banner';
 const SAVED_INDICATOR_MS = 1500;
+const SAVE_ERROR_MS = 4000;
 
 type EditableField = keyof typeof FIELD_IDS;
+type EditableValue<K extends EditableField> = SettingsV4[K];
+type EditablePatch = Partial<Omit<SettingsV4, 'version' | 'lastUsedWpm'>>;
+
+const THEME_VALUES = ['system', 'light', 'dark', 'sepia', 'paper', 'cream', 'nord'] as const;
+const ALIGNMENT_VALUES = ['orp', 'center'] as const;
+
+// Schema range constants kept in lockstep with `SettingsSchemaV4` in
+// `src/core/settings/schema.ts`. Widening the schema requires widening here.
+const WPM_MIN = 100;
+const WPM_MAX = 600;
+const WPM_STEP = 10;
+const FONT_SIZE_MIN = 12;
+const FONT_SIZE_MAX = 48;
 
 function getInput(doc: Document, id: string): HTMLInputElement | HTMLSelectElement | null {
   const el = doc.getElementById(id);
@@ -70,105 +81,180 @@ function populate(doc: Document, s: SettingsV4): void {
   if (startOne instanceof HTMLInputElement) startOne.checked = s.startFromWordOne;
 }
 
-function showSaved(doc: Document, win: Window): void {
-  const el = doc.getElementById(SAVED_INDICATOR_ID);
+function flashIndicator(doc: Document, win: Window, id: string, ms: number): void {
+  const el = doc.getElementById(id);
   if (!el) return;
   el.classList.add('visible');
-  win.setTimeout(() => el.classList.remove('visible'), SAVED_INDICATOR_MS);
+  win.setTimeout(() => el.classList.remove('visible'), ms);
 }
 
-interface FieldReader {
-  read(el: HTMLInputElement | HTMLSelectElement): SettingsV4[EditableField] | null;
+function showLoadErrorBanner(doc: Document): void {
+  const el = doc.getElementById(LOAD_ERROR_BANNER_ID);
+  if (!el) return;
+  el.classList.add('visible');
 }
 
-function readNumberOrNull(el: HTMLInputElement | HTMLSelectElement): number | null {
+/**
+ * Per-field reader. `K` ties the element-read result to the exact
+ * `SettingsV4[K]` slot so `theme`-shaped readers can't accidentally return
+ * a number. Each reader returns `null` to reject invalid input — the binder
+ * suppresses save on null, leaving the stored value untouched.
+ */
+type Reader<K extends EditableField> = (
+  el: HTMLInputElement | HTMLSelectElement,
+) => EditableValue<K> | null;
+
+function readWpm(el: HTMLInputElement | HTMLSelectElement): number | null {
   if (el.value.trim() === '') return null;
   const n = Number(el.value);
-  return Number.isFinite(n) ? n : null;
+  if (!Number.isInteger(n)) return null;
+  if (n < WPM_MIN || n > WPM_MAX) return null;
+  if (n % WPM_STEP !== 0) return null;
+  return n;
 }
 
-const FIELD_READERS: Record<EditableField, FieldReader> = {
-  wpm: { read: readNumberOrNull },
-  theme: {
-    read: (el) => {
-      const v = el.value as SettingsV4['theme'];
-      return v;
-    },
-  },
-  font: { read: (el) => el.value },
-  fontSize: { read: readNumberOrNull },
-  openDyslexic: {
-    read: (el) => (el instanceof HTMLInputElement ? el.checked : null),
-  },
-  punctuationPacing: {
-    read: (el) => (el instanceof HTMLInputElement ? el.checked : null),
-  },
-  alignment: {
-    read: (el) => {
-      const v = el.value as SettingsV4['alignment'];
-      return v;
-    },
-  },
-  contextLine: {
-    read: (el) => (el instanceof HTMLInputElement ? el.checked : null),
-  },
-  startFromWordOne: {
-    read: (el) => (el instanceof HTMLInputElement ? el.checked : null),
-  },
+function readFontSize(el: HTMLInputElement | HTMLSelectElement): number | null {
+  if (el.value.trim() === '') return null;
+  const n = Number(el.value);
+  if (!Number.isInteger(n)) return null;
+  if (n < FONT_SIZE_MIN || n > FONT_SIZE_MAX) return null;
+  return n;
+}
+
+function readFont(el: HTMLInputElement | HTMLSelectElement): string | null {
+  // Schema accepts any string; empty is legal but useless. Reject to avoid
+  // an accidental empty-string clobber of the stored value.
+  const v = el.value;
+  if (v.trim() === '') return null;
+  return v;
+}
+
+function readTheme(el: HTMLInputElement | HTMLSelectElement): SettingsV4['theme'] | null {
+  const v = el.value as SettingsV4['theme'];
+  return (THEME_VALUES as readonly string[]).includes(v) ? v : null;
+}
+
+function readAlignment(el: HTMLInputElement | HTMLSelectElement): SettingsV4['alignment'] | null {
+  const v = el.value as SettingsV4['alignment'];
+  return (ALIGNMENT_VALUES as readonly string[]).includes(v) ? v : null;
+}
+
+function readCheckbox(el: HTMLInputElement | HTMLSelectElement): boolean | null {
+  return el instanceof HTMLInputElement ? el.checked : null;
+}
+
+const FIELD_READERS: { [K in EditableField]: Reader<K> } = {
+  wpm: readWpm,
+  theme: readTheme,
+  font: readFont,
+  fontSize: readFontSize,
+  openDyslexic: readCheckbox,
+  punctuationPacing: readCheckbox,
+  alignment: readAlignment,
+  contextLine: readCheckbox,
+  startFromWordOne: readCheckbox,
 };
+
+function bindField<K extends EditableField>(
+  doc: Document,
+  win: Window,
+  field: K,
+  el: HTMLInputElement | HTMLSelectElement,
+  api: SettingsApi,
+  isSavingAllowed: () => boolean,
+): { el: Element; type: string; handler: EventListener } {
+  const reader: Reader<K> = FIELD_READERS[field];
+  const handler: EventListener = () => {
+    if (!isSavingAllowed()) return;
+    const value = reader(el);
+    if (value === null) return;
+    const patch = { [field]: value } as EditablePatch;
+    api.save(patch).then(
+      () => flashIndicator(doc, win, SAVED_INDICATOR_ID, SAVED_INDICATOR_MS),
+      (err) => {
+        console.error('[speedreader] options: save failed', err);
+        flashIndicator(doc, win, SAVE_ERROR_ID, SAVE_ERROR_MS);
+      },
+    );
+  };
+  el.addEventListener('change', handler);
+  return { el, type: 'change', handler };
+}
 
 /**
  * Bind the options-page form to the settings API.
  *
- * Load → populate → wire change handlers → subscribe.
+ * Load → populate → wire change handlers → subscribe → wire flush triggers.
  *
- * Returns a teardown function (unsubscribe + remove listeners) for tests
- * and future hot-reload scenarios.
+ * On `api.load()` rejection the binder enters degraded mode: defaults are
+ * shown for orientation, but change handlers suppress saves so a transient
+ * sync error cannot overwrite the user's stored values with defaults. A
+ * persistent banner (`#load-error-banner`) communicates the state.
+ *
+ * Returns a teardown function (unsubscribe + remove listeners) used by tests.
  */
 export async function bindOptionsForm(
   doc: Document,
   win: Window,
   api: SettingsApi,
 ): Promise<() => void> {
-  const initial = await api.load().catch((err) => {
-    console.warn('[speedreader] options: load failed, using defaults', err);
-    return { ...DEFAULT_SETTINGS };
-  });
+  let degraded = false;
+  let initial: SettingsV4;
+  try {
+    initial = await api.load();
+  } catch (err) {
+    degraded = true;
+    initial = { ...DEFAULT_SETTINGS };
+    console.error('[speedreader] options: load failed, entering degraded mode', err);
+    showLoadErrorBanner(doc);
+  }
   populate(doc, initial);
+
+  // Surface HTML drift early: if any FIELD_IDS entry has no DOM element, the
+  // corresponding setting becomes silently unreachable. Console error is the
+  // best we can do without raising in user-facing code.
+  const missing = (Object.keys(FIELD_IDS) as EditableField[]).filter(
+    (f) => getInput(doc, FIELD_IDS[f]) === null,
+  );
+  if (missing.length > 0) {
+    console.error('[speedreader] options: HTML missing field elements:', missing);
+  }
 
   const listeners: Array<{ el: Element; type: string; handler: EventListener }> = [];
   const fields = Object.keys(FIELD_IDS) as EditableField[];
+  const isSavingAllowed = (): boolean => !degraded;
 
   for (const field of fields) {
     const el = getInput(doc, FIELD_IDS[field]);
     if (!el) continue;
-    const handler = (): void => {
-      const reader = FIELD_READERS[field];
-      const value = reader.read(el);
-      if (value === null) return;
-      api
-        .save({ [field]: value } as Partial<SettingsV4>)
-        .then(() => showSaved(doc, win))
-        .catch((err) => console.warn('[speedreader] options: save failed', err));
-    };
-    el.addEventListener('change', handler);
-    listeners.push({ el, type: 'change', handler });
+    listeners.push(bindField(doc, win, field, el, api, isSavingAllowed));
   }
 
   const unsubscribe = api.subscribe((s) => populate(doc, s));
 
   // Flush pending writes when the page is hidden so a close-before-debounce
-  // does not drop the last change.
-  const visibilityHandler = (): void => {
+  // does not drop the last change. `visibilitychange` covers tab-switch and
+  // most close paths; `pagehide` is the more reliable last-gasp event for
+  // navigations and full-window close that don't always fire visibilitychange.
+  const flushIfHidden = (): void => {
     if (doc.visibilityState === 'hidden') {
-      api.flush().catch(() => undefined);
+      api.flush().catch((err) => {
+        console.error('[speedreader] options: flush failed on visibility-hidden', err);
+      });
     }
   };
-  doc.addEventListener('visibilitychange', visibilityHandler);
+  const flushOnPagehide = (): void => {
+    api.flush().catch((err) => {
+      console.error('[speedreader] options: flush failed on pagehide', err);
+    });
+  };
+  doc.addEventListener('visibilitychange', flushIfHidden);
+  win.addEventListener('pagehide', flushOnPagehide);
 
   return () => {
     listeners.forEach(({ el, type, handler }) => el.removeEventListener(type, handler));
-    doc.removeEventListener('visibilitychange', visibilityHandler);
+    doc.removeEventListener('visibilitychange', flushIfHidden);
+    win.removeEventListener('pagehide', flushOnPagehide);
     unsubscribe();
   };
 }

--- a/src/chrome/options/controller.ts
+++ b/src/chrome/options/controller.ts
@@ -1,0 +1,174 @@
+import type { SettingsV4 } from '../../core/settings/schema';
+import { DEFAULT_SETTINGS } from '../../core/settings/defaults';
+
+/**
+ * Settings surface the controller depends on. Mirrors the chrome storage
+ * adapter (`src/chrome/settings/storage.ts`) but typed as an interface so the
+ * options page can be unit-tested with a stub.
+ */
+export interface SettingsApi {
+  load(): Promise<SettingsV4>;
+  save(partial: Partial<Omit<SettingsV4, 'version' | 'lastUsedWpm'>>): Promise<void>;
+  flush(): Promise<void>;
+  subscribe(listener: (s: SettingsV4) => void): () => void;
+}
+
+/**
+ * IDs the options page HTML form is required to expose. Centralised so the
+ * binder, the HTML, and the tests cannot drift. `lastUsedWpm` is omitted —
+ * it's a context-menu artifact, not user-editable.
+ */
+export const FIELD_IDS = {
+  wpm: 'wpm',
+  theme: 'theme',
+  font: 'font',
+  fontSize: 'fontSize',
+  openDyslexic: 'openDyslexic',
+  punctuationPacing: 'punctuationPacing',
+  alignment: 'alignment',
+  contextLine: 'contextLine',
+  startFromWordOne: 'startFromWordOne',
+} as const;
+
+const SAVED_INDICATOR_ID = 'saved';
+const SAVED_INDICATOR_MS = 1500;
+
+type EditableField = keyof typeof FIELD_IDS;
+
+function getInput(doc: Document, id: string): HTMLInputElement | HTMLSelectElement | null {
+  const el = doc.getElementById(id);
+  if (el instanceof HTMLInputElement || el instanceof HTMLSelectElement) return el;
+  return null;
+}
+
+function populate(doc: Document, s: SettingsV4): void {
+  const wpm = getInput(doc, FIELD_IDS.wpm);
+  if (wpm) wpm.value = String(s.wpm);
+
+  const theme = getInput(doc, FIELD_IDS.theme);
+  if (theme) theme.value = s.theme;
+
+  const font = getInput(doc, FIELD_IDS.font);
+  if (font) font.value = s.font;
+
+  const fontSize = getInput(doc, FIELD_IDS.fontSize);
+  if (fontSize) fontSize.value = String(s.fontSize);
+
+  const openDyslexic = getInput(doc, FIELD_IDS.openDyslexic);
+  if (openDyslexic instanceof HTMLInputElement) openDyslexic.checked = s.openDyslexic;
+
+  const punctuation = getInput(doc, FIELD_IDS.punctuationPacing);
+  if (punctuation instanceof HTMLInputElement) punctuation.checked = s.punctuationPacing;
+
+  const alignment = getInput(doc, FIELD_IDS.alignment);
+  if (alignment) alignment.value = s.alignment;
+
+  const ctxLine = getInput(doc, FIELD_IDS.contextLine);
+  if (ctxLine instanceof HTMLInputElement) ctxLine.checked = s.contextLine;
+
+  const startOne = getInput(doc, FIELD_IDS.startFromWordOne);
+  if (startOne instanceof HTMLInputElement) startOne.checked = s.startFromWordOne;
+}
+
+function showSaved(doc: Document, win: Window): void {
+  const el = doc.getElementById(SAVED_INDICATOR_ID);
+  if (!el) return;
+  el.classList.add('visible');
+  win.setTimeout(() => el.classList.remove('visible'), SAVED_INDICATOR_MS);
+}
+
+interface FieldReader {
+  read(el: HTMLInputElement | HTMLSelectElement): SettingsV4[EditableField] | null;
+}
+
+function readNumberOrNull(el: HTMLInputElement | HTMLSelectElement): number | null {
+  if (el.value.trim() === '') return null;
+  const n = Number(el.value);
+  return Number.isFinite(n) ? n : null;
+}
+
+const FIELD_READERS: Record<EditableField, FieldReader> = {
+  wpm: { read: readNumberOrNull },
+  theme: {
+    read: (el) => {
+      const v = el.value as SettingsV4['theme'];
+      return v;
+    },
+  },
+  font: { read: (el) => el.value },
+  fontSize: { read: readNumberOrNull },
+  openDyslexic: {
+    read: (el) => (el instanceof HTMLInputElement ? el.checked : null),
+  },
+  punctuationPacing: {
+    read: (el) => (el instanceof HTMLInputElement ? el.checked : null),
+  },
+  alignment: {
+    read: (el) => {
+      const v = el.value as SettingsV4['alignment'];
+      return v;
+    },
+  },
+  contextLine: {
+    read: (el) => (el instanceof HTMLInputElement ? el.checked : null),
+  },
+  startFromWordOne: {
+    read: (el) => (el instanceof HTMLInputElement ? el.checked : null),
+  },
+};
+
+/**
+ * Bind the options-page form to the settings API.
+ *
+ * Load → populate → wire change handlers → subscribe.
+ *
+ * Returns a teardown function (unsubscribe + remove listeners) for tests
+ * and future hot-reload scenarios.
+ */
+export async function bindOptionsForm(
+  doc: Document,
+  win: Window,
+  api: SettingsApi,
+): Promise<() => void> {
+  const initial = await api.load().catch((err) => {
+    console.warn('[speedreader] options: load failed, using defaults', err);
+    return { ...DEFAULT_SETTINGS };
+  });
+  populate(doc, initial);
+
+  const listeners: Array<{ el: Element; type: string; handler: EventListener }> = [];
+  const fields = Object.keys(FIELD_IDS) as EditableField[];
+
+  for (const field of fields) {
+    const el = getInput(doc, FIELD_IDS[field]);
+    if (!el) continue;
+    const handler = (): void => {
+      const reader = FIELD_READERS[field];
+      const value = reader.read(el);
+      if (value === null) return;
+      api
+        .save({ [field]: value } as Partial<SettingsV4>)
+        .then(() => showSaved(doc, win))
+        .catch((err) => console.warn('[speedreader] options: save failed', err));
+    };
+    el.addEventListener('change', handler);
+    listeners.push({ el, type: 'change', handler });
+  }
+
+  const unsubscribe = api.subscribe((s) => populate(doc, s));
+
+  // Flush pending writes when the page is hidden so a close-before-debounce
+  // does not drop the last change.
+  const visibilityHandler = (): void => {
+    if (doc.visibilityState === 'hidden') {
+      api.flush().catch(() => undefined);
+    }
+  };
+  doc.addEventListener('visibilitychange', visibilityHandler);
+
+  return () => {
+    listeners.forEach(({ el, type, handler }) => el.removeEventListener(type, handler));
+    doc.removeEventListener('visibilitychange', visibilityHandler);
+    unsubscribe();
+  };
+}

--- a/src/chrome/options/index.html
+++ b/src/chrome/options/index.html
@@ -40,11 +40,10 @@
         font-size: 14px;
         padding: 6px 8px;
       }
-      .saved {
+      .toast {
         position: fixed;
         bottom: 16px;
         right: 16px;
-        background: #2a9d3a;
         color: white;
         padding: 6px 12px;
         border-radius: 4px;
@@ -53,11 +52,31 @@
         transition: opacity 200ms ease;
         pointer-events: none;
       }
-      .saved.visible {
+      .toast.visible {
         opacity: 1;
       }
+      .toast.saved {
+        background: #2a9d3a;
+      }
+      .toast.error {
+        background: #c0392b;
+        bottom: 56px;
+      }
+      .load-error-banner {
+        display: none;
+        background: #c0392b;
+        color: white;
+        padding: 10px 14px;
+        border-radius: 4px;
+        margin-bottom: 16px;
+        font-size: 13px;
+        line-height: 1.4;
+      }
+      .load-error-banner.visible {
+        display: block;
+      }
       @media (prefers-reduced-motion: reduce) {
-        .saved {
+        .toast {
           transition: none;
         }
       }
@@ -65,6 +84,16 @@
   </head>
   <body>
     <h1>SpeedReader Options</h1>
+
+    <div
+      class="load-error-banner"
+      id="load-error-banner"
+      role="alert"
+      aria-live="assertive"
+    >
+      Couldn't load your saved settings. Editing is disabled to avoid overwriting
+      stored values. Reload the page to retry.
+    </div>
 
     <div class="field">
       <label for="wpm">Words per minute (100–600, step 10)</label>
@@ -122,7 +151,10 @@
       <label for="startFromWordOne">Always start from word one</label>
     </div>
 
-    <div class="saved" id="saved" role="status" aria-live="polite">Saved</div>
+    <div class="toast saved" id="saved" role="status" aria-live="polite">Saved</div>
+    <div class="toast error" id="save-error" role="alert" aria-live="assertive">
+      Save failed. Your last change was not stored.
+    </div>
 
     <script type="module" src="./index.ts"></script>
   </body>

--- a/src/chrome/options/index.html
+++ b/src/chrome/options/index.html
@@ -1,80 +1,129 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>SpeedReader Options</title>
-  <style>
-    body {
-      width: 600px;
-      padding: 24px;
-      font-family: system-ui, -apple-system, sans-serif;
-      margin: 0;
-    }
-    h1 {
-      font-size: 20px;
-      margin: 0 0 16px 0;
-    }
-    .field {
-      margin-bottom: 16px;
-    }
-    label {
-      display: block;
-      font-size: 13px;
-      font-weight: 600;
-      margin-bottom: 4px;
-    }
-    input, select {
-      font-size: 14px;
-      padding: 6px 8px;
-      width: 100%;
-      box-sizing: border-box;
-    }
-    .saved {
-      font-size: 12px;
-      color: #2a9d3a;
-      margin-top: 8px;
-      display: none;
-    }
-  </style>
-</head>
-<body>
-  <h1>SpeedReader Options</h1>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SpeedReader Options</title>
+    <style>
+      body {
+        max-width: 640px;
+        margin: 0 auto;
+        padding: 24px;
+        font-family: system-ui, -apple-system, sans-serif;
+        color-scheme: light dark;
+      }
+      h1 {
+        font-size: 20px;
+        margin: 0 0 24px 0;
+      }
+      .field {
+        margin-bottom: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .field.inline {
+        flex-direction: row;
+        align-items: center;
+        gap: 8px;
+      }
+      label {
+        font-size: 13px;
+        font-weight: 600;
+      }
+      .field.inline label {
+        font-weight: 400;
+      }
+      input[type='number'],
+      input[type='text'],
+      select {
+        font-size: 14px;
+        padding: 6px 8px;
+      }
+      .saved {
+        position: fixed;
+        bottom: 16px;
+        right: 16px;
+        background: #2a9d3a;
+        color: white;
+        padding: 6px 12px;
+        border-radius: 4px;
+        font-size: 13px;
+        opacity: 0;
+        transition: opacity 200ms ease;
+        pointer-events: none;
+      }
+      .saved.visible {
+        opacity: 1;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .saved {
+          transition: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>SpeedReader Options</h1>
 
-  <div class="field">
-    <label for="wpm">Words per minute</label>
-    <input type="number" id="wpm" min="60" max="1500" value="300" />
-  </div>
+    <div class="field">
+      <label for="wpm">Words per minute (100–600, step 10)</label>
+      <input type="number" id="wpm" min="100" max="600" step="10" />
+    </div>
 
-  <div class="field">
-    <label for="fontSize">Font size</label>
-    <select id="fontSize">
-      <option value="12">Small</option>
-      <option value="16" selected>Medium</option>
-      <option value="20">Large</option>
-      <option value="24">X-Large</option>
-    </select>
-  </div>
+    <div class="field">
+      <label for="theme">Theme</label>
+      <select id="theme">
+        <option value="system">System</option>
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+        <option value="sepia">Sepia</option>
+        <option value="paper">Paper</option>
+        <option value="cream">Cream</option>
+        <option value="nord">Nord</option>
+      </select>
+    </div>
 
-  <div class="field">
-    <label for="theme">Theme</label>
-    <select id="theme">
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-      <option value="sepia">Sepia</option>
-    </select>
-  </div>
+    <div class="field">
+      <label for="font">Font family</label>
+      <input type="text" id="font" />
+    </div>
 
-  <div class="field">
-    <label for="fontFamily">Font</label>
-    <select id="fontFamily">
-      <option value="system">System Default</option>
-      <option value="open-dyslexic">OpenDyslexic</option>
-    </select>
-  </div>
+    <div class="field">
+      <label for="fontSize">Font size (12–48 px)</label>
+      <input type="number" id="fontSize" min="12" max="48" step="1" />
+    </div>
 
-  <div class="saved" id="saved">Settings saved!</div>
+    <div class="field">
+      <label for="alignment">Word alignment</label>
+      <select id="alignment">
+        <option value="orp">Optimal Recognition Point</option>
+        <option value="center">Centered</option>
+      </select>
+    </div>
 
-  <script type="module" src="./index.ts"></script>
-</body>
+    <div class="field inline">
+      <input type="checkbox" id="openDyslexic" />
+      <label for="openDyslexic">Use OpenDyslexic font</label>
+    </div>
+
+    <div class="field inline">
+      <input type="checkbox" id="punctuationPacing" />
+      <label for="punctuationPacing">Slow down at punctuation</label>
+    </div>
+
+    <div class="field inline">
+      <input type="checkbox" id="contextLine" />
+      <label for="contextLine">Show line of context around current word</label>
+    </div>
+
+    <div class="field inline">
+      <input type="checkbox" id="startFromWordOne" />
+      <label for="startFromWordOne">Always start from word one</label>
+    </div>
+
+    <div class="saved" id="saved" role="status" aria-live="polite">Saved</div>
+
+    <script type="module" src="./index.ts"></script>
+  </body>
 </html>

--- a/src/chrome/options/index.ts
+++ b/src/chrome/options/index.ts
@@ -1,16 +1,17 @@
 /**
- * SpeedReader — Options Page Script
+ * SpeedReader — Options Page Entry
  *
- * Entry point for the options page.  Handles saving/loading user preferences
- * via chrome.storage.sync.
+ * Thin DOM bind. All logic lives in `controller.ts` so it can be unit-tested
+ * against a stub SettingsApi.
  */
-
-// TODO(#5): Implement options logic
-// - Load saved settings on page load
-// - Save settings when user clicks "Save"
-// - Persist: wpm, fontSize, theme, fontFamily
+import { bindOptionsForm } from './controller';
+import { loadSettings, saveSettings, flushSettings, subscribeSettings } from '../settings/storage';
 
 document.addEventListener('DOMContentLoaded', () => {
-  // Stub: load settings from storage
-  console.log('[SpeedReader] Options page loaded');
+  void bindOptionsForm(document, window, {
+    load: loadSettings,
+    save: saveSettings,
+    flush: flushSettings,
+    subscribe: subscribeSettings,
+  });
 });

--- a/tests/e2e/options.spec.ts
+++ b/tests/e2e/options.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * options.spec.ts — options page renders and persists settings (#31).
+ *
+ * Loads the unpacked extension, opens `chrome-extension://<id>/.../options/index.html`,
+ * changes WPM + theme via the rendered form, reopens the page, and asserts
+ * the values survived `chrome.storage.sync`.
+ *
+ * Constraint: relies on the V4 settings storage layer
+ * (`src/chrome/settings/storage.ts`), which round-trips through
+ * `chrome.storage.sync`. Persistence is observable across same-extension
+ * tab reloads inside the persistent context.
+ */
+import { test, expect } from '@playwright/test';
+import {
+  launchExtensionContext,
+  closeExtensionContext,
+  type ExtensionHandle,
+} from './fixtures/extension';
+
+let handle: ExtensionHandle | undefined;
+
+test.beforeAll(async () => {
+  handle = await launchExtensionContext();
+});
+
+test.afterAll(async () => {
+  await closeExtensionContext(handle);
+  handle = undefined;
+});
+
+test('options page renders V4 form surface', async () => {
+  if (!handle) throw new Error('extension context not initialized');
+  const url = `chrome-extension://${handle.extensionId}/src/chrome/options/index.html`;
+  const page = await handle.context.newPage();
+  await page.goto(url);
+
+  await expect(page.locator('h1')).toHaveText('SpeedReader Options');
+  // Every V4 editable field is present.
+  for (const id of [
+    'wpm',
+    'theme',
+    'font',
+    'fontSize',
+    'alignment',
+    'openDyslexic',
+    'punctuationPacing',
+    'contextLine',
+    'startFromWordOne',
+  ]) {
+    await expect(page.locator(`#${id}`)).toBeVisible();
+  }
+  // Theme select exposes the V4 7-value enum.
+  const themeValues = await page.locator('#theme option').evaluateAll((opts) =>
+    opts.map((o) => (o as HTMLOptionElement).value),
+  );
+  expect(themeValues).toEqual(['system', 'light', 'dark', 'sepia', 'paper', 'cream', 'nord']);
+
+  await page.close();
+});
+
+test('options page persists WPM + theme across reload', async () => {
+  if (!handle) throw new Error('extension context not initialized');
+  const url = `chrome-extension://${handle.extensionId}/src/chrome/options/index.html`;
+
+  const page = await handle.context.newPage();
+  await page.goto(url);
+  // Wait for initial populate (loadSettings + populate runs on DOMContentLoaded).
+  await expect(page.locator('#wpm')).not.toHaveValue('');
+
+  await page.locator('#wpm').fill('420');
+  await page.locator('#wpm').dispatchEvent('change');
+  await page.locator('#theme').selectOption('nord');
+
+  // Visibility-hidden flushes the 300ms debounce window deterministically.
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      configurable: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+  // Small grace for the flush's awaited set() to resolve.
+  await page.waitForTimeout(200);
+  await page.close();
+
+  const page2 = await handle.context.newPage();
+  await page2.goto(url);
+  await expect(page2.locator('#wpm')).toHaveValue('420');
+  await expect(page2.locator('#theme')).toHaveValue('nord');
+  await page2.close();
+});

--- a/tests/e2e/options.spec.ts
+++ b/tests/e2e/options.spec.ts
@@ -71,7 +71,9 @@ test('options page persists WPM + theme across reload', async () => {
   await page.locator('#wpm').dispatchEvent('change');
   await page.locator('#theme').selectOption('nord');
 
-  // Visibility-hidden flushes the 300ms debounce window deterministically.
+  // Visibility-hidden triggers `flushSettings()`, which cancels the 300ms
+  // debounce timer and forces an immediate `chrome.storage.sync.set()` —
+  // bypasses the debounce window rather than waiting it out.
   await page.evaluate(() => {
     Object.defineProperty(document, 'visibilityState', {
       value: 'hidden',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
       'src/chrome/background/messaging/**/__tests__/**/*.test.ts',
       'src/chrome/background/state/**/__tests__/**/*.test.ts',
       'src/chrome/content/**/__tests__/**/*.test.ts',
+      'src/chrome/options/**/__tests__/**/*.test.ts',
     ],
     exclude: ['node_modules/**', 'dist/**'],
   },


### PR DESCRIPTION
## Summary

Replaces the stub options page with a working settings UI bound to the existing chrome.storage.sync layer. Closes #31.

V4 form surface (all editable fields exposed):
- wpm (100–600 step 10), theme (system/light/dark/sepia/paper/cream/nord), font, fontSize (12–48), alignment (orp/center)
- openDyslexic, punctuationPacing, contextLine, startFromWordOne

`lastUsedWpm` intentionally omitted — managed by the context-menu listener, not user-editable.

## Implementation

- `src/chrome/options/controller.ts` — testable `bindOptionsForm(doc, win, api)`: loads → populates → wires change handlers → subscribes → flushes pending writes on `visibilitychange=hidden` so a close-before-debounce-window cannot drop the last change.
- `src/chrome/options/index.html` — V4 surface; `#saved` indicator uses `role=status`+`aria-live=polite` for screen-reader announcement, transitions disabled under `prefers-reduced-motion: reduce`.
- `src/chrome/options/index.ts` — thin DOM bind, invokes controller on `DOMContentLoaded` with the real storage adapter.
- `src/chrome/options/__tests__/controller.test.ts` — 11 unit tests against a `SettingsApi` stub.
- `tests/e2e/options.spec.ts` — Playwright smoke: V4 surface renders + WPM/theme persist across reload through real `chrome.storage.sync`.
- `vitest.config.ts` — extend narrow inclusion to `src/chrome/options/**`.

## Related

- #32 closed separately — schema + migration strategy already landed across #101, #72-series, and #121.
- Subscribes to `chrome.storage.onChanged` so context-menu changes to `contextLine`/`startFromWordOne` reflect live in an open options tab.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` (tsc + vite) succeeds; `dist/src/chrome/options/index.html` emits at 3.64kB
- [x] `npm test` — 620/620 pass (42 files)
- [x] `npm run format:check` clean
- [x] `npx playwright test tests/e2e/options.spec.ts` — 2/2 pass; persistence across reload verified via real chrome.storage.sync
- [ ] Manual smoke: load unpacked dist/, open options, change each field, reload page, values persist — **agent cannot verify on host** (no user-gesture / visual-inspection capability); covered functionally by `tests/e2e/options.spec.ts` real-Chrome persistence assertion. Reviewer to confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


