### PR TITLE
chore: ignore .worktrees and Ruflo RVF vector containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Dependencies
 node_modules/
 
+# Parallel-builder worktrees (sandbox requires in-repo path; see CLAUDE.md swarm config)
+.worktrees/
+
 # Build output
 dist/
 dist-e2e/
@@ -74,6 +77,10 @@ experiments/**/.claude/
 ruvector.db
 .harness-mem/
 .ring-output/
+
+# Ruflo AgentDB / RVF vector containers (regenerable cache; never tracked)
+*.rvf
+*.rvf.lock
 
 # Coverage / profiling
 default.profraw


### PR DESCRIPTION
## Summary

- Add `.worktrees/` ignore (parallel-builder subagent sandbox; in-repo path required per CLAUDE.md swarm config)
- Add `*.rvf` / `*.rvf.lock` ignore (Ruflo AgentDB vector containers; regenerable cache — must never be tracked)

## Why

Architect review of Ruflo configuration flagged `agentdb.rvf` and `agentdb.rvf.lock` as untracked at repo root with no matching gitignore pattern. Risk: accidental commit of machine-local vector DB state, or data exposure. `.worktrees/` ignore was already on disk locally but never staged — bundled here for hygiene.

## Test plan

- [x] `git check-ignore -v agentdb.rvf agentdb.rvf.lock` confirms both match
- [x] `git status` shows clean working tree after edit (RVF files no longer appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
