### PR TITLE
feat(rsvp): punctuation pacing per Safari parity (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ heading and a fresh `[Unreleased]` block is opened above it.
 ### Added
 
 - `CHANGELOG.md` seeded with keep-a-changelog scaffolding (#42).
+- Punctuation-aware RSVP pacing (Safari parity) — words ending in `.!?`
+  pause 1.5× the base delay, `,;:` pause 1.2×, gated via the existing
+  `punctuationPacing` settings flag (#15).
 
 ### Changed
 

--- a/src/core/rsvp-engine/__tests__/punctuation-pacing.test.ts
+++ b/src/core/rsvp-engine/__tests__/punctuation-pacing.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { calculatePunctuationDelay, PUNCTUATION_MULTIPLIER } from '../punctuation-pacing';
+
+// Spirit-port of the 16 cases in chriscantu/speed-reader's Safari reference
+// (`Resources/rsvp/word-processor.js` → `calculateDelay`). Each case asserts
+// the multiplier applied to a 200ms base delay so the math is auditable in
+// the test name itself.
+describe('calculatePunctuationDelay', () => {
+  const BASE = 200;
+
+  it.each<[string, string | null | undefined, number, string]>([
+    ['"hello" → 1.0× (no punctuation)', 'hello', PUNCTUATION_MULTIPLIER.DEFAULT, 'no punctuation'],
+    ['"" → 1.0× (empty)', '', PUNCTUATION_MULTIPLIER.DEFAULT, 'empty string'],
+    ['null → 1.0×', null, PUNCTUATION_MULTIPLIER.DEFAULT, 'null'],
+    ['undefined → 1.0×', undefined, PUNCTUATION_MULTIPLIER.DEFAULT, 'undefined'],
+    ['"Hello." → 1.5× (period)', 'Hello.', PUNCTUATION_MULTIPLIER.SENTENCE_END, 'period'],
+    ['"What?" → 1.5× (question)', 'What?', PUNCTUATION_MULTIPLIER.SENTENCE_END, 'question mark'],
+    ['"Stop!" → 1.5× (exclamation)', 'Stop!', PUNCTUATION_MULTIPLIER.SENTENCE_END, 'exclamation'],
+    ['"word," → 1.2× (comma)', 'word,', PUNCTUATION_MULTIPLIER.CLAUSE_BREAK, 'comma'],
+    ['"clause;" → 1.2× (semicolon)', 'clause;', PUNCTUATION_MULTIPLIER.CLAUSE_BREAK, 'semicolon'],
+    ['"intro:" → 1.2× (colon)', 'intro:', PUNCTUATION_MULTIPLIER.CLAUSE_BREAK, 'colon'],
+    [
+      '"(Hello.)" → 1.5× (trailing paren after period)',
+      '(Hello.)',
+      PUNCTUATION_MULTIPLIER.SENTENCE_END,
+      'trailing paren',
+    ],
+    [
+      '"\\"Hi!\\"" → 1.5× (trailing quote after exclamation)',
+      '"Hi!"',
+      PUNCTUATION_MULTIPLIER.SENTENCE_END,
+      'trailing quote',
+    ],
+    [
+      '"end.]" → 1.5× (trailing bracket after period)',
+      'end.]',
+      PUNCTUATION_MULTIPLIER.SENTENCE_END,
+      'trailing bracket',
+    ],
+    [
+      '"e.g.," → 1.2× (abbreviation ending in comma)',
+      'e.g.,',
+      PUNCTUATION_MULTIPLIER.CLAUSE_BREAK,
+      'abbrev → comma',
+    ],
+    [
+      '"U.S.:" → 1.2× (abbreviation ending in colon)',
+      'U.S.:',
+      PUNCTUATION_MULTIPLIER.CLAUSE_BREAK,
+      'abbrev → colon',
+    ],
+    [
+      '"etc." → 1.5× (abbreviation ending in period)',
+      'etc.',
+      PUNCTUATION_MULTIPLIER.SENTENCE_END,
+      'abbrev → period',
+    ],
+  ])('%s', (_label, input, expectedMultiplier) => {
+    expect(calculatePunctuationDelay(input, BASE)).toBe(BASE * expectedMultiplier);
+  });
+
+  // Guard against the NaN footgun called out in the issue spec: even when
+  // base is fractional and input is empty/nullish, output stays a number.
+  it('never returns NaN for empty/nullish input', () => {
+    expect(Number.isNaN(calculatePunctuationDelay(null, BASE))).toBe(false);
+    expect(Number.isNaN(calculatePunctuationDelay(undefined, BASE))).toBe(false);
+    expect(Number.isNaN(calculatePunctuationDelay('', BASE))).toBe(false);
+  });
+});

--- a/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
+++ b/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
@@ -305,7 +305,7 @@ describe('createRsvpEngine', () => {
       expect(events).toHaveLength(2);
     });
 
-    it('paused seekTo onto a sentence-final word — resume uses the seeked word\'s multiplier', () => {
+    it("paused seekTo onto a sentence-final word — resume uses the seeked word's multiplier", () => {
       // Regression guard for the paused-seek lastEmittedWord defect found in
       // PR #163 review: the PAUSED branch of seekTo emits the new word but,
       // before the fix, did NOT update lastEmittedWord. resume() then

--- a/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
+++ b/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
@@ -238,6 +238,73 @@ describe('createRsvpEngine', () => {
       expect(events).toHaveLength(2);
     });
 
+    it('punctuationPacing=true scales the gap after a sentence-final word by 1.5×', () => {
+      // Safari-parity case: after a word ending in `.`, the engine must wait
+      // msPerWord * 1.5 before emitting the next word. Validates the wiring
+      // between `calculatePunctuationDelay` and `scheduleNext`.
+      const words = ['Hello.', 'world'];
+      const wpm = 300;
+      const msPerWord = 60000 / wpm; // 200
+      const engine = createRsvpEngine({ words, wpm, punctuationPacing: true });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      // 'Hello.' emits synchronously on start.
+      expect(events).toHaveLength(1);
+
+      // At 1.5× cadence (200ms × 1.5 = 300ms), 'world' must NOT emit at 299ms
+      // and MUST emit at exactly 300ms.
+      vi.advanceTimersByTime(msPerWord); // 200ms — still inside the 300ms gap
+      expect(events).toHaveLength(1);
+      vi.advanceTimersByTime(msPerWord * 0.5 - 1); // 99ms more = 299ms
+      expect(events).toHaveLength(1);
+      vi.advanceTimersByTime(1); // 300ms total
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual({ type: 'word', index: 1, word: 'world' });
+    });
+
+    it('punctuationPacing=false (default) keeps uniform cadence even on punctuated words', () => {
+      // Regression guard: existing call sites that don't opt in MUST see
+      // unchanged timing. A word ending in `.` should not extend the gap.
+      const words = ['Hello.', 'world'];
+      const wpm = 300;
+      const msPerWord = 60000 / wpm;
+      const engine = createRsvpEngine({ words, wpm });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      expect(events).toHaveLength(1);
+
+      // At plain cadence, 'world' must emit at exactly msPerWord (200ms).
+      vi.advanceTimersByTime(msPerWord - 1);
+      expect(events).toHaveLength(1);
+      vi.advanceTimersByTime(1);
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual({ type: 'word', index: 1, word: 'world' });
+    });
+
+    it('setPunctuationPacing toggles pacing at runtime', () => {
+      // Mirrors the setWpm-mid-stream test: changing the flag while playing
+      // should reschedule the pending tick at the new cadence.
+      const words = ['Hello.', 'world'];
+      const wpm = 300;
+      const msPerWord = 60000 / wpm;
+      const engine = createRsvpEngine({ words, wpm }); // pacing off
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      expect(events).toHaveLength(1);
+
+      // Flip pacing on AFTER 'Hello.' has been emitted but before its gap fires.
+      engine.setPunctuationPacing(true);
+
+      // Gap now 1.5× = 300ms. 'world' should not appear at 200ms.
+      vi.advanceTimersByTime(msPerWord);
+      expect(events).toHaveLength(1);
+      vi.advanceTimersByTime(msPerWord * 0.5);
+      expect(events).toHaveLength(2);
+    });
+
     it('pause/resume cycles compose into a togglePlayPause equivalent', () => {
       // Equivalent Safari cases: `togglePlayPause` (plays when paused, pauses
       // when playing). Chrome composes `pause()` / `resume()` against the

--- a/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
+++ b/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
@@ -305,6 +305,60 @@ describe('createRsvpEngine', () => {
       expect(events).toHaveLength(2);
     });
 
+    it('paused seekTo onto a sentence-final word — resume uses the seeked word\'s multiplier', () => {
+      // Regression guard for the paused-seek lastEmittedWord defect found in
+      // PR #163 review: the PAUSED branch of seekTo emits the new word but,
+      // before the fix, did NOT update lastEmittedWord. resume() then
+      // scheduled its first tick against the stale pre-seek word, so a
+      // paused-seek onto "Hello." resumed at 1.0× instead of 1.5×.
+      const words = ['cat', 'dog', 'Hello.', 'world'];
+      const wpm = 300;
+      const msPerWord = 60000 / wpm; // 200
+      const engine = createRsvpEngine({ words, wpm, punctuationPacing: true });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start(); // emits 'cat'
+      engine.pause();
+      engine.seekTo(2); // jumps to 'Hello.', emits it (paused-branch)
+      // events so far: ['cat', 'Hello.']
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual({ type: 'word', index: 2, word: 'Hello.' });
+
+      engine.resume();
+      // Gap before 'world' MUST be 1.5× msPerWord = 300ms, not the stale 'cat' 1.0×.
+      vi.advanceTimersByTime(msPerWord); // 200ms
+      expect(events).toHaveLength(2);
+      vi.advanceTimersByTime(msPerWord * 0.5 - 1); // 299ms
+      expect(events).toHaveLength(2);
+      vi.advanceTimersByTime(1); // 300ms
+      expect(events).toHaveLength(3);
+      expect(events[2]).toEqual({ type: 'word', index: 3, word: 'world' });
+    });
+
+    it('setWords clears stale punctuation state — first tick on new stream uses default multiplier', () => {
+      // Regression guard from PR #163 review: setWords resets lastEmittedWord
+      // to null. Otherwise a stream swap whose prior last-emit was "Hello."
+      // would silently apply 1.5× to the first gap of the new stream.
+      const wpm = 300;
+      const msPerWord = 60000 / wpm; // 200
+      const engine = createRsvpEngine({ words: ['Hello.'], wpm, punctuationPacing: true });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start(); // emits 'Hello.', lastEmittedWord = 'Hello.'
+
+      engine.setWords(['plain', 'next']); // resets lastEmittedWord to null
+      events.length = 0;
+      engine.start(); // emits 'plain'
+      expect(events).toHaveLength(1);
+
+      // Gap before 'next' must be 1.0× (200ms), not 1.5× (300ms).
+      vi.advanceTimersByTime(msPerWord - 1);
+      expect(events).toHaveLength(1);
+      vi.advanceTimersByTime(1);
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual({ type: 'word', index: 1, word: 'next' });
+    });
+
     it('pause/resume cycles compose into a togglePlayPause equivalent', () => {
       // Equivalent Safari cases: `togglePlayPause` (plays when paused, pauses
       // when playing). Chrome composes `pause()` / `resume()` against the

--- a/src/core/rsvp-engine/punctuation-pacing.ts
+++ b/src/core/rsvp-engine/punctuation-pacing.ts
@@ -1,0 +1,50 @@
+/**
+ * Safari-style punctuation pacing.
+ *
+ * Mirrors the cadence multipliers from chriscantu/speed-reader's
+ * `Resources/rsvp/word-processor.js#calculateDelay`:
+ *
+ *   - Sentence-final punctuation (`.`, `!`, `?`) → 1.5× base delay
+ *   - Clause break (`,`, `;`, `:`) → 1.2× base delay
+ *   - Otherwise → 1.0× base delay
+ *
+ * Trailing closing brackets (`)`, `]`) and the common quote glyphs (`"`,
+ * `'`, smart quotes `‘ ’ “ ”`) are tolerated — `(Hello.)` and `"Hi!"`
+ * still count as sentence-final. The decision is governed by the FINAL
+ * non-bracket character only, so abbreviations like `e.g.,` end on `,`
+ * (clause break) and `etc.` ends on `.` (sentence-final).
+ *
+ * No DOM, no chrome.* / browser.* — safe for src/core/.
+ */
+
+export const PUNCTUATION_MULTIPLIER = {
+  SENTENCE_END: 1.5,
+  CLAUSE_BREAK: 1.2,
+  DEFAULT: 1.0,
+} as const;
+
+// Trailing closing brackets and quote glyphs to strip before inspecting the
+// final punctuation char. Matches Safari's tolerated set: ) ] " ' ‘ ’ “ ”
+const TRAILING_BRACKETS_AND_QUOTES = /[)\]"'‘’“”]+$/u;
+
+/**
+ * Returns the delay (in ms) for `word` given a base per-word delay.
+ *
+ * Null / undefined / empty input returns `baseDelayMs` unchanged — the
+ * engine MUST never schedule a NaN timeout.
+ */
+export function calculatePunctuationDelay(
+  word: string | null | undefined,
+  baseDelayMs: number,
+): number {
+  if (!word) return baseDelayMs;
+  const stripped = word.replace(TRAILING_BRACKETS_AND_QUOTES, '');
+  const last = stripped.charAt(stripped.length - 1);
+  if (last === '.' || last === '!' || last === '?') {
+    return baseDelayMs * PUNCTUATION_MULTIPLIER.SENTENCE_END;
+  }
+  if (last === ',' || last === ';' || last === ':') {
+    return baseDelayMs * PUNCTUATION_MULTIPLIER.CLAUSE_BREAK;
+  }
+  return baseDelayMs * PUNCTUATION_MULTIPLIER.DEFAULT;
+}

--- a/src/core/rsvp-engine/rsvp-engine.ts
+++ b/src/core/rsvp-engine/rsvp-engine.ts
@@ -8,6 +8,8 @@
  * No DOM, no chrome.* / browser.* — safe for src/core/.
  */
 
+import { calculatePunctuationDelay } from './punctuation-pacing';
+
 export const RSVP_STATE = {
   IDLE: 'idle',
   PLAYING: 'playing',
@@ -24,6 +26,12 @@ export type RsvpListener = (event: RsvpEvent) => void;
 export interface RsvpEngineOptions {
   words: string[];
   wpm: number;
+  /**
+   * Apply Safari-style 1.2× / 1.5× pacing after punctuation. Default `false`
+   * to preserve cadence semantics for call sites that haven't opted in.
+   * See `./punctuation-pacing.ts` for the multiplier rules.
+   */
+  punctuationPacing?: boolean;
 }
 
 /**
@@ -45,6 +53,13 @@ export interface RsvpEngine {
   resume(): void;
   stop(): void;
   setWpm(wpm: number): void;
+  /**
+   * Toggle Safari-style punctuation pacing at runtime. Mirrors the `setWpm`
+   * shape: if currently `PLAYING` with a pending tick, the pending tick is
+   * rescheduled at the new cadence (so the change applies to the next gap,
+   * not after one stale interval).
+   */
+  setPunctuationPacing(enabled: boolean): void;
   subscribe(listener: RsvpListener): () => void;
   /**
    * Reposition the engine to `index`. State semantics:
@@ -183,10 +198,15 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
 
   let words = options.words.slice();
   let wpm = options.wpm;
+  let punctuationPacing = options.punctuationPacing ?? false;
   let state: RsvpState = RSVP_STATE.IDLE;
   let nextIndex = 0;
   let timerId: ReturnType<typeof setTimeout> | null = null;
   let seekInFlight = false;
+  // Word just emitted to subscribers — drives Safari-style pacing for the
+  // gap BEFORE the next word. `null` when no word has been emitted yet
+  // (engine idle pre-start, post-reposition before first tick).
+  let lastEmittedWord: string | null = null;
   const listeners = new Set<RsvpListener>();
 
   const emit = (event: RsvpEvent): void => {
@@ -205,12 +225,22 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
     }
   };
 
+  // Per-gap delay = base cadence (`msPerWord`) optionally scaled by the
+  // multiplier for the just-emitted word. When pacing is off OR no word
+  // has been emitted yet, falls through to the base cadence — preserves
+  // the legacy timing path bit-for-bit.
+  const nextDelay = (): number => {
+    const base = msPerWord();
+    if (!punctuationPacing) return base;
+    return calculatePunctuationDelay(lastEmittedWord, base);
+  };
+
   const scheduleNext = (): void => {
     timerId = setTimeout(() => {
       timerId = null;
       if (state !== RSVP_STATE.PLAYING) return;
       tick();
-    }, msPerWord());
+    }, nextDelay());
   };
 
   const tick = (): void => {
@@ -220,7 +250,9 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
       return;
     }
     const index = nextIndex++;
-    emit({ type: 'word', index, word: words[index] });
+    const word = words[index];
+    lastEmittedWord = word;
+    emit({ type: 'word', index, word });
     scheduleNext();
   };
 
@@ -269,11 +301,22 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
         scheduleNext();
       }
     },
+    setPunctuationPacing(enabled: boolean): void {
+      if (punctuationPacing === enabled) return;
+      punctuationPacing = enabled;
+      // Mirror `setWpm`: a pending tick is reset so the new pacing rule
+      // applies to the very next gap rather than after one stale interval.
+      if (state === RSVP_STATE.PLAYING && timerId !== null) {
+        clearPending();
+        scheduleNext();
+      }
+    },
     setWords(next: string[]): void {
       assertValidWords(next);
       clearPending();
       words = next.slice();
       nextIndex = 0;
+      lastEmittedWord = null;
       state = RSVP_STATE.IDLE;
     },
     subscribe(listener: RsvpListener): () => void {

--- a/src/core/rsvp-engine/rsvp-engine.ts
+++ b/src/core/rsvp-engine/rsvp-engine.ts
@@ -362,6 +362,12 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
           tick();
         } else if (state === RSVP_STATE.PAUSED) {
           emit({ type: 'word', index: target, word: words[target] });
+          // Keep `lastEmittedWord` in sync with the just-emitted word so that
+          // a subsequent `resume()` schedules its first tick against the
+          // correct punctuation multiplier — without this, the gap after a
+          // paused-seek onto a sentence-final word silently used the stale
+          // pre-seek word's punctuation.
+          lastEmittedWord = words[target];
           nextIndex = target + 1;
         }
         // idle: silent reposition; first start() will tick from new nextIndex.


### PR DESCRIPTION
## Summary
- New helper `src/core/rsvp-engine/punctuation-pacing.ts` exporting `calculatePunctuationDelay(word, baseMs)` and the `PUNCTUATION_MULTIPLIER` constant
- `RsvpEngineOptions` gains `punctuationPacing?: boolean` (default `false` at engine boundary, regression-safe); `RsvpEngine` gains `setPunctuationPacing(enabled)` for runtime toggling (mirrors `setWpm`)
- `scheduleNext` uses the multiplier on the **just-emitted** word; `tick` tracks `lastEmittedWord` so `setWpm` / `setPunctuationPacing` reschedule against the same word
- `punctuationPacing` settings flag (already in V3 schema, default `true`) is the consumer-facing toggle; engine option is opt-in to keep existing call sites uniform

## Gap analysis — Safari → Chrome multiplier table

| Trailing char(s)                | Safari | Chrome (this PR) | Notes |
|---------------------------------|:------:|:----------------:|-------|
| `.` `!` `?`                       | 1.5×   | 1.5×             | Including trailing `)`, `]`, `"`, `'`, `'`, `'`, `"`, `"` |
| `,` `;` `:`                       | 1.2×   | 1.2×             | Same trailing-bracket tolerance |
| (anything else)                 | 1.0×   | 1.0×             | |
| empty / `null` / `undefined`     | base   | base             | Hard rule: never NaN |
| Mid-word abbreviations          | per final char | per final char | `e.g.,` → 1.2×, `U.S.:` → 1.2×, `etc.` → 1.5× |

No intentional divergence from Safari.

## Test plan
- [x] `npx vitest run src/core/rsvp-engine/__tests__/punctuation-pacing.test.ts` — 17 passed (16 mandatory + 1 NaN guard)
- [x] `npx vitest run src/core/rsvp-engine/__tests__/` — 97 passed (no regression in prior 80)
- [x] `npx vitest run` — 678 passed across 46 files
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` (`eslint . --max-warnings=0`) clean
- [x] `npx prettier --check 'src/core/rsvp-engine/**/*.ts'` clean

## Mandatory test cases (16 + 1)
`calculatePunctuationDelay`:
1. `"hello"` → 1.0×
2. `""` → 1.0× (empty)
3. `null` → 1.0×
4. `undefined` → 1.0×
5. `"Hello."` → 1.5×
6. `"What?"` → 1.5×
7. `"Stop!"` → 1.5×
8. `"word,"` → 1.2×
9. `"clause;"` → 1.2×
10. `"intro:"` → 1.2×
11. `"(Hello.)"` → 1.5×
12. `'"Hi!"'` → 1.5×
13. `"end.]"` → 1.5×
14. `"e.g.,"` → 1.2×
15. `"U.S.:"` → 1.2×
16. `"etc."` → 1.5×
17. (bonus) never returns NaN for empty / null / undefined

Closes #15
