### PR TITLE
docs(claude-md): clarify agent dispatch as subset profile (closes #156)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ For a fuller repo-layout reference (every directory and its role), see [`STRUCTU
 
 ## Agent routing (for Claude / swarm dispatch)
 
-Hierarchical swarm, max 6, specialized strategy. Queen: `extension-architect`.
+For routine extension work, prefer hierarchical dispatch, ~6 agents, Queen: `extension-architect`. Full daemon envelope (hierarchical-mesh, max 15, consensus) lives in [`.claude-flow/config.yaml`](docs/ruflo-setup.md#runtime-topology-claude-flowconfigyaml).
 
 | Task | Specialist |
 |---|---|


### PR DESCRIPTION
## Summary

Reconcile apparent contradiction between `CLAUDE.md` and `.claude-flow/config.yaml` flagged by architect review.

Before:
> Hierarchical swarm, max 6, specialized strategy. Queen: `extension-architect`.

After:
> For routine extension work, prefer hierarchical dispatch, ~6 agents, Queen: `extension-architect`. Full daemon envelope (hierarchical-mesh, max 15, consensus) lives in [`.claude-flow/config.yaml`](docs/ruflo-setup.md#runtime-topology-claude-flowconfigyaml).

`config.yaml` ships hierarchical-mesh / max 15 / consensus. The two are not in conflict — `CLAUDE.md` describes the project-side preference for routine extension tasks; `config.yaml` is the daemon ceiling. New phrasing makes the subset relationship explicit and links to `docs/ruflo-setup.md` for the full picture.

User-selected option A from issue #156.

Closes #156.

## Test plan

- [x] `git diff` shows single-line replacement (no scope creep)
- [x] `scripts/verify-ring-config.sh` exits 0 (no regression)
- [x] Anchor link `docs/ruflo-setup.md#runtime-topology-claude-flowconfigyaml` resolves to existing header in PR #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
