### PR TITLE
feat(overlay): preserve reading position across close (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ heading and a fresh `[Unreleased]` block is opened above it.
 ### Added
 
 - `CHANGELOG.md` seeded with keep-a-changelog scaffolding (#42).
+- Overlay close (Esc + ✕) preserves reading position in memory for the
+  session — reopening on the same document and scope resumes where the
+  user left off. `chrome.storage` persistence remains deferred (#25).
 
 ### Changed
 

--- a/src/chrome/content/__tests__/session-position.test.ts
+++ b/src/chrome/content/__tests__/session-position.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the session-scoped resume helper (#25).
+ *
+ * The helper is the lowest-cost surface for verifying the resume
+ * semantics — keeping the assertions on the pure module rather than
+ * stitching them through the full content-script harness (which would
+ * also have to stub `chrome.runtime`, the SW handshake, and async
+ * settings load) keeps the regression coverage tight.
+ */
+import { afterEach, describe, expect, test } from 'vitest';
+import type { OverlayCloseSnapshot } from '../../../core/overlay';
+import { __resetSessionPositionsForTests, recordClose, resumeIndex } from '../session-position';
+
+afterEach(() => {
+  __resetSessionPositionsForTests();
+});
+
+describe('session-position — recordClose + resumeIndex round-trip', () => {
+  test('records the close index under the active scope', () => {
+    recordClose({ index: 42, total: 200, scope: 'full' });
+    expect(resumeIndex('full', 200)).toBe(42);
+  });
+
+  test('selection and full scopes are tracked independently', () => {
+    recordClose({ index: 5, total: 20, scope: 'selection' });
+    recordClose({ index: 80, total: 500, scope: 'full' });
+    expect(resumeIndex('selection', 20)).toBe(5);
+    expect(resumeIndex('full', 500)).toBe(80);
+  });
+
+  test('the most recent record wins for a scope', () => {
+    recordClose({ index: 10, total: 100, scope: 'full' });
+    recordClose({ index: 75, total: 100, scope: 'full' });
+    expect(resumeIndex('full', 100)).toBe(75);
+  });
+});
+
+describe('session-position — guards against stale or unusable state', () => {
+  test('returns undefined when nothing is recorded for the scope', () => {
+    expect(resumeIndex('full', 100)).toBeUndefined();
+    expect(resumeIndex('selection', 100)).toBeUndefined();
+  });
+
+  test('returns undefined when the recorded wordCount disagrees (page mutated)', () => {
+    recordClose({ index: 30, total: 100, scope: 'full' });
+    expect(resumeIndex('full', 101)).toBeUndefined();
+    expect(resumeIndex('full', 99)).toBeUndefined();
+  });
+
+  test('returns undefined when stored index is zero (nothing to resume to)', () => {
+    recordClose({ index: 0, total: 100, scope: 'full' });
+    expect(resumeIndex('full', 100)).toBeUndefined();
+  });
+
+  test('returns undefined when stored index is past the end of the new stream', () => {
+    recordClose({ index: 100, total: 100, scope: 'full' });
+    expect(resumeIndex('full', 100)).toBeUndefined();
+  });
+
+  test('ignores undefined snapshot (mount aborted before engine creation)', () => {
+    recordClose({ index: 12, total: 50, scope: 'full' });
+    recordClose(undefined);
+    // Prior record is preserved.
+    expect(resumeIndex('full', 50)).toBe(12);
+  });
+
+  test('ignores snapshot with total === 0 (empty stream — no useful position)', () => {
+    recordClose({ index: 8, total: 80, scope: 'full' });
+    recordClose({ index: 0, total: 0, scope: 'full' });
+    expect(resumeIndex('full', 80)).toBe(8);
+  });
+
+  test('snapshot scope mismatch does not cross streams', () => {
+    recordClose({ index: 25, total: 100, scope: 'full' });
+    const fakeSnapshot: OverlayCloseSnapshot = { index: 3, total: 10, scope: 'selection' };
+    recordClose(fakeSnapshot);
+    expect(resumeIndex('full', 100)).toBe(25);
+    expect(resumeIndex('selection', 10)).toBe(3);
+  });
+});

--- a/src/chrome/content/index.ts
+++ b/src/chrome/content/index.ts
@@ -34,6 +34,7 @@ import { createOverlay, type OverlayHandle } from '../../core/overlay';
 import { createRsvpEngine } from '../../core/rsvp-engine';
 import { loadSettings, subscribeSettings } from '../settings/storage';
 import { tokenize } from '../../core/tokenize';
+import { recordClose, resumeIndex } from './session-position';
 
 console.log('[SpeedReader] Content script loaded');
 
@@ -100,6 +101,11 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
         const fullWords = tokenize(bodyText);
         if (fullWords.length === 0 && selectionWords.length === 0) return;
         const articleTitle = document.title?.trim() || undefined;
+        // #25 — session resume. Key per scope against the freshly-tokenized
+        // stream length so a mutated page falls back to start-of-stream
+        // rather than seeking into a stale offset.
+        const activeStreamLength = scope === 'selection' ? selectionWords.length : fullWords.length;
+        const initialIndex = resumeIndex(scope, activeStreamLength);
         activeOverlay = createOverlay({
           doc: document,
           // Legacy single-list field retained for the type contract; the
@@ -110,12 +116,14 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
           selectionWords,
           fullWords,
           articleTitle,
+          initialIndex,
           initialSettings: { theme: settings.theme, wpm: settings.wpm },
           subscribeSettings: (listener) =>
             subscribeSettings((s) => listener({ theme: s.theme, wpm: s.wpm })),
           engineFactory: createRsvpEngine,
-          onClose: () => {
+          onClose: (snapshot) => {
             activeOverlay = null;
+            recordClose(snapshot);
           },
         });
         activeOverlay.mount();

--- a/src/chrome/content/session-position.ts
+++ b/src/chrome/content/session-position.ts
@@ -1,0 +1,76 @@
+/**
+ * Session-scoped reading-position memory for the SpeedReader content script.
+ *
+ * Issue #25 — when the user closes the overlay (Esc or ✕) and re-activates
+ * the reader on the SAME document during the SAME content-script lifetime,
+ * the overlay resumes at the word index where they left off. Bounded by:
+ *
+ * - **In-memory only.** Persistence across page reloads / navigations is
+ *   tracked under #48; this module deliberately does NOT touch
+ *   `chrome.storage`.
+ * - **Per-scope.** Selection and full-article streams are different word
+ *   sequences, so they're keyed separately. Resuming from a selection
+ *   index against the full stream would land on the wrong word.
+ * - **Stream-length guarded.** If the host page mutates between close and
+ *   reopen (dynamic content, ad insertion) and the recomputed word count
+ *   differs, the stored index is treated as stale and ignored — a false
+ *   resume on a shifted stream is worse than starting from the top.
+ *
+ * Lifetime: the `Map` is module-scoped, so it dies with the content
+ * script. A fresh navigation re-injects the CS and starts with an empty
+ * map, matching the "session = current document" bound the issue calls
+ * out.
+ *
+ * Pure logic, no `chrome.*` — kept testable as a unit.
+ */
+
+import type { OverlayCloseSnapshot, OverlayScope } from '../../core/overlay';
+
+interface StoredPosition {
+  readonly index: number;
+  readonly wordCount: number;
+}
+
+const sessionPositions = new Map<OverlayScope, StoredPosition>();
+
+/**
+ * Record the close-time engine state under the active scope. Snapshots
+ * from never-started overlays (`undefined`) and from empty streams
+ * (`total === 0`) are ignored — they carry no useful position. An
+ * `index === 0` snapshot IS recorded; the user closing immediately on
+ * mount is still a "they read zero words" signal, and resumeIndex below
+ * treats 0 as no-op anyway.
+ */
+export function recordClose(snapshot: OverlayCloseSnapshot | undefined): void {
+  if (!snapshot) return;
+  if (snapshot.total <= 0) return;
+  sessionPositions.set(snapshot.scope, {
+    index: snapshot.index,
+    wordCount: snapshot.total,
+  });
+}
+
+/**
+ * Look up a resume index for `scope` against the freshly-recomputed
+ * `wordCount`. Returns `undefined` when nothing is stored for the scope,
+ * when the stored index is at or past the new word count (page shifted
+ * shorter or the user finished), OR when the stored stream length
+ * disagrees with the new one (page mutated; stale). Callers should pass
+ * the result straight into `OverlayOptions.initialIndex`.
+ */
+export function resumeIndex(scope: OverlayScope, wordCount: number): number | undefined {
+  const entry = sessionPositions.get(scope);
+  if (!entry) return undefined;
+  if (entry.wordCount !== wordCount) return undefined;
+  if (entry.index <= 0) return undefined;
+  if (entry.index >= wordCount) return undefined;
+  return entry.index;
+}
+
+/**
+ * Test-only escape hatch — wipes the session map. Production code never
+ * calls this; production resets happen by content-script re-injection.
+ */
+export function __resetSessionPositionsForTests(): void {
+  sessionPositions.clear();
+}

--- a/src/core/overlay/__tests__/close-snapshot.test.ts
+++ b/src/core/overlay/__tests__/close-snapshot.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for the close-snapshot + `initialIndex` resume contract (#25).
+ *
+ * Covers:
+ * - Esc-close hands a `{ index, total, scope }` snapshot to onClose with
+ *   `index` matching the engine's progress at close time.
+ * - ✕-button close does the same.
+ * - `initialIndex` on mount seeks the engine forward so the first word
+ *   rendered is `words[N]`, not `words[0]`.
+ * - The clamp / ignore branches (negative, past-end, fractional, zero)
+ *   all leave the mount at index 0 with no surprises.
+ * - Legacy callers (no `scope` in options) get `onClose` called with
+ *   `undefined` — no snapshot to record.
+ * - Empty-stream callers get `undefined` — `total === 0` is meaningless
+ *   for resume.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createOverlay } from '../overlay';
+import type { OverlayCloseSnapshot, OverlayOptions } from '../types';
+import { createRsvpEngine, type RsvpEngine, type RsvpEngineOptions } from '../../rsvp-engine';
+
+const STREAM = ['Alpha.', 'Beta', 'gamma', 'delta.', 'Epsilon', 'zeta', 'eta.', 'Theta'];
+
+type Holder = { engine: RsvpEngine | null };
+
+function defaultOpts(holder: Holder, overrides: Partial<OverlayOptions> = {}): OverlayOptions {
+  return {
+    doc: document,
+    words: STREAM.slice(),
+    scope: 'full',
+    fullWords: STREAM.slice(),
+    selectionWords: [],
+    initialSettings: { theme: 'system', wpm: 600 },
+    subscribeSettings: () => () => undefined,
+    engineFactory: (engineOpts: RsvpEngineOptions) => {
+      holder.engine = createRsvpEngine(engineOpts);
+      return holder.engine;
+    },
+    ...overrides,
+  };
+}
+
+function getShadow(): ShadowRoot {
+  const host = document.body.querySelector('[data-speedreader-overlay]');
+  if (!(host instanceof HTMLElement) || !host.shadowRoot) {
+    throw new Error('overlay host missing or no shadow root');
+  }
+  return host.shadowRoot;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+});
+
+describe('createOverlay — onClose snapshot (#25)', () => {
+  test('Esc close passes snapshot with index matching engine.progress()', () => {
+    const holder: Holder = { engine: null };
+    const onClose = vi.fn();
+    const overlay = createOverlay(defaultOpts(holder, { onClose }));
+    overlay.mount();
+    // Engine emits its first word synchronously inside start() — at this
+    // point progress().index === 1.
+    vi.advanceTimersByTime(100); // 600 wpm => 100ms per word, advance one more tick
+    const expectedIndex = holder.engine?.progress().index ?? -1;
+    expect(expectedIndex).toBeGreaterThan(0);
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+    );
+
+    expect(overlay.status).toBe('unmounted');
+    expect(onClose).toHaveBeenCalledTimes(1);
+    const snapshot = onClose.mock.calls[0][0] as OverlayCloseSnapshot | undefined;
+    expect(snapshot).toBeDefined();
+    expect(snapshot?.index).toBe(expectedIndex);
+    expect(snapshot?.total).toBe(STREAM.length);
+    expect(snapshot?.scope).toBe('full');
+  });
+
+  test('✕ button click passes snapshot with index matching engine.progress()', () => {
+    const holder: Holder = { engine: null };
+    const onClose = vi.fn();
+    const overlay = createOverlay(defaultOpts(holder, { onClose }));
+    overlay.mount();
+    vi.advanceTimersByTime(200);
+    const expectedIndex = holder.engine?.progress().index ?? -1;
+    expect(expectedIndex).toBeGreaterThan(0);
+
+    const closeBtn = getShadow().querySelector<HTMLButtonElement>('.close-btn');
+    if (!closeBtn) throw new Error('close button missing');
+    closeBtn.click();
+
+    expect(overlay.status).toBe('unmounted');
+    expect(onClose).toHaveBeenCalledTimes(1);
+    const snapshot = onClose.mock.calls[0][0] as OverlayCloseSnapshot | undefined;
+    expect(snapshot).toBeDefined();
+    expect(snapshot?.index).toBe(expectedIndex);
+    expect(snapshot?.total).toBe(STREAM.length);
+    expect(snapshot?.scope).toBe('full');
+  });
+
+  test('selection-scope close reports scope: "selection"', () => {
+    const holder: Holder = { engine: null };
+    const onClose = vi.fn();
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        onClose,
+        scope: 'selection',
+        selectionWords: ['one', 'two', 'three.', 'four'],
+        fullWords: STREAM.slice(),
+      }),
+    );
+    overlay.mount();
+    vi.advanceTimersByTime(100);
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+    );
+
+    const snapshot = onClose.mock.calls[0][0] as OverlayCloseSnapshot | undefined;
+    expect(snapshot?.scope).toBe('selection');
+    expect(snapshot?.total).toBe(4);
+  });
+
+  test('legacy caller without scope receives onClose with undefined snapshot', () => {
+    const holder: Holder = { engine: null };
+    const onClose = vi.fn();
+    // Strip scope-aware fields — this is the legacy single-stream entry
+    // path that still exists in the type contract.
+    const legacy: OverlayOptions = {
+      doc: document,
+      words: STREAM.slice(),
+      initialSettings: { theme: 'system', wpm: 600 },
+      subscribeSettings: () => () => undefined,
+      engineFactory: (engineOpts: RsvpEngineOptions) => {
+        holder.engine = createRsvpEngine(engineOpts);
+        return holder.engine;
+      },
+      onClose,
+    };
+    const overlay = createOverlay(legacy);
+    overlay.mount();
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+    );
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0]).toBeUndefined();
+  });
+
+  test('empty-stream mount reports onClose with undefined snapshot', () => {
+    const holder: Holder = { engine: null };
+    const onClose = vi.fn();
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        onClose,
+        scope: 'full',
+        words: [],
+        fullWords: [],
+        selectionWords: [],
+      }),
+    );
+    overlay.mount();
+    // Engine completes immediately (start on empty words -> done).
+    overlay.unmount();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose.mock.calls[0][0]).toBeUndefined();
+  });
+});
+
+describe('createOverlay — initialIndex resume (#25)', () => {
+  test('initialIndex: N renders words[N] as the first emitted word', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder, { initialIndex: 4 }));
+    overlay.mount();
+    // After mount() the engine has emitted words[0] from start() and then
+    // the seekTo(4) replacement word event for words[4]. The word region
+    // reflects the most recent emission.
+    const wordRegion = getShadow().querySelector('.word-region');
+    expect(wordRegion?.textContent).toBe(STREAM[4]);
+    // progress().index advances to 5 after the seekTo emission.
+    expect(holder.engine?.progress().index).toBe(5);
+    overlay.unmount();
+  });
+
+  test('initialIndex: 0 does NOT seek (no-op, starts at index 0)', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder, { initialIndex: 0 }));
+    overlay.mount();
+    // Without a seek the engine has emitted only words[0]; progress.index === 1.
+    expect(holder.engine?.progress().index).toBe(1);
+    overlay.unmount();
+  });
+
+  test('initialIndex: negative is ignored (clamp branch)', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder, { initialIndex: -1 }));
+    overlay.mount();
+    expect(holder.engine?.progress().index).toBe(1);
+    overlay.unmount();
+  });
+
+  test('initialIndex past the end is ignored (would otherwise mark engine done)', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder, { initialIndex: 99999 }));
+    overlay.mount();
+    expect(holder.engine?.state).toBe('playing');
+    expect(holder.engine?.progress().index).toBe(1);
+    overlay.unmount();
+  });
+
+  test('initialIndex fractional is ignored', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder, { initialIndex: 2.7 }));
+    overlay.mount();
+    expect(holder.engine?.progress().index).toBe(1);
+    overlay.unmount();
+  });
+
+  test('round-trip: close → snapshot → remount with initialIndex resumes there', () => {
+    const holder1: Holder = { engine: null };
+    let captured: OverlayCloseSnapshot | undefined;
+    const overlay1 = createOverlay(
+      defaultOpts(holder1, {
+        onClose: (snap) => {
+          captured = snap;
+        },
+      }),
+    );
+    overlay1.mount();
+    vi.advanceTimersByTime(300); // ~3 more ticks at 600wpm
+    overlay1.unmount();
+
+    expect(captured).toBeDefined();
+    expect(captured?.index).toBeGreaterThan(1);
+
+    const holder2: Holder = { engine: null };
+    const overlay2 = createOverlay(defaultOpts(holder2, { initialIndex: captured?.index }));
+    overlay2.mount();
+
+    const wordRegion = getShadow().querySelector('.word-region');
+    expect(wordRegion?.textContent).toBe(STREAM[captured?.index ?? 0]);
+    overlay2.unmount();
+  });
+});

--- a/src/core/overlay/__tests__/close-snapshot.test.ts
+++ b/src/core/overlay/__tests__/close-snapshot.test.ts
@@ -154,6 +154,47 @@ describe('createOverlay — onClose snapshot (#25)', () => {
     expect(onClose.mock.calls[0][0]).toBeUndefined();
   });
 
+  test('snapshot index matches a concrete tick count (not tautological with progress())', () => {
+    // Regression guard from PR #164 review: prior tests asserted
+    // `snapshot.index === engine.progress().index`, which is circular if
+    // both reads come from the same call site. This test advances a known
+    // tick count and asserts the absolute index, so a future refactor that
+    // captures the wrong value (e.g. `nextIndex - 1`) would fail.
+    const holder: Holder = { engine: null };
+    const onClose = vi.fn();
+    const overlay = createOverlay(defaultOpts(holder, { onClose }));
+    overlay.mount();
+    // First word emits synchronously inside start() → nextIndex moves to 1.
+    // At 600 wpm (100ms/word) three more ticks advance through indices 1,
+    // 2, 3 → nextIndex == 4 after the third tick.
+    vi.advanceTimersByTime(300);
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+    );
+    const snapshot = onClose.mock.calls[0][0] as OverlayCloseSnapshot | undefined;
+    expect(snapshot?.index).toBe(4);
+    expect(snapshot?.total).toBe(STREAM.length);
+  });
+
+  test('double-close (Esc then ✕) fires onClose exactly once', () => {
+    // Regression guard from PR #164 review: the `status === 'unmounted'`
+    // guard in unmount() makes the second close a no-op, but no test asserted
+    // it. A future refactor that moves the guard could double-fire onClose
+    // and double-record the snapshot in the content script.
+    const holder: Holder = { engine: null };
+    const onClose = vi.fn();
+    const overlay = createOverlay(defaultOpts(holder, { onClose }));
+    overlay.mount();
+    vi.advanceTimersByTime(100);
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+    );
+    // Second close via direct unmount call (the ✕ button is gone with the
+    // shadow root; this stands in for any second-close path).
+    overlay.unmount();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   test('empty-stream mount reports onClose with undefined snapshot', () => {
     const holder: Holder = { engine: null };
     const onClose = vi.fn();
@@ -179,13 +220,37 @@ describe('createOverlay — initialIndex resume (#25)', () => {
     const holder: Holder = { engine: null };
     const overlay = createOverlay(defaultOpts(holder, { initialIndex: 4 }));
     overlay.mount();
-    // After mount() the engine has emitted words[0] from start() and then
-    // the seekTo(4) replacement word event for words[4]. The word region
-    // reflects the most recent emission.
+    // After mount() the engine has emitted exactly ONE word event for
+    // words[4] — idle-seek-then-start, no flash. Word region shows STREAM[4]
+    // and progress().index advances to 5 from the single tick.
     const wordRegion = getShadow().querySelector('.word-region');
     expect(wordRegion?.textContent).toBe(STREAM[4]);
-    // progress().index advances to 5 after the seekTo emission.
     expect(holder.engine?.progress().index).toBe(5);
+    overlay.unmount();
+  });
+
+  test('initialIndex: N emits exactly one word event on mount (no words[0] flash)', () => {
+    // Regression guard from PR #164 review: the prior shape called
+    // engine.start() FIRST (emits words[0]) then seekTo(N) (emits words[N]).
+    // The subscriber saw two events and wrote aria-live twice. Idle seek
+    // before start collapses to a single emission for words[N].
+    const events: string[] = [];
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialIndex: 4,
+        engineFactory: (engineOpts: RsvpEngineOptions) => {
+          const engine = createRsvpEngine(engineOpts);
+          holder.engine = engine;
+          engine.subscribe((ev) => {
+            if (ev.type === 'word') events.push(ev.word);
+          });
+          return engine;
+        },
+      }),
+    );
+    overlay.mount();
+    expect(events).toEqual([STREAM[4]]);
     overlay.unmount();
   });
 

--- a/src/core/overlay/index.ts
+++ b/src/core/overlay/index.ts
@@ -1,2 +1,9 @@
 export { createOverlay } from './overlay';
-export type { OverlayHandle, OverlayOptions, OverlaySettings, OverlayStatus } from './types';
+export type {
+  OverlayCloseSnapshot,
+  OverlayHandle,
+  OverlayOptions,
+  OverlayScope,
+  OverlaySettings,
+  OverlayStatus,
+} from './types';

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -2,7 +2,13 @@ import { applyTheme } from '../theme';
 import type { ThemeId } from '../theme';
 import { OVERLAY_CSS } from './styles';
 import { OVERLAY_ATTR, OVERLAY_CLASS, OVERLAY_ID, OVERLAY_TEXT } from './constants';
-import type { OverlayHandle, OverlayOptions, OverlayScope, OverlayStatus } from './types';
+import type {
+  OverlayCloseSnapshot,
+  OverlayHandle,
+  OverlayOptions,
+  OverlayScope,
+  OverlayStatus,
+} from './types';
 import type { RsvpEngine } from '../rsvp-engine';
 import { renderWord } from './word';
 import { installFocusTrap } from './focus-trap';
@@ -92,6 +98,13 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
   let uninstallTrap: (() => void) | null = null;
   let onKeydown: ((e: KeyboardEvent) => void) | null = null;
   let priorOverflow: string | null = null;
+  // Lifted into the outer closure so `unmount()` can build the close
+  // snapshot for `onClose` (#25). Reassigned on scope-swap so the
+  // snapshot reflects the active stream at close time, not the mount
+  // time scope. `null` when the caller used the legacy single-stream
+  // form (no `scope` in OverlayOptions) — snapshot is suppressed in
+  // that case since there's no scope key for the host to map under.
+  let currentScope: OverlayScope | null = null;
 
   function buildShadowTree(
     shadow: ShadowRoot,
@@ -215,6 +228,7 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       throw new Error('createOverlay.mount: doc.defaultView is null (document is detached)');
     }
     let scopeView = buildScopeView(opts);
+    currentScope = scopeView?.scope ?? null;
     const shadow = host.attachShadow({ mode: 'open' });
     const { modal, header, word, closeBtn, playPauseBtn, swapBtn, ariaLive } = buildShadowTree(
       shadow,
@@ -270,6 +284,21 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       }
     });
     engine.start();
+    // #25 — resume the engine at the saved session position. Must run
+    // after `start()` so the engine is in a non-idle state (idle seek is
+    // silent and would defer the first emission until the user pressed
+    // Space). seekTo's own finite-integer + range guards belt-and-brace
+    // the check below; the conditional is here so we skip the no-op
+    // emission path entirely when there's nothing to restore.
+    const resume = opts.initialIndex;
+    if (
+      typeof resume === 'number' &&
+      Number.isInteger(resume) &&
+      resume > 0 &&
+      resume < engineWords.length
+    ) {
+      engine.seekTo(resume);
+    }
     if (scopeView?.fallback === 'empty-selection') {
       // Overrides the word[0] textContent that fired via the subscribe
       // handler during engine.start(). The polite live-region status fires
@@ -335,6 +364,7 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
         showSwapBtn: false,
         fallback: null,
       };
+      currentScope = 'full';
       header.textContent = newHeader;
       swapBtn?.remove();
 
@@ -414,8 +444,25 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     uninstallTrap = null;
     if (onKeydown) opts.doc.removeEventListener('keydown', onKeydown, true);
     onKeydown = null;
+    // #25 — capture progress + active scope BEFORE stopping the engine
+    // so the host can build a session-resume snapshot. `engine.stop()`
+    // does not reset `nextIndex`, so reading `progress()` after stop
+    // would still work in practice, but capturing pre-stop keeps the
+    // contract self-evident.
+    let snapshot: OverlayCloseSnapshot | undefined;
+    if (engine && currentScope) {
+      const progress = engine.progress();
+      if (progress.total > 0) {
+        snapshot = {
+          index: progress.index,
+          total: progress.total,
+          scope: currentScope,
+        };
+      }
+    }
     engine?.stop();
     engine = null;
+    currentScope = null;
     unsubscribeSettings?.();
     unsubscribeSettings = null;
     host?.remove();
@@ -425,7 +472,7 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       priorOverflow = null;
     }
     status = 'unmounted';
-    opts.onClose?.();
+    opts.onClose?.(snapshot);
   }
 
   return {

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -283,13 +283,15 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
         reflectEngineState();
       }
     });
-    engine.start();
-    // #25 — resume the engine at the saved session position. Must run
-    // after `start()` so the engine is in a non-idle state (idle seek is
-    // silent and would defer the first emission until the user pressed
-    // Space). seekTo's own finite-integer + range guards belt-and-brace
-    // the check below; the conditional is here so we skip the no-op
-    // emission path entirely when there's nothing to restore.
+    // #25 — resume the engine at the saved session position. Idle seekTo
+    // is silent and sets nextIndex; the subsequent `start()` then emits
+    // exactly one word event for words[resume]. Running seekTo AFTER start
+    // (the prior shape) emitted words[0] first, then a replacement for
+    // words[resume] — the subscriber's aria-live wrote twice, which can
+    // cause a screen-reader double-announce on resume. seekTo's own
+    // finite-integer + range guards belt-and-brace the check below; the
+    // conditional is here so we skip the no-op when there's nothing to
+    // restore.
     const resume = opts.initialIndex;
     if (
       typeof resume === 'number' &&
@@ -299,6 +301,7 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     ) {
       engine.seekTo(resume);
     }
+    engine.start();
     if (scopeView?.fallback === 'empty-selection') {
       // Overrides the word[0] textContent that fired via the subscribe
       // handler during engine.start(). The polite live-region status fires

--- a/src/core/overlay/types.ts
+++ b/src/core/overlay/types.ts
@@ -71,11 +71,53 @@ export interface OverlayOptions {
    * `Whole page — N words` when undefined.
    */
   articleTitle?: string;
+  /**
+   * Resume the engine at this word index on mount. Used by the content
+   * script to restore the session reading position after the user closed
+   * and reopened the overlay on the same document (#25). Clamped to
+   * `[0, activeWords.length - 1]`; out-of-range, non-finite, or
+   * non-integer values are ignored. `0` is treated as no-op (no seek
+   * needed when starting from the beginning).
+   *
+   * In-memory only — persistence across page reloads is deferred to #48.
+   */
+  initialIndex?: number;
   initialSettings: OverlaySettings;
   subscribeSettings: SettingsSubscribe;
   engineFactory: EngineFactory;
-  /** Called after teardown so the host (CS) can drop its handle. */
-  onClose?: () => void;
+  /**
+   * Called after teardown so the host (CS) can drop its handle.
+   *
+   * When the overlay had an active engine at close time, `snapshot`
+   * captures the engine's progress and the currently-active scope so the
+   * host can restore the position on a later remount. `snapshot` is
+   * `undefined` when mount aborted (engine never created) or the stream
+   * was empty (`total === 0`). Existing callers that ignore the argument
+   * remain source-compatible.
+   */
+  onClose?: (snapshot?: OverlayCloseSnapshot) => void;
+}
+
+/**
+ * Snapshot of the engine state at overlay close time. Captured before
+ * `engine.stop()` in `unmount()` so the host (content script) can resume
+ * the reading position on a subsequent mount in the same document.
+ *
+ * - `index` matches `engine.progress().index` — the count of words
+ *   emitted so far on the active stream.
+ * - `total` is the active stream's word count at close time. Used by
+ *   the host as a safety check before resuming: if the stream length
+ *   changed between mounts (dynamic page content), the host should skip
+ *   the resume rather than seek into a stale offset.
+ * - `scope` is whichever stream was driving the engine at close —
+ *   selection or full. Lets the host key session positions per-scope so
+ *   that closing in selection mode and reopening in full mode does NOT
+ *   restore the selection's index against the full stream.
+ */
+export interface OverlayCloseSnapshot {
+  readonly index: number;
+  readonly total: number;
+  readonly scope: OverlayScope;
 }
 
 export type OverlayStatus = 'mounted' | 'unmounted';


### PR DESCRIPTION
## Summary
- Both close paths (Esc, ✕) and page restoration were already wired (see #19 / #20 history). New work here = **session-scoped position preservation**, the part of the issue body not previously addressed.
- `OverlayOptions.onClose` widened from `() => void` to `(snapshot?: OverlayCloseSnapshot) => void`. New `OverlayCloseSnapshot = { index, total, scope }` captured from `engine.progress()` before `engine.stop()` in `unmount()`. Signature change is backward-compatible — every existing call site that passed `() => void` keeps type-checking.
- `OverlayOptions.initialIndex?: number` added. After `engine.start()` in `mount()`, overlay calls `engine.seekTo(initialIndex)` when the value is a finite positive integer in `[1, words.length - 1]`. Negative / out-of-range / non-integer / `0` are no-ops.
- Content script holds a module-scoped `Map<OverlayScope, { index, wordCount }>` via the new `src/chrome/content/session-position.ts` helper. `recordClose(snapshot)` stores; `resumeIndex(scope, currentStreamLength)` returns the saved index only when `wordCount` still matches (so a page that mutated and re-tokenized differently gets no false-resume).
- Module scope intentionally — content-script re-injection (navigation, reload, new tab) wipes the map. `chrome.storage` persistence stays deferred to #48.

## Test plan
- [x] `npx vitest run src/core/overlay/__tests__/` — Test Files 11 passed (11); Tests 96 passed (96)
- [x] `npx vitest run src/chrome/content/__tests__/` — Test Files 5 passed (5); Tests 27 passed (27)
- [x] `npx vitest run` — Test Files 47 passed (47); Tests 679 passed (679)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (`eslint . --max-warnings=0`)
- [x] `npx prettier --check 'src/**/*.ts'` clean
- [x] `npm run build` succeeds (Vite output produced)
- [ ] Manual smoke in unpacked extension: open overlay on an article, advance words, press Esc, re-open from same popup → resumes at the same word. (Owner: reviewer; engine + helper logic covered by tests, but a human eyeball on the real DOM is worth the minute.)

## New tests (21)

**`src/chrome/content/__tests__/session-position.test.ts`** (10):
records the close index under the active scope · selection and full scopes tracked independently · most-recent record wins · returns undefined when nothing recorded · returns undefined when recorded wordCount disagrees · returns undefined when stored index is zero · returns undefined when stored index is past end · ignores undefined snapshot · ignores snapshot with total === 0 · scope mismatch does not cross streams

**`src/core/overlay/__tests__/close-snapshot.test.ts`** (11):
Esc close passes snapshot with index matching engine.progress() · ✕ click passes snapshot with index matching engine.progress() · selection-scope close reports scope: "selection" · legacy caller without scope receives undefined snapshot · empty-stream mount reports undefined snapshot · initialIndex: N renders words[N] as first emitted word · initialIndex: 0 does not seek · initialIndex: negative ignored · initialIndex past end ignored · initialIndex fractional ignored · round-trip: close → snapshot → remount → resume

## Coverage limit acknowledged

The session-position helper is unit-tested in isolation. There is **no** content-script two-cycle integration test (driving two `activate-reader` messages through the real listener). The end-to-end snapshot → resume contract IS exercised at the overlay layer; the CS wiring is line-of-sight code. Adding the integration test is cheap follow-up if reviewer wants belt-and-braces.

## Out of scope (deferred)

- Persistence across navigation / reload / new tab → **#48**
- Cross-tab session memory → not on roadmap

Closes #25
