### PR TITLE
feat(overlay): consume --surface and --accent-soft theme slots (#150)

### DIFF
--- a/src/core/overlay/__tests__/styles.test.ts
+++ b/src/core/overlay/__tests__/styles.test.ts
@@ -1,0 +1,59 @@
+/**
+ * styles.test.ts — issue #150
+ *
+ * Selector-bound guards that OVERLAY_CSS continues to consume the
+ * `--surface` and `--accent-soft` theme slots written by the theming
+ * applier (`src/core/theme/applier.ts`). The applier writes five slots
+ * per ADR #0002; before #150 the overlay consumed only three, leaving
+ * `--surface` and `--accent-soft` as dead surface area on the contract.
+ *
+ * Bare substring checks (`OVERLAY_CSS.includes('var(--surface')`)
+ * would survive deleting any specific consumer as long as ONE
+ * `var(--surface)` reference existed anywhere in the sheet — including
+ * a comment or an unrelated rule. The regex assertions below bind the
+ * guard to the load-bearing selector + property pair, so a deletion of
+ * `.modal { background: var(--surface, …) }` or any of the three
+ * `:hover { background: var(--accent-soft, …) }` rules surfaces here
+ * instead of silently reverting the floor. Identified during the
+ * adversarial-ring critique of PR for #150 (test-gap finding #1).
+ *
+ * Visual pairing (accentSoft↔text contrast, surface↔text contrast)
+ * is covered at the token layer by
+ * `src/core/theme/__tests__/contrast.test.ts`. The selector-bound
+ * `color: var(--text` assertion on the hover rules guards against a
+ * refactor that decouples the hover foreground from `--text` (which
+ * would silently invalidate the contrast pairing — also a test-gap
+ * critic finding).
+ */
+import { describe, expect, test } from 'vitest';
+import { OVERLAY_CSS } from '../styles';
+
+describe('OVERLAY_CSS theme-slot consumers (issue #150)', () => {
+  test('.modal binds its background to var(--surface, …)', () => {
+    expect(OVERLAY_CSS).toMatch(/\.modal\s*\{[^}]*background:\s*var\(--surface/);
+  });
+
+  test('.close-btn:hover binds background to var(--accent-soft, …)', () => {
+    expect(OVERLAY_CSS).toMatch(/\.close-btn:hover\s*\{[^}]*background:\s*var\(--accent-soft/);
+  });
+
+  test('.play-pause-btn:hover binds background to var(--accent-soft, …)', () => {
+    expect(OVERLAY_CSS).toMatch(/\.play-pause-btn:hover\s*\{[^}]*background:\s*var\(--accent-soft/);
+  });
+
+  test('.scope-swap-btn:hover binds background to var(--accent-soft, …)', () => {
+    expect(OVERLAY_CSS).toMatch(/\.scope-swap-btn:hover\s*\{[^}]*background:\s*var\(--accent-soft/);
+  });
+
+  test('every accent-soft hover rule keeps foreground bound to var(--text, …) for contrast', () => {
+    // Find every `:hover { … var(--accent-soft … }` block and assert each
+    // also pins `color: var(--text`. A future refactor that drops the
+    // color binding would silently invalidate the accentSoft↔text
+    // contrast pairing proven at the token layer in contrast.test.ts.
+    const hoverBlocks = OVERLAY_CSS.match(/[^{}]+:hover\s*\{[^}]*var\(--accent-soft[^}]*\}/g);
+    expect(hoverBlocks, 'expected at least one accent-soft hover rule').not.toBeNull();
+    for (const block of hoverBlocks ?? []) {
+      expect(block).toMatch(/color:\s*var\(--text/);
+    }
+  });
+});

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -28,7 +28,7 @@ export const OVERLAY_CSS = `
 }
 
 .modal {
-  background: var(--bg, #ffffff);
+  background: var(--surface, #ffffff);
   color: var(--text, #111111);
   border-radius: 12px;
   padding: clamp(24px, 6cqi, 64px);
@@ -54,6 +54,11 @@ export const OVERLAY_CSS = `
   cursor: pointer;
 }
 
+.close-btn:hover {
+  background: var(--accent-soft, rgba(37, 99, 235, 0.12));
+  color: var(--text, #111111);
+}
+
 .close-btn:focus-visible {
   outline: 3px solid var(--accent, #2563eb);
   outline-offset: 2px;
@@ -77,6 +82,11 @@ export const OVERLAY_CSS = `
   color: var(--bg, #ffffff);
   font: 700 16px / 1 system-ui, sans-serif;
   cursor: pointer;
+}
+
+.play-pause-btn:hover {
+  background: var(--accent-soft, rgba(37, 99, 235, 0.12));
+  color: var(--text, #111111);
 }
 
 .play-pause-btn:focus-visible {
@@ -115,6 +125,11 @@ export const OVERLAY_CSS = `
   color: var(--text, #111111);
   font: 600 14px / 1 system-ui, sans-serif;
   cursor: pointer;
+}
+
+.scope-swap-btn:hover {
+  background: var(--accent-soft, rgba(37, 99, 235, 0.12));
+  color: var(--text, #111111);
 }
 
 .scope-swap-btn:focus-visible {


### PR DESCRIPTION
## Summary
- `.modal` background: `var(--bg)` → `var(--surface)` (panel tier per ADR #0002)
- Three transport buttons (`.close-btn`, `.play-pause-btn`, `.scope-swap-btn`) gain `:hover { background: var(--accent-soft, ...); color: var(--text, ...) }` so the second previously-dead slot has a real consumer
- 5-test selector-bound guard in `styles.test.ts` (mutates: deleting any one hover rule fails the suite)

## Adversarial-ring sweep

| Critic | Top finding | Resolution |
|---|---|---|
| security-adversary | — none — stylesheet is a static template literal injected via constructable sheet into shadow root; theme applier whitelist-gated | n/a |
| perf-adversary | hover repaint risk on `.modal` ancestor during RSVP playback (~4Hz at 250wpm); no `transition` declared so paint is 1-frame (right call) | acceptable — no transition added, no scope expansion |
| scope-adversary | F1: 3 hover rules when AC #2 requires "at least one" — Karpathy #2 minimum | kept all 3 (transport-button affordance parity); selector-bound tests lock the choice so future deletion surfaces here |
| test-gap-adversary | F1: hover-rule deletion survives substring guard; F2: `.modal` mutation partially survives; F3: no contrast assertion bound to hover pairing | All three fixed via selector-bound regex assertions + a hover-block scanner asserting `color: var(--text` on every accent-soft block |

Convergence (the primary signal per project memory): scope F1 and test-gap F1+F2 all pointed at the same loose-substring weakness. Tightening tests addressed scope intent and mutation survival in one diff.

## Test plan
- [x] `npx vitest run src/core/overlay/__tests__/styles.test.ts` — 5/5 pass
- [x] `npx vitest run` — 709 across 49 files (was 706)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] Contrast suite — 30/30 pass (surface↔text and accent-soft↔text already covered for all 6 themes)
- [ ] Manual: load unpacked, hover each transport button across the 6 themes, confirm tinted background renders and text stays readable (reviewer eyeball)

## Out of scope (deferred)

- Tier-2 surface variable (`--surface-2`, `--text-muted`, `--border`) — gates on #150 landing first per the issue body
- `:active` / `:pressed` states for the transport buttons
- Hover transition (would shift a single-frame paint into a 200ms animated paint adjacent to `.word-region`)

Closes #150
