### PR TITLE
feat(overlay): context preview on pause (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ heading and a fresh `[Unreleased]` block is opened above it.
 - Overlay close (Esc + ✕) preserves reading position in memory for the
   session — reopening on the same document and scope resumes where the
   user left off. `chrome.storage` persistence remains deferred (#25).
+- Overlay now consumes the `--surface` and `--accent-soft` theme slots
+  written by the applier — `.modal` background tracks `--surface`, and
+  transport buttons render a tinted `--accent-soft` background on hover
+  (#150).
+- Context preview on pause — when the reader is paused, the overlay
+  shows the surrounding sentence (previous + current + up to 3 next
+  words) with the current word bolded so the user can re-orient before
+  resuming. Hides on resume / done (#20).
 
 ### Changed
 

--- a/src/core/overlay/__tests__/context-preview.test.ts
+++ b/src/core/overlay/__tests__/context-preview.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { buildSentenceContext } from '../sentence-context';
+import type { SentenceContext } from '../sentence-context';
+import { createOverlay } from '../overlay';
+import type { OverlayOptions } from '../types';
+import { createRsvpEngine } from '../../rsvp-engine';
+
+function expectCtx(ctx: SentenceContext | null): SentenceContext {
+  if (ctx === null) throw new Error('expected SentenceContext, got null');
+  return ctx;
+}
+
+describe('buildSentenceContext (#20 helper)', () => {
+  test('mid-sentence: idx=1 in ["the","quick","brown","fox.","jumped","over."]', () => {
+    const words = ['the', 'quick', 'brown', 'fox.', 'jumped', 'over.'];
+    const ctx = expectCtx(buildSentenceContext(words, 1));
+    expect(ctx.before).toEqual(['the']);
+    expect(ctx.current).toBe('quick');
+    expect(ctx.after).toEqual(['brown', 'fox.', 'jumped', 'over.']);
+  });
+
+  test('current word IS the sentence terminator: idx=3 ("fox.") → after starts at next sentence', () => {
+    const words = ['the', 'quick', 'brown', 'fox.', 'jumped', 'over.', 'the', 'lazy'];
+    const ctx = expectCtx(buildSentenceContext(words, 3, { nextLimit: 3 }));
+    expect(ctx.current).toBe('fox.');
+    expect(ctx.before).toEqual(['the', 'quick', 'brown']);
+    // current word is terminator → after starts past it, capped at nextLimit
+    expect(ctx.after).toEqual(['jumped', 'over.', 'the']);
+  });
+
+  test('stream start: idx=0 → before is empty', () => {
+    const words = ['hello', 'world.', 'next'];
+    const ctx = expectCtx(buildSentenceContext(words, 0));
+    expect(ctx.before).toEqual([]);
+    expect(ctx.current).toBe('hello');
+    expect(ctx.after).toEqual(['world.', 'next']);
+  });
+
+  test('stream end: idx=length-1 → after is empty', () => {
+    const words = ['one', 'two.', 'three', 'four'];
+    const ctx = expectCtx(buildSentenceContext(words, 3));
+    expect(ctx.current).toBe('four');
+    expect(ctx.before).toEqual(['three']);
+    expect(ctx.after).toEqual([]);
+  });
+
+  test('empty stream → null', () => {
+    expect(buildSentenceContext([], 0)).toBeNull();
+  });
+
+  test('negative idx → null', () => {
+    expect(buildSentenceContext(['a', 'b'], -1)).toBeNull();
+  });
+
+  test('out-of-range idx → null', () => {
+    expect(buildSentenceContext(['a', 'b'], 5)).toBeNull();
+  });
+
+  test('non-integer idx → null', () => {
+    expect(buildSentenceContext(['a', 'b'], 0.5)).toBeNull();
+    expect(buildSentenceContext(['a', 'b'], Number.NaN)).toBeNull();
+    expect(buildSentenceContext(['a', 'b'], Number.POSITIVE_INFINITY)).toBeNull();
+  });
+
+  test('nextLimit=1 truncates after to terminator + 1 word', () => {
+    const words = ['a', 'b.', 'c', 'd', 'e', 'f'];
+    const ctx = expectCtx(buildSentenceContext(words, 0, { nextLimit: 1 }));
+    expect(ctx.current).toBe('a');
+    expect(ctx.after).toEqual(['b.', 'c']); // terminator + 1
+  });
+
+  test('nextLimit=0 returns just the rest of the current sentence', () => {
+    const words = ['a', 'b.', 'c', 'd'];
+    const ctx = expectCtx(buildSentenceContext(words, 0, { nextLimit: 0 }));
+    expect(ctx.after).toEqual(['b.']);
+  });
+
+  test('last sentence has no terminator: after extends to end of stream', () => {
+    const words = ['intro.', 'tail', 'without', 'period'];
+    const ctx = expectCtx(buildSentenceContext(words, 1));
+    expect(ctx.current).toBe('tail');
+    expect(ctx.before).toEqual([]);
+    expect(ctx.after).toEqual(['without', 'period']);
+  });
+
+  test('"!" and "?" both end sentences (engine predicate parity)', () => {
+    const ctxBang = expectCtx(buildSentenceContext(['hey!', 'next', 'word.'], 1));
+    expect(ctxBang.before).toEqual([]);
+    expect(ctxBang.current).toBe('next');
+    const ctxQ = expectCtx(buildSentenceContext(['why?', 'next', 'word.'], 1));
+    expect(ctxQ.before).toEqual([]);
+    expect(ctxQ.current).toBe('next');
+  });
+});
+
+// --------- Overlay integration ---------
+
+function defaultOpts(overrides: Partial<OverlayOptions> = {}): OverlayOptions {
+  return {
+    doc: document,
+    words: ['the', 'quick', 'brown', 'fox.', 'jumped', 'over.', 'the', 'lazy', 'dog.'],
+    initialSettings: { theme: 'system', wpm: 300 },
+    subscribeSettings: () => () => undefined,
+    engineFactory: createRsvpEngine,
+    ...overrides,
+  };
+}
+
+function getShadow(): ShadowRoot {
+  const host = document.body.querySelector('[data-speedreader-overlay]');
+  if (!(host instanceof HTMLElement) || !host.shadowRoot) {
+    throw new Error('overlay host missing or no shadow root');
+  }
+  return host.shadowRoot;
+}
+
+function getPreview(): HTMLElement {
+  const el = getShadow().querySelector<HTMLElement>('.context-preview');
+  if (!el) throw new Error('overlay shadow: missing .context-preview');
+  return el;
+}
+
+function getPlayPauseBtn(): HTMLButtonElement {
+  const btn = getShadow().querySelector<HTMLButtonElement>('.play-pause-btn');
+  if (!btn) throw new Error('overlay shadow: missing .play-pause-btn');
+  return btn;
+}
+
+function getCurrentStrong(preview: HTMLElement): HTMLElement {
+  const strong = preview.querySelector<HTMLElement>('strong.context-current');
+  if (!strong) throw new Error('preview: missing strong.context-current');
+  return strong;
+}
+
+describe('createOverlay — context preview (#20)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+  });
+
+  test('preview region exists with role=region and aria-label', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const preview = getPreview();
+    expect(preview.getAttribute('role')).toBe('region');
+    expect(preview.getAttribute('aria-label')).toBe('Surrounding sentence');
+    overlay.unmount();
+  });
+
+  test('hidden while playing (initial state)', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const preview = getPreview();
+    expect(preview.hidden).toBe(true);
+    expect(preview.textContent).toBe('');
+    overlay.unmount();
+  });
+
+  test('pause shows preview with <strong> wrapping the current word', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    // First word emitted on start → "the" at index 0.
+    getPlayPauseBtn().click();
+
+    const preview = getPreview();
+    expect(preview.hidden).toBe(false);
+    const strong = getCurrentStrong(preview);
+    expect(strong.textContent).toBe('the');
+    // Semantic emphasis — must be <strong>, not <b> / <span class=…>.
+    // Mutation guard from test-gap-adversary F2: dropping the semantic
+    // emphasis silently regresses screen-reader announcement.
+    expect(strong.tagName).toBe('STRONG');
+    // Surrounding sentence rendered: full first sentence ("the quick
+    // brown fox.") + up to 3 next-sentence words.
+    expect(preview.textContent).toContain('quick');
+    expect(preview.textContent).toContain('fox.');
+    // No raw HTML — <strong> is the ONLY element child.
+    expect(preview.children.length).toBe(1);
+    overlay.unmount();
+  });
+
+  test('resume hides preview and clears its content', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const btn = getPlayPauseBtn();
+    btn.click(); // pause
+    const preview = getPreview();
+    expect(preview.hidden).toBe(false);
+
+    btn.click(); // resume
+    expect(preview.hidden).toBe(true);
+    expect(preview.textContent).toBe('');
+    overlay.unmount();
+  });
+
+  test('pause at different word positions shows different previews', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const btn = getPlayPauseBtn();
+    const preview = getPreview();
+
+    // Pause #1 — engine just emitted index 0 = "the"
+    btn.click();
+    const firstWord = getCurrentStrong(preview).textContent;
+    expect(firstWord).toBe('the');
+
+    // Resume and advance ~one cadence so the engine emits the next word.
+    btn.click();
+    // At 300 wpm, msPerWord = 200ms. Advance to land on word index 1.
+    vi.advanceTimersByTime(220);
+
+    // Pause #2 — engine just emitted index 1 = "quick"
+    btn.click();
+    const secondWord = getCurrentStrong(preview).textContent;
+    expect(secondWord).toBe('quick');
+    expect(secondWord).not.toBe(firstWord);
+    overlay.unmount();
+  });
+
+  test('done reached after pause hides the previously-visible preview', () => {
+    // Original test only proved "preview hidden when engine was never
+    // shown" — tautological with the initial-state test. Test-gap F3:
+    // pause first (preview visible), then drive engine to done, assert
+    // the preview was cleared on the done transition.
+    const overlay = createOverlay(defaultOpts({ words: ['only.'] }));
+    overlay.mount();
+    const btn = getPlayPauseBtn();
+    btn.click(); // pause — preview now visible
+    const preview = getPreview();
+    expect(preview.hidden).toBe(false);
+    btn.click(); // resume
+    // Advance past the single word so the engine ticks to done.
+    vi.advanceTimersByTime(60000 / 300 + 5);
+    expect(preview.hidden).toBe(true);
+    expect(preview.textContent).toBe('');
+    overlay.unmount();
+  });
+
+  test('after scope-swap, preview uses the full-article stream not the selection stream', () => {
+    // Test-gap-adversary builder-self-weakness rank 1: scope-swap
+    // preview source was untested. The overlay's preview must read
+    // scopeView.activeWords, which `swapToFull` reassigns from
+    // selectionWords to fullWords. A regression that captured words
+    // at mount (instead of via the live ref) would silently render
+    // selection context in the post-swap full-article view.
+    const selectionWords = ['short', 'selection.'];
+    const fullWords = ['the', 'quick', 'brown', 'fox.', 'jumped', 'over.'];
+    const overlay = createOverlay(
+      defaultOpts({
+        scope: 'selection',
+        words: selectionWords,
+        selectionWords,
+        fullWords,
+      }),
+    );
+    overlay.mount();
+    const preview = getPreview();
+    const swapBtn = getShadow().querySelector<HTMLButtonElement>('.scope-swap-btn');
+    if (!swapBtn) throw new Error('overlay shadow: missing .scope-swap-btn');
+
+    // Swap to full — `swapToFull` does start + pause, so the engine
+    // lands paused on full[0] = "the" and `renderPreview()` fires
+    // against the full stream. No extra click needed.
+    swapBtn.click();
+
+    const strong = getCurrentStrong(preview);
+    expect(strong.textContent).toBe('the');
+    // Preview must include a sibling word from the full sentence
+    // ("quick"), proving the helper read `fullWords` not the prior
+    // `selectionWords` (which has no "quick").
+    expect(preview.textContent).toContain('quick');
+    expect(preview.textContent).not.toContain('selection.');
+    overlay.unmount();
+  });
+
+  test('preview built via textContent + <strong> only (no innerHTML injection surface)', () => {
+    // Verify that even if a word contained "<script>" it would render
+    // as text, not as DOM. This is structural — buildSentenceContext is
+    // pure data, but the overlay renderer must never use innerHTML.
+    const overlay = createOverlay(defaultOpts({ words: ['<script>x</script>', 'next.'] }));
+    overlay.mount();
+    getPlayPauseBtn().click(); // pause
+    const preview = getPreview();
+    // The script-like string must appear as plain text, never as a tag.
+    expect(preview.querySelector('script')).toBeNull();
+    const strong = getCurrentStrong(preview);
+    expect(strong.textContent).toBe('<script>x</script>');
+    overlay.unmount();
+  });
+});

--- a/src/core/overlay/constants.ts
+++ b/src/core/overlay/constants.ts
@@ -25,6 +25,8 @@ export const OVERLAY_CLASS = Object.freeze({
   FOOTER: 'footer',
   SCOPE_SWAP_BTN: 'scope-swap-btn',
   PLAY_PAUSE_BTN: 'play-pause-btn',
+  CONTEXT_PREVIEW: 'context-preview',
+  CONTEXT_CURRENT: 'context-current',
 });
 
 /** DOM ids referenced by ARIA relationships (e.g., aria-labelledby). */
@@ -65,6 +67,9 @@ export const OVERLAY_TEXT = Object.freeze({
 
   /** Empty-selection fallback subtitle + polite live-region announcement. */
   EMPTY_SELECTION_FALLBACK: 'No selection detected. Reading full article instead.',
+
+  /** Surrounding-sentence preview region label (#20). */
+  CONTEXT_LABEL: 'Surrounding sentence',
 
   /** Scoped-mode header template: `SELECTION · N words · ~M sec`. */
   scopedHeader(wordCount: number, seconds: number): string {

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -11,6 +11,7 @@ import type {
 } from './types';
 import type { RsvpEngine } from '../rsvp-engine';
 import { renderWord } from './word';
+import { buildSentenceContext } from './sentence-context';
 import { installFocusTrap } from './focus-trap';
 import { WPM_MAX, WPM_MIN, WPM_STEP } from '../settings/bounds';
 
@@ -117,6 +118,7 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     playPauseBtn: HTMLButtonElement;
     swapBtn: HTMLButtonElement | null;
     ariaLive: HTMLElement;
+    preview: HTMLElement;
   } {
     const doc = opts.doc;
 
@@ -166,6 +168,16 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     const word = doc.createElement('div');
     word.className = OVERLAY_CLASS.WORD_REGION;
 
+    // Surrounding-sentence preview (#20). Hidden by default; the pause
+    // hook in mount() shows it with before/<strong>current</strong>/after.
+    // Built with textContent + a single appended <strong> (no innerHTML,
+    // no XSS surface).
+    const preview = doc.createElement('div');
+    preview.className = OVERLAY_CLASS.CONTEXT_PREVIEW;
+    preview.setAttribute('role', 'region');
+    preview.setAttribute('aria-label', OVERLAY_TEXT.CONTEXT_LABEL);
+    preview.hidden = true;
+
     const ariaLive = doc.createElement('div');
     ariaLive.className = OVERLAY_CLASS.ARIA_LIVE;
     ariaLive.setAttribute('aria-live', 'polite');
@@ -195,12 +207,12 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
 
     const children: Node[] = [topSentinel, closeBtn, header];
     if (subtitle) children.push(subtitle);
-    children.push(word, ariaLive, footer, bottomSentinel);
+    children.push(word, preview, ariaLive, footer, bottomSentinel);
     modal.append(...children);
     backdrop.appendChild(modal);
     shadow.appendChild(backdrop);
 
-    return { modal, header, word, closeBtn, playPauseBtn, swapBtn, ariaLive };
+    return { modal, header, word, closeBtn, playPauseBtn, swapBtn, ariaLive, preview };
   }
 
   function mount(): void {
@@ -230,10 +242,8 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     let scopeView = buildScopeView(opts);
     currentScope = scopeView?.scope ?? null;
     const shadow = host.attachShadow({ mode: 'open' });
-    const { modal, header, word, closeBtn, playPauseBtn, swapBtn, ariaLive } = buildShadowTree(
-      shadow,
-      scopeView,
-    );
+    const { modal, header, word, closeBtn, playPauseBtn, swapBtn, ariaLive, preview } =
+      buildShadowTree(shadow, scopeView);
     const resolvedTheme = resolveTheme(opts.initialSettings.theme, view);
     applyTheme(resolvedTheme, modal);
 
@@ -275,12 +285,73 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       }
     };
 
+    const clearPreview = (): void => {
+      // Idempotency guard — clearPreview can be called on every state
+      // transition; skip the layout-touching property writes when the
+      // node is already in the cleared state. Matters when callers fan
+      // out (toggle, swap, paused-state seek-driven word emits) — the
+      // hot path stays free of redundant DOM writes.
+      if (preview.hidden && preview.firstChild === null) return;
+      preview.hidden = true;
+      // textContent='' removes children too, dropping the <strong>.
+      preview.textContent = '';
+    };
+
+    // #20 — render the surrounding-sentence preview. Caller MUST gate
+    // on `engine.state === 'paused'`. The internal early-return below
+    // is belt-and-braces only; the per-word hot path should never reach
+    // this function (perf-adversary F1 + scope-adversary F1).
+    const renderPreview = (): void => {
+      if (!engine) return;
+      if (engine.state !== 'paused') {
+        clearPreview();
+        return;
+      }
+      const progress = engine.progress();
+      if (progress.total === 0) {
+        clearPreview();
+        return;
+      }
+      const currentIndex = progress.index - 1;
+      // Active stream: scopeView's activeWords reflects swap-to-full;
+      // fall back to the legacy single-stream path when no scope.
+      const activeWords = scopeView ? scopeView.activeWords : opts.words;
+      const ctx = buildSentenceContext(activeWords, currentIndex);
+      if (!ctx) {
+        clearPreview();
+        return;
+      }
+      // Build via textContent + a single appended <strong>. No innerHTML.
+      clearPreview();
+      const beforeText = ctx.before.length > 0 ? ctx.before.join(' ') + ' ' : '';
+      const afterText = ctx.after.length > 0 ? ' ' + ctx.after.join(' ') : '';
+      preview.appendChild(opts.doc.createTextNode(beforeText));
+      const strong = opts.doc.createElement('strong');
+      strong.className = OVERLAY_CLASS.CONTEXT_CURRENT;
+      strong.textContent = ctx.current;
+      preview.appendChild(strong);
+      preview.appendChild(opts.doc.createTextNode(afterText));
+      preview.hidden = false;
+    };
+
     engine.subscribe((ev) => {
       if (ev.type === 'word') {
         renderWord(word, ev.word);
         ariaLive.textContent = ev.word;
+        // Only re-render the preview if the just-emitted word landed
+        // while the engine was already paused (paused-state seekTo emits
+        // a replacement `word` event — see RsvpEngine.seekTo docs). On
+        // the per-word PLAYING tick path we MUST skip the call entirely;
+        // clearPreview's idempotency guard makes the no-op cheap, but
+        // not calling it at all is cheaper still (perf-adversary F1).
+        if (engine?.state === 'paused') renderPreview();
       } else if (ev.type === 'done') {
         reflectEngineState();
+        // Done is reached by playback; the preview was never visible if
+        // we were playing. If a future caller can land in `done` from a
+        // paused state, the idempotent clearPreview below is the safety
+        // net.
+        clearPreview();
       }
     });
     // #25 — resume the engine at the saved session position. Idle seekTo
@@ -310,6 +381,7 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       ariaLive.textContent = OVERLAY_TEXT.EMPTY_SELECTION_FALLBACK;
     }
     reflectEngineState();
+    renderPreview();
 
     const togglePlayPause = (): void => {
       if (!engine) return;
@@ -321,6 +393,7 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
         return;
       }
       reflectEngineState();
+      renderPreview();
     };
 
     playPauseBtn.addEventListener('click', togglePlayPause);
@@ -377,6 +450,7 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       ariaLive.textContent = OVERLAY_TEXT.expandedAnnouncement(fullWords.length);
 
       reflectEngineState();
+      renderPreview();
       playPauseBtn.focus();
     };
 

--- a/src/core/overlay/sentence-context.ts
+++ b/src/core/overlay/sentence-context.ts
@@ -1,0 +1,124 @@
+/**
+ * Surrounding-sentence context helper for the pause-state preview (#20).
+ *
+ * Pure data — no DOM, no chrome.*; safe for `src/core/`. The overlay
+ * builds the preview region from the slices returned here; rendering and
+ * visibility toggling live in `overlay.ts`.
+ *
+ * Sentence model intentionally mirrors the engine's `[.!?]$` predicate
+ * (see `rsvp-engine.ts` `SENTENCE_END`, `snapToSentenceStart`,
+ * `findNextSentenceStart`). Keeping the predicate identical means the
+ * preview's "before / current / after" slices agree with
+ * `seekToSentence('prev' | 'next')` navigation — the user sees the same
+ * sentence shape the engine will jump within. Drift here would surface
+ * as a subtle UX mismatch where ←/→ would skip past words the preview
+ * had just shown as part of the current sentence.
+ */
+
+/** Match the engine's sentence terminator. Do NOT introduce a divergent regex. */
+const SENTENCE_END = /[.!?]$/;
+
+export interface SentenceContext {
+  /** Words preceding the current word in the same sentence. May be empty. */
+  readonly before: readonly string[];
+  /** The current word (the one displayed when paused). */
+  readonly current: string;
+  /**
+   * Words following the current word, up to `nextLimit` words after the
+   * current sentence's terminator. The terminator itself stays in `after`.
+   */
+  readonly after: readonly string[];
+}
+
+export interface BuildSentenceContextOptions {
+  /**
+   * How many words past the current sentence's terminator to include in
+   * `after`. Defaults to 3 (matches the issue body's "next few words").
+   * Clipped at the end of `words`.
+   */
+  readonly nextLimit?: number;
+}
+
+const DEFAULT_NEXT_LIMIT = 3;
+
+/**
+ * Upper bound on how many words to walk backward for `before`. Defends
+ * against pathological input (a 5000-word "sentence" with no `.!?`,
+ * e.g. code blocks, URLs, transcripts) that would otherwise dump the
+ * entire document into the preview and spike layout cost. 40 words is
+ * a generous re-orientation window; longer sentences truncate to "…
+ * <last 40 words of the sentence-so-far> <current> …". Surfaced by
+ * perf-adversary F3.
+ */
+const BEFORE_MAX_WORDS = 40;
+
+/**
+ * Build the surrounding-sentence context for the word at `currentIndex`
+ * in `words`. `currentIndex` is the index of the word CURRENTLY displayed
+ * (not `engine.progress().index`, which is the count of emitted words —
+ * the caller does the `- 1` conversion before calling).
+ *
+ * Returns `null` when the inputs cannot describe a current word:
+ *   - `words.length === 0`
+ *   - `currentIndex < 0`
+ *   - `currentIndex >= words.length`
+ *   - `currentIndex` is non-finite or non-integer
+ *
+ * The caller treats `null` as "don't render the preview".
+ */
+export function buildSentenceContext(
+  words: readonly string[],
+  currentIndex: number,
+  options?: BuildSentenceContextOptions,
+): SentenceContext | null {
+  if (!Number.isInteger(currentIndex)) return null;
+  if (words.length === 0) return null;
+  if (currentIndex < 0 || currentIndex >= words.length) return null;
+
+  const nextLimit = options?.nextLimit ?? DEFAULT_NEXT_LIMIT;
+  const safeNextLimit =
+    Number.isInteger(nextLimit) && nextLimit >= 0 ? nextLimit : DEFAULT_NEXT_LIMIT;
+
+  // `before`: walk backward from currentIndex - 1 until we hit a
+  // sentence terminator (exclusive), the start of the stream, OR the
+  // BEFORE_MAX_WORDS bound. The bound caps render cost on pathological
+  // input without changing prose behavior.
+  const beforeFloor = Math.max(0, currentIndex - BEFORE_MAX_WORDS);
+  let sentenceStart = beforeFloor;
+  for (let i = currentIndex - 1; i >= beforeFloor; i--) {
+    if (SENTENCE_END.test(words[i])) {
+      sentenceStart = i + 1;
+      break;
+    }
+  }
+  const before = words.slice(sentenceStart, currentIndex);
+
+  // `after`: walk forward from currentIndex until (and including) the
+  // first sentence terminator, then continue for up to `nextLimit`
+  // additional words. If the current word itself is a terminator,
+  // `terminatorIndex` equals `currentIndex` and `after` starts past it.
+  let terminatorIndex = -1;
+  for (let i = currentIndex; i < words.length; i++) {
+    if (SENTENCE_END.test(words[i])) {
+      terminatorIndex = i;
+      break;
+    }
+  }
+
+  let afterEnd: number;
+  if (terminatorIndex === -1) {
+    // No terminator from currentIndex onward — last sentence runs to
+    // end of stream. nextLimit doesn't apply because there's no
+    // post-terminator region to bound.
+    afterEnd = words.length;
+  } else {
+    afterEnd = Math.min(words.length, terminatorIndex + 1 + safeNextLimit);
+  }
+  const after = words.slice(currentIndex + 1, afterEnd);
+
+  return {
+    before,
+    current: words[currentIndex],
+    after,
+  };
+}

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -146,6 +146,25 @@ export const OVERLAY_CSS = `
   border: 0;
 }
 
+.context-preview {
+  margin-block-start: clamp(12px, 3cqi, 24px);
+  font-size: clamp(0.85rem, 1.2cqi + 0.4rem, 1.05rem);
+  line-height: 1.5;
+  color: var(--text, #111111);
+  opacity: 0.85;
+  max-inline-size: 60ch;
+  margin-inline: auto;
+  text-align: center;
+}
+
+.context-preview[hidden] { display: none; }
+
+.context-current {
+  font-weight: 700;
+  /* Subtle accent so the eye lands on the current word in the sentence. */
+  color: var(--accent, #2563eb);
+}
+
 .trap-sentinel {
   position: absolute;
   width: 1px;
@@ -173,6 +192,8 @@ export const OVERLAY_CSS = `
     border-color: ButtonText;
   }
   .scope-swap-btn:focus-visible { outline-color: Highlight; }
+  .context-preview { color: CanvasText; opacity: 1; }
+  .context-current { color: Highlight; }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary

When the reader is paused, show the surrounding sentence (previous + current + up to 3 next-sentence words) with the current word bolded so the user can re-orient before resuming. Hides on resume / done.

- New pure helper `src/core/overlay/sentence-context.ts` building `{ before, current, after }` slices; reuses the engine`s `[.!?]$` predicate so sentence boundaries agree with `seekToSentence` navigation
- New shadow-DOM region `.context-preview` with `<strong class="context-current">` for the bolded current word, built via `textContent` + `appendChild` (no `innerHTML`)
- Scope-aware: reads `scopeView.activeWords` so post-`swapToFull` the preview renders against the full-article stream
- Idempotent `clearPreview()` + paused-state gate on the hot path — the per-word PLAYING tick does NOT touch the preview DOM
- `BEFORE_MAX_WORDS = 40` cap defends against pathological no-punctuation input

## Adversarial-ring sweep (4 critics + convergence-led arbiter)

| Critic | Top finding | Resolution |
|---|---|---|
| security-adversary | Clean. No `innerHTML`/`insertAdjacentHTML` anywhere; word content reaches DOM only as text nodes; whitelist-gated applier; no CSP regression. | n/a |
| perf-adversary | **F1**: `renderPreview()` fired on EVERY word event; `clearPreview()` non-idempotent → DOM property writes at 100-600 wpm hot path. **F3**: no upper bound on backward sentence walk. | Gate `renderPreview` at the call site (only when `engine?.state === "paused"`); idempotency guard on `clearPreview` (skip when already hidden + no children); `BEFORE_MAX_WORDS = 40` cap in helper. |
| scope-adversary | **F1**: `renderPreview` hooked into engine word + done branches = anticipatory coupling beyond the pause-only spec. | Same fix as perf F1 (call-site gate); `done` branch now calls `clearPreview()` directly, not the speculative `renderPreview`. Forced-colors block kept (file-wide parity); `margin-inline: auto` kept (paired with `text-align: center` + `max-inline-size: 60ch` for centered cap-width block). XSS structural test kept (cheap regression guard against `innerHTML` drift). |
| test-gap-adversary | **F1**: `clearPreview` no-op survived "resume hides preview" partially. **F2**: `<strong>→<span>` semantic regression untestable. **F3**: "done state hides preview" was tautological (preview never shown first). **builder-self-weakness rank 1**: scope-swap preview source untested → mutation undetected. | Added `expect(strong.tagName).toBe("STRONG")` mutation guard. Rewrote "done" test to pause first → resume → tick to done → assert hidden + empty. New `after scope-swap, preview uses full-article stream not selection stream` test exercises the load-bearing `scopeView.activeWords` read path. |

**Convergence (primary signal per project memory `feedback_antagonistic_ring_patterns`)**: perf F1 + scope F1 hit the same root cause (`renderPreview` on hot path). One fix resolved both. Builder self-weakness rank 1 + test-gap top rank both pointed at the same scope-swap mutation gap — one new test resolved both. Arbiter not needed; findings were independently ranked and pre-aligned.

## Test plan

- [x] Helper unit suite — 12 slice-equality cases (mid-sentence, terminator-as-current, stream-start/end, empty stream, negative/oob/non-integer idx, nextLimit honored, no-terminator stream, `!`/`?` parity)
- [x] Overlay integration suite — 8 cases including pause/resume DOM round-trip, `<strong>` tagName mutation guard, scope-swap preview source, paused-then-done hidden, XSS surface check
- [x] `npx vitest run` — 729/729 across 50 files (was 706 after #150)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [ ] Manual: pause / resume across 6 themes; verify the bolded current word reads as emphasis under NVDA / VoiceOver; visual check at 320 px through 4K

## Coverage limits explicitly held back (deferred)

- Click-to-jump on words inside the preview (word-level seek surface — separate issue worth filing)
- Real sentence-segmenter that handles abbreviations (Dr., U.S.A., etc.) shared between `seekToSentence` and `buildSentenceContext`
- Layout-shift / CLS measurement on the pause/resume reflow
- RTL / BiDi visual verification
- Manual AT announcement order verification

Closes #20
