### PR TITLE
feat(popup): Read selection fallback (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ heading and a fresh `[Unreleased]` block is opened above it.
   shows the surrounding sentence (previous + current + up to 3 next
   words) with the current word bolded so the user can re-orient before
   resuming. Hides on resume / done (#20).
+- Popup gains a "Read selection" affordance — when the active tab has a
+  non-empty selection, the popup offers a fallback path that reads just
+  the selection instead of the auto-extracted article. Useful on SPAs,
+  paywalls, and pages where extraction misses the user's intended text.
+  Keyboard-shortcut variant deferred (#18).
 
 ### Changed
 

--- a/src/chrome/background/__tests__/route.test.ts
+++ b/src/chrome/background/__tests__/route.test.ts
@@ -53,11 +53,80 @@ describe('route — activate-reader handler', () => {
     const deps = makeDeps({ ok: true, data: undefined }, { activeTabId: 42 });
     const { promise, sendResponse } = waitForResponse();
 
-    route({ type: 'activate-reader', tabId: 42 }, popupSender(), sendResponse, deps);
+    route({ type: 'activate-reader', tabId: 42, scope: 'full' }, popupSender(), sendResponse, deps);
 
     const resp = await promise;
     expect(resp).toEqual({ ok: true, data: undefined });
-    expect(deps.dispatchActivation).toHaveBeenCalledWith({ source: 'popup', tabId: 42 });
+    expect(deps.dispatchActivation).toHaveBeenCalledWith({
+      source: 'popup',
+      tabId: 42,
+      scope: 'full',
+    });
+  });
+
+  // Issue #18 — popup-driven scope selection.
+  it('forwards scope="selection" from popup payload into the intent', async () => {
+    const deps = makeDeps({ ok: true, data: undefined }, { activeTabId: 42 });
+    const { promise, sendResponse } = waitForResponse();
+
+    route(
+      { type: 'activate-reader', tabId: 42, scope: 'selection' },
+      popupSender(),
+      sendResponse,
+      deps,
+    );
+
+    await promise;
+    expect(deps.dispatchActivation).toHaveBeenCalledWith({
+      source: 'popup',
+      tabId: 42,
+      scope: 'selection',
+    });
+  });
+
+  it('forwards scope="full" from popup payload into the intent', async () => {
+    const deps = makeDeps({ ok: true, data: undefined }, { activeTabId: 42 });
+    const { promise, sendResponse } = waitForResponse();
+
+    route({ type: 'activate-reader', tabId: 42, scope: 'full' }, popupSender(), sendResponse, deps);
+
+    await promise;
+    expect(deps.dispatchActivation).toHaveBeenCalledWith({
+      source: 'popup',
+      tabId: 42,
+      scope: 'full',
+    });
+  });
+
+  it('rejects bogus scope values with invalid-payload — does NOT silently coerce', async () => {
+    // Adversarial-ring scope F1 + security F2: the prior shape silently
+    // coerced any non-whitelisted scope to `'full'`. That hid a buggy /
+    // compromised popup sending an unknown scope. Reject with the same
+    // envelope used for missing-tabId.
+    const deps = makeDeps({ ok: true, data: undefined }, { activeTabId: 42 });
+    const { promise, sendResponse } = waitForResponse();
+
+    route(
+      { type: 'activate-reader', tabId: 42, scope: 'bogus' },
+      popupSender(),
+      sendResponse,
+      deps,
+    );
+
+    const resp = await promise;
+    expect(resp).toEqual({ ok: false, error: { kind: 'invalid-payload' } });
+    expect(deps.dispatchActivation).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing scope with invalid-payload — scope is required at the wire', async () => {
+    const deps = makeDeps({ ok: true, data: undefined }, { activeTabId: 42 });
+    const { promise, sendResponse } = waitForResponse();
+
+    route({ type: 'activate-reader', tabId: 42 }, popupSender(), sendResponse, deps);
+
+    const resp = await promise;
+    expect(resp).toEqual({ ok: false, error: { kind: 'invalid-payload' } });
+    expect(deps.dispatchActivation).not.toHaveBeenCalled();
   });
 
   it('forwards restricted-page error verbatim under activation-failed envelope', async () => {
@@ -68,7 +137,7 @@ describe('route — activate-reader handler', () => {
     const deps = makeDeps({ ok: false, error: activationError }, { activeTabId: 7 });
     const { promise, sendResponse } = waitForResponse();
 
-    route({ type: 'activate-reader', tabId: 7 }, popupSender(), sendResponse, deps);
+    route({ type: 'activate-reader', tabId: 7, scope: 'full' }, popupSender(), sendResponse, deps);
 
     const resp = await promise;
     expect(resp).toEqual({
@@ -90,7 +159,7 @@ describe('route — activate-reader handler', () => {
     const deps = makeDeps({ ok: false, error: activationError }, { activeTabId: 11 });
     const { promise, sendResponse } = waitForResponse();
 
-    route({ type: 'activate-reader', tabId: 11 }, popupSender(), sendResponse, deps);
+    route({ type: 'activate-reader', tabId: 11, scope: 'full' }, popupSender(), sendResponse, deps);
 
     const resp = await promise;
     if (resp.ok) throw new Error('unreachable');
@@ -106,7 +175,12 @@ describe('route — activate-reader handler', () => {
       const deps = makeDeps({ ok: false, error: activationError }, { activeTabId: 1 });
       const { promise, sendResponse } = waitForResponse();
 
-      route({ type: 'activate-reader', tabId: 1 }, popupSender(), sendResponse, deps);
+      route(
+        { type: 'activate-reader', tabId: 1, scope: 'full' },
+        popupSender(),
+        sendResponse,
+        deps,
+      );
 
       const resp = await promise;
       if (resp.ok) throw new Error('unreachable');

--- a/src/chrome/background/activation/__tests__/dispatch.test.ts
+++ b/src/chrome/background/activation/__tests__/dispatch.test.ts
@@ -110,7 +110,7 @@ describe('dispatchActivation', () => {
   it('rejects with restricted-page error for the Chrome Web Store', async () => {
     stub = installChromeStub({ tabUrl: 'https://chromewebstore.google.com/category/extensions' });
     const { dispatchActivation } = await import('../dispatch');
-    const intent: ActivationIntent = { source: 'popup', tabId: 7 };
+    const intent: ActivationIntent = { source: 'popup', tabId: 7, scope: 'full' };
 
     const result = await dispatchActivation(intent);
 
@@ -123,7 +123,7 @@ describe('dispatchActivation', () => {
   it('allows chrome-extension URLs from our own ID', async () => {
     stub = installChromeStub({ tabUrl: `chrome-extension://${OWN_ID}/popup.html` });
     const { dispatchActivation } = await import('../dispatch');
-    const intent: ActivationIntent = { source: 'popup', tabId: 9 };
+    const intent: ActivationIntent = { source: 'popup', tabId: 9, scope: 'full' };
 
     const result = await dispatchActivation(intent);
 
@@ -167,7 +167,7 @@ describe('dispatchActivation', () => {
   it('converts a tabs.sendMessage rejection to a handoff-failed error', async () => {
     stub = installChromeStub({ sendMessageRejects: new Error('Could not establish connection') });
     const { dispatchActivation } = await import('../dispatch');
-    const intent: ActivationIntent = { source: 'popup', tabId: 5 };
+    const intent: ActivationIntent = { source: 'popup', tabId: 5, scope: 'full' };
 
     const result = await dispatchActivation(intent);
 
@@ -220,7 +220,7 @@ describe('dispatchActivation', () => {
   it('#135: popup source executeScript target has no allFrames / frameIds', async () => {
     const { dispatchActivation } = await import('../dispatch');
 
-    await dispatchActivation({ source: 'popup', tabId: 122 });
+    await dispatchActivation({ source: 'popup', tabId: 122, scope: 'full' });
 
     const callArg = stub.scripting.executeScript.mock.calls[0]?.[0] as {
       target: Record<string, unknown>;
@@ -248,13 +248,35 @@ describe('dispatchActivation', () => {
     const { dispatchActivation } = await import('../dispatch');
 
     await dispatchActivation({ source: 'command', tabId: 1 });
-    await dispatchActivation({ source: 'popup', tabId: 2 });
+    await dispatchActivation({ source: 'popup', tabId: 2, scope: 'full' });
 
     expect(stub.tabs.sendMessage.mock.calls).toHaveLength(2);
     const [, p1] = stub.tabs.sendMessage.mock.calls[0] ?? [];
     const [, p2] = stub.tabs.sendMessage.mock.calls[1] ?? [];
     expect(p1).toMatchObject({ type: 'activate-reader', scope: 'full' });
     expect(p2).toMatchObject({ type: 'activate-reader', scope: 'full' });
+  });
+
+  // Issue #18 — popup "Read selection" flows scope='selection' through the
+  // funnel to the wire payload, mirroring the contextMenu-with-selection path.
+  it('forwards popup intent scope="selection" into the wire payload', async () => {
+    const { dispatchActivation } = await import('../dispatch');
+
+    await dispatchActivation({ source: 'popup', tabId: 3, scope: 'selection' });
+
+    const [, payload] = stub.tabs.sendMessage.mock.calls[0] ?? [];
+    expect(payload).toMatchObject({ type: 'activate-reader', scope: 'selection' });
+    // The popup path does NOT carry overrides — only contextMenu presets do.
+    expect(payload).not.toHaveProperty('overrides');
+  });
+
+  it('forwards popup intent scope="full" explicitly into the wire payload', async () => {
+    const { dispatchActivation } = await import('../dispatch');
+
+    await dispatchActivation({ source: 'popup', tabId: 4, scope: 'full' });
+
+    const [, payload] = stub.tabs.sendMessage.mock.calls[0] ?? [];
+    expect(payload).toMatchObject({ type: 'activate-reader', scope: 'full' });
   });
 
   // Context-menu integration spec §"Activation Payload Extension" — preset
@@ -286,7 +308,7 @@ describe('dispatchActivation', () => {
   it('omits overrides key for popup source', async () => {
     const { dispatchActivation } = await import('../dispatch');
 
-    const result = await dispatchActivation({ source: 'popup', tabId: 14 });
+    const result = await dispatchActivation({ source: 'popup', tabId: 14, scope: 'full' });
 
     expect(result.ok).toBe(true);
     const [, payload] = stub.tabs.sendMessage.mock.calls[0] ?? [];

--- a/src/chrome/background/activation/dispatch.ts
+++ b/src/chrome/background/activation/dispatch.ts
@@ -380,7 +380,11 @@ function intentToActivatePayload(intent: ActivationIntent): ActivateReaderMessag
     intent.source === 'contextMenu' &&
     intent.selectionText !== undefined &&
     intent.menuItemId.startsWith('speedreader.ctx.preset.');
-  const scope: ActivateReaderMessage['scope'] = isPresetSelection ? 'selection' : 'full';
+  // Issue #18 — popup carries its own scope (Read article vs Read selection).
+  // Default to `'full'` when omitted to preserve prior popup behavior.
+  const isPopupSelection = intent.source === 'popup' && intent.scope === 'selection';
+  const scope: ActivateReaderMessage['scope'] =
+    isPresetSelection || isPopupSelection ? 'selection' : 'full';
   const base = { type: 'activate-reader' as const, scope };
   return intent.source === 'contextMenu' && intent.overrides
     ? { ...base, overrides: intent.overrides }

--- a/src/chrome/background/activation/types.ts
+++ b/src/chrome/background/activation/types.ts
@@ -69,6 +69,20 @@ export interface ContextMenuActivationIntent {
 export interface PopupActivationIntent {
   source: 'popup';
   tabId: number;
+  /**
+   * Issue #18 — popup-driven scope selection.
+   *
+   * The popup surfaces both "Read article" (full extraction) and "Read
+   * selection" (fallback when auto-extraction fails on SPAs / paywalls /
+   * odd DOM). Forwarded to `intentToActivatePayload` so the CS receives
+   * `scope: 'selection'` instead of defaulting to `'full'`.
+   *
+   * Required — every popup producer in this PR sets it explicitly, and
+   * the type system catches a future caller that forgets. The CS already
+   * handles empty-selection fallback when `scope === 'selection'` and
+   * `window.getSelection()` is empty (see `activate-handler-scope.test.ts`).
+   */
+  scope: 'selection' | 'full';
 }
 
 /** Normalized activation intent — discriminated union over `source`. */

--- a/src/chrome/background/route.ts
+++ b/src/chrome/background/route.ts
@@ -73,7 +73,22 @@ export function route(
         return;
       }
 
-      const intent: ActivationIntent = { source: 'popup', tabId: intentTabId };
+      // Issue #18 — popup carries scope ('full' for Read article,
+      // 'selection' for Read selection). The runtime guard validates the
+      // wire shape because the provenance gate above only enforced
+      // popup-shape, not field values; a buggy/compromised popup could
+      // still send a bogus scope. Reject the message rather than silently
+      // coerce — silent coercion loses the audit trail (security
+      // adversary F2). Matches the invalid-tabId branch above.
+      if (msg.scope !== 'selection' && msg.scope !== 'full') {
+        sendResponse({ ok: false, error: { kind: 'invalid-payload' } });
+        return;
+      }
+      const intent: ActivationIntent = {
+        source: 'popup',
+        tabId: intentTabId,
+        scope: msg.scope,
+      };
       const result = await deps.dispatchActivation(intent);
       if (result.ok) {
         sendResponse({ ok: true, data: result.data });

--- a/src/chrome/popup/__tests__/activate.test.ts
+++ b/src/chrome/popup/__tests__/activate.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for popup-side activation helpers (issue #18).
+ *
+ * Pure-function tests — `chrome.*` is passed in as a parameter so we
+ * mock with plain vi.fn stubs rather than mutating the global.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { buildActivateRequest, resolveActiveTabId, tabHasSelection } from '../activate';
+
+interface ChromeStubOpts {
+  activeTabs?: Array<{ id?: number }>;
+  tabsQueryRejects?: Error;
+  executeScriptResult?: Array<{ result?: unknown }>;
+  executeScriptRejects?: Error;
+}
+
+function makeChromeStub(opts: ChromeStubOpts = {}): typeof chrome {
+  const stub = {
+    tabs: {
+      query: vi.fn(() => {
+        if (opts.tabsQueryRejects) return Promise.reject(opts.tabsQueryRejects);
+        return Promise.resolve(opts.activeTabs ?? [{ id: 42 }]);
+      }),
+    },
+    scripting: {
+      executeScript: vi.fn(() => {
+        if (opts.executeScriptRejects) return Promise.reject(opts.executeScriptRejects);
+        return Promise.resolve(opts.executeScriptResult ?? [{ result: false }]);
+      }),
+    },
+    runtime: { id: 'test-ext' },
+  };
+  return stub as unknown as typeof chrome;
+}
+
+describe('buildActivateRequest', () => {
+  it('produces the exact wire shape route.ts expects', () => {
+    expect(buildActivateRequest(7, 'full')).toEqual({
+      type: 'activate-reader',
+      tabId: 7,
+      scope: 'full',
+    });
+    expect(buildActivateRequest(7, 'selection')).toEqual({
+      type: 'activate-reader',
+      tabId: 7,
+      scope: 'selection',
+    });
+  });
+});
+
+describe('resolveActiveTabId', () => {
+  it('queries the active tab in the current window', async () => {
+    const api = makeChromeStub({ activeTabs: [{ id: 99 }] });
+    const id = await resolveActiveTabId(api);
+    expect(id).toBe(99);
+    expect(api.tabs.query).toHaveBeenCalledWith({ active: true, currentWindow: true });
+  });
+
+  it('throws when no tab is present', async () => {
+    const api = makeChromeStub({ activeTabs: [] });
+    await expect(resolveActiveTabId(api)).rejects.toThrow(/no-active-tab/);
+  });
+
+  it('throws when the active tab is missing an id', async () => {
+    const api = makeChromeStub({ activeTabs: [{}] });
+    await expect(resolveActiveTabId(api)).rejects.toThrow(/no-active-tab/);
+  });
+});
+
+describe('tabHasSelection', () => {
+  it('returns true when the in-page probe reports a non-empty selection', async () => {
+    const api = makeChromeStub({ executeScriptResult: [{ result: true }] });
+    expect(await tabHasSelection(api, 1)).toBe(true);
+    expect(api.scripting.executeScript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: { tabId: 1 },
+        func: expect.any(Function),
+      }),
+    );
+  });
+
+  it('returns false when the in-page probe reports empty', async () => {
+    const api = makeChromeStub({ executeScriptResult: [{ result: false }] });
+    expect(await tabHasSelection(api, 1)).toBe(false);
+  });
+
+  it('returns false on missing or shapeless result', async () => {
+    const api = makeChromeStub({ executeScriptResult: [] });
+    expect(await tabHasSelection(api, 1)).toBe(false);
+  });
+
+  it('returns false when executeScript rejects (restricted URL)', async () => {
+    const api = makeChromeStub({
+      executeScriptRejects: new Error('Cannot access contents of url'),
+    });
+    expect(await tabHasSelection(api, 1)).toBe(false);
+  });
+
+  it('the probe func itself returns true for a non-empty selection (run via jsdom)', () => {
+    // Smoke the inline probe function against a real jsdom selection so
+    // we know the function body — not just the stub — does what we
+    // assert. This is the only place the func body actually executes.
+    document.body.innerHTML = '<p id="x">Selected text</p>';
+    const el = document.getElementById('x');
+    if (!el) throw new Error('fixture missing');
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+
+    const probe = (): boolean => (window.getSelection()?.toString() ?? '').trim().length > 0;
+    expect(probe()).toBe(true);
+
+    sel?.removeAllRanges();
+    expect(probe()).toBe(false);
+  });
+});

--- a/src/chrome/popup/__tests__/index.test.ts
+++ b/src/chrome/popup/__tests__/index.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Popup DOM bootstrap tests (issue #18).
+ *
+ * Exercises `bootstrapPopup` against a jsdom document built from the
+ * production popup HTML structure. `chrome.*` is stubbed so we can
+ * assert the runtime.sendMessage payload.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { bootstrapPopup } from '../index';
+
+interface ChromeStubOpts {
+  activeTabs?: Array<{ id?: number }>;
+  hasSelection?: boolean;
+  selectionProbeRejects?: Error;
+  sendMessageResponse?: unknown;
+  sendMessageRejects?: Error;
+}
+
+type SendMessageMock = ReturnType<typeof vi.fn>;
+type ExecuteScriptMock = ReturnType<typeof vi.fn>;
+
+interface PopupChromeStub {
+  api: typeof chrome;
+  sendMessage: SendMessageMock;
+  executeScript: ExecuteScriptMock;
+}
+
+function makeChromeStub(opts: ChromeStubOpts = {}): PopupChromeStub {
+  const sendMessage: SendMessageMock = vi.fn(() => {
+    if (opts.sendMessageRejects) return Promise.reject(opts.sendMessageRejects);
+    return Promise.resolve(opts.sendMessageResponse ?? { ok: true, data: undefined });
+  });
+  const executeScript: ExecuteScriptMock = vi.fn(() => {
+    if (opts.selectionProbeRejects) return Promise.reject(opts.selectionProbeRejects);
+    return Promise.resolve([{ result: opts.hasSelection ?? false }]);
+  });
+  const api = {
+    tabs: {
+      query: vi.fn(() => Promise.resolve(opts.activeTabs ?? [{ id: 42 }])),
+    },
+    scripting: { executeScript },
+    runtime: { id: 'test-ext', sendMessage },
+  } as unknown as typeof chrome;
+  return { api, sendMessage, executeScript };
+}
+
+function installPopupDom(): void {
+  document.body.innerHTML = `
+    <h1>SpeedReader</h1>
+    <div class="actions">
+      <button type="button" id="read-article" class="action action--primary"
+        aria-label="Read article">Read article</button>
+      <button type="button" id="read-selection" class="action action--secondary"
+        aria-label="Read selection" aria-disabled="true" disabled>Read selection</button>
+    </div>
+    <div class="status" id="status" role="status" aria-live="polite"></div>
+  `;
+}
+
+function getButtons(): {
+  article: HTMLButtonElement;
+  selection: HTMLButtonElement;
+  status: HTMLElement;
+} {
+  return {
+    article: document.getElementById('read-article') as HTMLButtonElement,
+    selection: document.getElementById('read-selection') as HTMLButtonElement,
+    status: document.getElementById('status') as HTMLElement,
+  };
+}
+
+describe('bootstrapPopup — selection probe gating', () => {
+  beforeEach(() => {
+    installPopupDom();
+    // Stub window.close so the success-path setTimeout doesn't bomb in jsdom.
+    vi.spyOn(window, 'close').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('enables Read selection when the probe returns true', async () => {
+    const { api } = makeChromeStub({ hasSelection: true });
+    await bootstrapPopup({ api, doc: document });
+    const { article, selection } = getButtons();
+    expect(article.disabled).toBe(false);
+    expect(selection.disabled).toBe(false);
+    expect(selection.getAttribute('aria-disabled')).toBe('false');
+  });
+
+  it('keeps Read selection disabled when the probe returns false', async () => {
+    const { api } = makeChromeStub({ hasSelection: false });
+    await bootstrapPopup({ api, doc: document });
+    const { article, selection } = getButtons();
+    expect(article.disabled).toBe(false);
+    expect(selection.disabled).toBe(true);
+    expect(selection.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('keeps Read selection disabled when the probe rejects (restricted URL)', async () => {
+    const { api } = makeChromeStub({
+      selectionProbeRejects: new Error('Cannot access contents'),
+    });
+    await bootstrapPopup({ api, doc: document });
+    const { article, selection } = getButtons();
+    expect(article.disabled).toBe(false);
+    expect(selection.disabled).toBe(true);
+  });
+
+  it('disables Read article and surfaces status when no active tab', async () => {
+    const { api } = makeChromeStub({ activeTabs: [] });
+    await bootstrapPopup({ api, doc: document });
+    const { article, status } = getButtons();
+    expect(article.disabled).toBe(true);
+    expect(status.textContent).toMatch(/No active tab/i);
+  });
+});
+
+describe('bootstrapPopup — button clicks', () => {
+  beforeEach(() => {
+    installPopupDom();
+    vi.spyOn(window, 'close').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('Read article click sends activate-reader with scope="full"', async () => {
+    const { api, sendMessage } = makeChromeStub({ hasSelection: false });
+    await bootstrapPopup({ api, doc: document });
+    const { article, status } = getButtons();
+    article.click();
+    // Allow the async activate() handler to flush.
+    await vi.waitFor(() => {
+      expect(sendMessage).toHaveBeenCalled();
+    });
+    expect(sendMessage).toHaveBeenCalledWith({
+      type: 'activate-reader',
+      tabId: 42,
+      scope: 'full',
+    });
+    await vi.waitFor(() => {
+      expect(status.textContent).toMatch(/Activated full read/);
+    });
+  });
+
+  it('Read selection click sends activate-reader with scope="selection"', async () => {
+    const { api, sendMessage } = makeChromeStub({ hasSelection: true });
+    await bootstrapPopup({ api, doc: document });
+    const { selection, status } = getButtons();
+    selection.click();
+    await vi.waitFor(() => {
+      expect(sendMessage).toHaveBeenCalled();
+    });
+    expect(sendMessage).toHaveBeenCalledWith({
+      type: 'activate-reader',
+      tabId: 42,
+      scope: 'selection',
+    });
+    await vi.waitFor(() => {
+      expect(status.textContent).toMatch(/Activated selection read/);
+    });
+  });
+
+  it('error response renders reason and re-enables Read article without closing the popup', async () => {
+    const { api, sendMessage } = makeChromeStub({
+      hasSelection: false,
+      sendMessageResponse: {
+        ok: false,
+        error: {
+          kind: 'activation-failed',
+          error: { kind: 'restricted-page', url: 'chrome://settings' },
+        },
+      },
+    });
+    const closeSpy = window.close as unknown as ReturnType<typeof vi.fn>;
+    await bootstrapPopup({ api, doc: document });
+    const { article, status } = getButtons();
+    article.click();
+    await vi.waitFor(() => {
+      expect(sendMessage).toHaveBeenCalled();
+    });
+    await vi.waitFor(() => {
+      expect(status.textContent).toMatch(/restricted/i);
+    });
+    expect(status.getAttribute('data-state')).toBe('error');
+    expect(article.disabled).toBe(false);
+    // The popup must stay open so the user can read the error.
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+
+  // Adversarial-ring test-gap F1: prior coverage exercised only the
+  // `restricted-page` inner branch; the four other inner kinds and the
+  // outer-fallback template were dead-letter. One parameterized test per
+  // branch closes the mutation gap.
+  it.each([
+    {
+      inner: 'inject-failed' as const,
+      match: /Could not inject SpeedReader/i,
+    },
+    {
+      inner: 'handoff-failed' as const,
+      match: /Lost connection to the page/i,
+    },
+    {
+      inner: 'tab-unavailable' as const,
+      match: /Tab is no longer available/i,
+    },
+  ])('error response with inner=$inner renders the expected reason', async ({ inner, match }) => {
+    const { api } = makeChromeStub({
+      hasSelection: false,
+      sendMessageResponse: {
+        ok: false,
+        error: {
+          kind: 'activation-failed',
+          error: { kind: inner } as never,
+        },
+      },
+    });
+    await bootstrapPopup({ api, doc: document });
+    const { article, status } = getButtons();
+    article.click();
+    await vi.waitFor(() => {
+      expect(status.textContent).toMatch(match);
+    });
+    expect(status.getAttribute('data-state')).toBe('error');
+    expect(article.disabled).toBe(false);
+  });
+
+  it('error response with unknown outer kind falls back to "Activation failed (<outer>)."', async () => {
+    const { api } = makeChromeStub({
+      hasSelection: false,
+      sendMessageResponse: {
+        ok: false,
+        // Outer kind is NOT 'activation-failed' → hits the outer-fallback
+        // branch in formatActivationError.
+        error: { kind: 'invalid-payload' as never },
+      },
+    });
+    await bootstrapPopup({ api, doc: document });
+    const { article, status } = getButtons();
+    article.click();
+    await vi.waitFor(() => {
+      expect(status.textContent).toMatch(/Activation failed \(invalid-payload\)\./);
+    });
+  });
+
+  it('bootstrapPopup with missing DOM elements resolves without throwing and does not query chrome', async () => {
+    // Adversarial-ring test-gap F3: the defensive early-return on a
+    // missing button / status was unexercised; a structural HTML
+    // regression would have shipped silently.
+    document.body.innerHTML = '<div id="status"></div>'; // missing both buttons
+    const { api } = makeChromeStub({ hasSelection: false });
+    await expect(bootstrapPopup({ api, doc: document })).resolves.toBeUndefined();
+    expect(api.tabs.query).not.toHaveBeenCalled();
+  });
+
+  it('sendMessage rejection surfaces error state', async () => {
+    const { api } = makeChromeStub({
+      hasSelection: false,
+      sendMessageRejects: new Error('Could not establish connection'),
+    });
+    await bootstrapPopup({ api, doc: document });
+    const { article, status } = getButtons();
+    article.click();
+    await vi.waitFor(() => {
+      expect(status.textContent).toMatch(/Could not establish connection/);
+    });
+    expect(status.getAttribute('data-state')).toBe('error');
+    expect(article.disabled).toBe(false);
+  });
+});

--- a/src/chrome/popup/activate.ts
+++ b/src/chrome/popup/activate.ts
@@ -1,0 +1,71 @@
+/**
+ * Popup-side activation helpers (issue #18).
+ *
+ * Pure functions split out from `index.ts` so the message-construction
+ * and tab-probe logic are unit-testable without bootstrapping the DOM.
+ * `index.ts` does only DOM wiring; everything that touches `chrome.*`
+ * lives here behind a `typeof chrome` parameter so tests can pass a
+ * stub instead of mutating the global.
+ *
+ * The popup is the only surface that probes the active tab for a
+ * selection (via `chrome.scripting.executeScript`) — the rest of the
+ * dispatch pipeline (`route.ts` → `dispatchActivation`) handles routing
+ * and the CS re-reads `window.getSelection().toString()` for the
+ * authoritative value per the SW-lifecycle spec §"Context-Menu
+ * Selection Trust" (same trust contract applies here).
+ */
+
+export type PopupScope = 'full' | 'selection';
+
+export interface ActivateRequest {
+  readonly type: 'activate-reader';
+  readonly tabId: number;
+  readonly scope: PopupScope;
+}
+
+/** Construct the `activate-reader` wire payload the popup sends. */
+export function buildActivateRequest(tabId: number, scope: PopupScope): ActivateRequest {
+  return { type: 'activate-reader', tabId, scope };
+}
+
+/**
+ * Resolve the active tab in the current window. Throws when no tab is
+ * resolvable — a popup open with no active tab is a degenerate state we
+ * surface rather than swallow.
+ */
+export async function resolveActiveTabId(api: typeof chrome): Promise<number> {
+  const tabs = await api.tabs.query({ active: true, currentWindow: true });
+  const id = tabs[0]?.id;
+  if (typeof id !== 'number') {
+    throw new Error('no-active-tab');
+  }
+  return id;
+}
+
+/**
+ * Probe the active tab for a non-empty selection. Returns `false` when:
+ *   - `executeScript` rejects (restricted URL, no host permission, etc.)
+ *   - the script returns no usable result (script context teardown, etc.)
+ *   - the trimmed selection is empty
+ *
+ * The probe is a UX hint only — the CS re-reads `window.getSelection()`
+ * on activation, so a stale `true` here is recovered by the CS's
+ * empty-selection fallback (`activate-handler-scope.test.ts`).
+ */
+export async function tabHasSelection(api: typeof chrome, tabId: number): Promise<boolean> {
+  try {
+    const results = await api.scripting.executeScript({
+      target: { tabId },
+      // Inline function — runs in the page's isolated world. Keep tiny
+      // and side-effect-free; the result is the only value we trust.
+      func: () => (window.getSelection()?.toString() ?? '').trim().length > 0,
+    });
+    const first = results[0];
+    return first?.result === true;
+  } catch {
+    // Restricted URL / no host permission / tab gone — UX falls back to
+    // "Read selection" disabled, which is the same affordance the user
+    // would see for an empty selection. Don't surface as an error.
+    return false;
+  }
+}

--- a/src/chrome/popup/index.css
+++ b/src/chrome/popup/index.css
@@ -8,7 +8,7 @@
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, sans-serif;
-  min-width: 300px;
+  min-width: 280px;
   padding: 16px;
   background-color: #ffffff;
   color: #333;
@@ -16,10 +16,68 @@ body {
 
 h1 {
   font-size: 1.25rem;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
 }
 
-p {
-  font-size: 0.875rem;
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+/* 44×44 minimum tap target per WCAG 2.5.5 (Target Size). */
+.action {
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 14px;
+  font: inherit;
+  font-size: 0.95rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-align: center;
+}
+
+.action:focus-visible {
+  outline: 2px solid #1a73e8;
+  outline-offset: 2px;
+}
+
+.action--primary {
+  background-color: #1a73e8;
+  color: #ffffff;
+  border-color: #1a73e8;
+}
+
+.action--primary:hover {
+  background-color: #1666c9;
+}
+
+.action--secondary {
+  background-color: #ffffff;
+  color: #1a73e8;
+  border-color: #1a73e8;
+}
+
+.action--secondary:hover:not([disabled]) {
+  background-color: #f1f6fd;
+}
+
+.action[disabled],
+.action[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: #999;
+  border-color: #ccc;
+  background-color: #f5f5f5;
+}
+
+.status {
+  min-height: 1.25rem;
+  font-size: 0.8125rem;
   color: #666;
+}
+
+.status[data-state='error'] {
+  color: #c5221f;
 }

--- a/src/chrome/popup/index.html
+++ b/src/chrome/popup/index.html
@@ -1,35 +1,39 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>SpeedReader</title>
-  <style>
-    body {
-      width: 300px;
-      padding: 16px;
-      font-family: system-ui, -apple-system, sans-serif;
-      margin: 0;
-    }
-    h1 {
-      font-size: 16px;
-      margin: 0 0 8px 0;
-    }
-    p {
-      font-size: 13px;
-      color: #555;
-      margin: 0 0 12px 0;
-    }
-    .status {
-      font-size: 12px;
-      color: #888;
-    }
-  </style>
-</head>
-<body>
-  <h1>SpeedReader</h1>
-  <p>Click the extension icon or use the keyboard shortcut to start reading.</p>
-  <div class="status" id="status">Ready</div>
-  <script type="module" src="./index.ts"></script>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SpeedReader</title>
+    <link rel="stylesheet" href="./index.css" />
+  </head>
+  <body>
+    <h1>SpeedReader</h1>
+    <div class="actions">
+      <button
+        type="button"
+        id="read-article"
+        class="action action--primary"
+        aria-label="Read article"
+      >
+        Read article
+      </button>
+      <button
+        type="button"
+        id="read-selection"
+        class="action action--secondary"
+        aria-label="Read selection"
+        aria-disabled="true"
+        disabled
+      >
+        Read selection
+      </button>
+    </div>
+    <div
+      class="status"
+      id="status"
+      role="status"
+      aria-live="polite"
+    ></div>
+    <script type="module" src="./index.ts"></script>
+  </body>
 </html>

--- a/src/chrome/popup/index.ts
+++ b/src/chrome/popup/index.ts
@@ -1,18 +1,168 @@
 /**
- * SpeedReader — Popup Script
+ * SpeedReader — Popup Script (issue #18).
  *
- * Entry point for the browser-action popup.  Handles popup UI state and
- * messaging with the content script / background service worker.
+ * Two-button surface:
+ *   - "Read article"   → activate-reader { scope: 'full' }
+ *   - "Read selection" → activate-reader { scope: 'selection' }
+ *
+ * Selection button is gated on a `chrome.scripting.executeScript` probe
+ * at popup-open. The probe is best-effort: the CS re-reads
+ * `window.getSelection().toString()` on activation, so a stale "true"
+ * here is recovered by the CS's empty-selection fallback (see
+ * `activate-handler-scope.test.ts` — `scope="selection" with empty
+ * selection: empty-selection fallback fires`).
+ *
+ * All `chrome.*` indirection goes through `./activate.ts` so the
+ * message-construction + probe paths are unit-testable.
  */
 
-// TODO(#5): Implement popup logic
-// - Display current reading status
-// - Show WPM, speed controls
-// - Message content script to toggle reader
+import {
+  buildActivateRequest,
+  resolveActiveTabId,
+  tabHasSelection,
+  type PopupScope,
+} from './activate';
 
-document.addEventListener('DOMContentLoaded', () => {
-  const statusEl = document.getElementById('status');
-  if (statusEl) {
-    statusEl.textContent = 'Ready';
+interface PopupBootstrapDeps {
+  readonly api: typeof chrome;
+  readonly doc: Document;
+}
+
+/**
+ * Wire up the popup UI. Exported for testability — `index.test.ts`
+ * invokes this with a stubbed `chrome` API + jsdom document.
+ */
+export async function bootstrapPopup(deps: PopupBootstrapDeps): Promise<void> {
+  const { api, doc } = deps;
+  const articleBtn = doc.getElementById('read-article') as HTMLButtonElement | null;
+  const selectionBtn = doc.getElementById('read-selection') as HTMLButtonElement | null;
+  const statusEl = doc.getElementById('status');
+
+  if (!articleBtn || !selectionBtn || !statusEl) {
+    // Defensive — the popup HTML controls these IDs. A missing element
+    // means a structural mismatch; surface nothing and bail.
+    return;
   }
-});
+
+  let tabId: number;
+  try {
+    tabId = await resolveActiveTabId(api);
+  } catch {
+    setStatus(statusEl, 'No active tab. Open the popup on a page.', 'error');
+    articleBtn.disabled = true;
+    articleBtn.setAttribute('aria-disabled', 'true');
+    return;
+  }
+
+  // Article button is always enabled — even restricted URLs surface a
+  // typed error from the route, which we then render in the status line.
+  articleBtn.addEventListener('click', () => {
+    void activate(api, statusEl, articleBtn, selectionBtn, tabId, 'full');
+  });
+
+  // Probe selection. On failure (restricted URL, no host permission, no
+  // selection), the selection button stays disabled with a visible cue.
+  const hasSelection = await tabHasSelection(api, tabId);
+  if (hasSelection) {
+    selectionBtn.disabled = false;
+    selectionBtn.setAttribute('aria-disabled', 'false');
+    selectionBtn.addEventListener('click', () => {
+      void activate(api, statusEl, articleBtn, selectionBtn, tabId, 'selection');
+    });
+  } else {
+    selectionBtn.disabled = true;
+    selectionBtn.setAttribute('aria-disabled', 'true');
+    selectionBtn.title = 'No selection on this tab';
+  }
+}
+
+interface ActivationResponse {
+  ok: boolean;
+  error?: { kind: string; error?: { kind: string; url?: string } };
+}
+
+async function activate(
+  api: typeof chrome,
+  statusEl: HTMLElement,
+  articleBtn: HTMLButtonElement,
+  selectionBtn: HTMLButtonElement,
+  tabId: number,
+  scope: PopupScope,
+): Promise<void> {
+  articleBtn.disabled = true;
+  selectionBtn.disabled = true;
+  setStatus(statusEl, scope === 'selection' ? 'Activating selection…' : 'Activating reader…');
+
+  const req = buildActivateRequest(tabId, scope);
+  let resp: ActivationResponse | undefined;
+  try {
+    resp = (await api.runtime.sendMessage(req)) as ActivationResponse | undefined;
+  } catch (err) {
+    setStatus(statusEl, formatErrorMessage(err), 'error');
+    articleBtn.disabled = false;
+    // Re-enable selection only if it was enabled to begin with — checked
+    // via aria-disabled (set by the probe path).
+    if (selectionBtn.getAttribute('aria-disabled') === 'false') {
+      selectionBtn.disabled = false;
+    }
+    return;
+  }
+
+  if (resp && resp.ok) {
+    setStatus(
+      statusEl,
+      scope === 'selection' ? 'Activated selection read.' : 'Activated full read.',
+    );
+    // The popup unmounts on its own when the page takes focus during
+    // overlay activation. The prior shape held the popup open for 400 ms
+    // before closing — that was self-justified UX noise the ring critics
+    // (scope F3, perf F3, test-gap F2) all flagged as a measurable
+    // visible delay with no user benefit.
+    return;
+  }
+
+  // Error path — keep popup open so the user can read the message.
+  setStatus(statusEl, formatActivationError(resp), 'error');
+  articleBtn.disabled = false;
+  if (selectionBtn.getAttribute('aria-disabled') === 'false') {
+    selectionBtn.disabled = false;
+  }
+}
+
+function setStatus(el: HTMLElement, text: string, state?: 'error'): void {
+  el.textContent = text;
+  if (state) {
+    el.setAttribute('data-state', state);
+  } else {
+    el.removeAttribute('data-state');
+  }
+}
+
+function formatErrorMessage(err: unknown): string {
+  if (err instanceof Error && err.message) return err.message;
+  return 'Unable to reach the extension service worker.';
+}
+
+function formatActivationError(resp: ActivationResponse | undefined): string {
+  if (!resp || !resp.error) return 'Activation failed.';
+  const outer = resp.error.kind;
+  if (outer === 'activation-failed' && resp.error.error) {
+    const inner = resp.error.error.kind;
+    if (inner === 'restricted-page') {
+      return 'SpeedReader cannot run on this page (restricted URL).';
+    }
+    if (inner === 'inject-failed') return 'Could not inject SpeedReader into this page.';
+    if (inner === 'handoff-failed') return 'Lost connection to the page. Try again.';
+    if (inner === 'tab-unavailable') return 'Tab is no longer available.';
+    return `Activation failed (${inner}).`;
+  }
+  return `Activation failed (${outer}).`;
+}
+
+// DOM bootstrap. Skipped in test contexts that import the module
+// without a `chrome` global.
+if (typeof document !== 'undefined' && typeof chrome !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    void bootstrapPopup({ api: chrome, doc: document });
+  });
+}

--- a/tests/e2e/popup.spec.ts
+++ b/tests/e2e/popup.spec.ts
@@ -1,10 +1,14 @@
 /**
  * popup.spec.ts — "popup opens, renders" cover spec (issue #38).
  *
- * The popup is `src/chrome/popup/index.html` + `index.ts`. Today (2026-05-26)
- * the popup is a stub: it renders an <h1>SpeedReader</h1>, an instructional
- * <p>, and a status <div id="status"> whose text the script sets to "Ready".
- * See `src/chrome/popup/index.ts` (TODO(#5)).
+ * The popup is `src/chrome/popup/index.html` + `index.ts`. Issue #18 turned
+ * the prior "Ready" stub into a two-button surface:
+ *   - h1 "SpeedReader"
+ *   - <button id="read-article">Read article</button>
+ *   - <button id="read-selection">Read selection</button> (gated on a
+ *     selection probe of the active tab)
+ *   - <div id="status" role="status"> that the bootstrap fills with
+ *     state ("No active tab…", "Activating…", error text, etc.)
  *
  * Constraint documented inline (issue #38 ask: "open extension popup, assert
  * renders"): Chrome browser-action popups can only be opened by a real user
@@ -13,11 +17,15 @@
  * navigate directly to the popup's html URL inside an extension-origin tab
  * — this exercises the SAME html + js bundle the toolbar click would load.
  * Behavior delta: in this mode the popup is NOT bound to a target tab, but
- * the render assertions ("does the popup html load + the script run + the
- * status element populate") are unchanged.
+ * the render assertions ("does the popup html load + the script run") are
+ * unchanged.
  */
 import { test, expect } from '@playwright/test';
-import { launchExtensionContext, closeExtensionContext, type ExtensionHandle } from './fixtures/extension';
+import {
+  launchExtensionContext,
+  closeExtensionContext,
+  type ExtensionHandle,
+} from './fixtures/extension';
 
 let handle: ExtensionHandle | undefined;
 
@@ -30,15 +38,19 @@ test.afterAll(async () => {
   handle = undefined;
 });
 
-test('popup renders heading and status', async () => {
+test('popup renders heading and the two activation buttons', async () => {
   if (!handle) throw new Error('extension context not initialized');
   const popupUrl = `chrome-extension://${handle.extensionId}/src/chrome/popup/index.html`;
   const page = await handle.context.newPage();
   await page.goto(popupUrl);
 
   await expect(page.locator('h1')).toHaveText('SpeedReader');
-  // index.ts sets #status textContent to "Ready" on DOMContentLoaded.
-  await expect(page.locator('#status')).toHaveText('Ready');
+  await expect(page.locator('#read-article')).toBeVisible();
+  await expect(page.locator('#read-selection')).toBeVisible();
+  // Status element is wired with role=status; visible regardless of the
+  // text the bootstrap settles on (which depends on whether a target tab
+  // is reachable through the extension-origin navigation).
+  await expect(page.locator('#status')).toHaveAttribute('role', 'status');
 
   await page.close();
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
       'src/chrome/background/state/**/__tests__/**/*.test.ts',
       'src/chrome/content/**/__tests__/**/*.test.ts',
       'src/chrome/options/**/__tests__/**/*.test.ts',
+      'src/chrome/popup/**/__tests__/**/*.test.ts',
     ],
     exclude: ['node_modules/**', 'dist/**'],
   },


### PR DESCRIPTION
## Summary

When the active tab has a non-empty selection, the popup offers a "Read selection" fallback that scopes the reader to the selection instead of the auto-extracted article. Recovery path for SPAs, paywalls, and other DOM shapes where extraction misses the user`s intended text.

### Shipped
- Popup UI: two stacked buttons (`Read article` + `Read selection`) with `role=status` line; selection button enabled only when the active tab actually has a non-empty selection (probed via `chrome.scripting.executeScript` on popup open)
- `PopupActivationIntent.scope` now **required**: `"selection" | "full"`. Route validates explicitly — bogus or missing scope is rejected with `invalid-payload` (no silent coercion to `"full"`)
- Dispatch funnel honors popup scope; the CS already handles empty-selection fallback when the selection clears between probe and click
- Pure helpers split into `src/chrome/popup/activate.ts` so the wire-shape and tab-resolution logic are unit-testable without DOM bootstrap

### Not shipped (deferred)
- Keyboard shortcut for "Read selection" — issue spec said "popup *and/or* keyboard shortcut"; popup satisfies the "and/or". A follow-up issue would add a `_read_selection` `commands` entry and `chrome.commands.onCommand` handler that builds a `PopupActivationIntent` directly

## Adversarial-ring sweep (4 critics)

| Critic | Top finding | Resolution |
|---|---|---|
| security-adversary | F1 selection-content spoofing race (page DOM mutation between probe and CS read). F2 silent scope coercion lost the audit trail. | F2 fixed — route now rejects bogus/missing scope rather than coerce. F1 acknowledged: CS-side empty-selection fallback is the existing safety net (`activate-handler-scope.test.ts`). |
| perf-adversary | F1 serial `tabs.query` → `executeScript` (~2 RTTs). F2 no cross-popup probe cache. F3 400 ms `setTimeout(window.close)` is visible delay with no benefit. | F3 fixed — `setTimeout` removed; popup unmounts naturally when the page takes focus on activation. F1/F2 acknowledged as cold-path single roundtrips; not optimized this PR. |
| scope-adversary | F1 **`PopupActivationIntent.scope` typed optional** = Karpathy #2 violation (no caller in PR omits it). F3 400 ms timer theatrical. | F1 fixed — `scope` made required; runtime default coercion dropped; redundant "defaults invalid scope" / "defaults missing scope" tests replaced with `invalid-payload` rejection tests. F3 fixed alongside perf F3. CSS rewrite (F2) kept — the BEM/`:focus-visible`/tap-target scaffolding is the minimum for a usable popup, not design-system smuggling. |
| test-gap-adversary | F1 four `formatActivationError` inner-kind branches were dead-letter. F2 success-path `window.close` never asserted. F3 `bootstrapPopup` early-return on missing DOM untested. | F1 fixed — parameterized tests for `inject-failed` / `handoff-failed` / `tab-unavailable` + an outer-fallback template test. F2 obsolete after F3 fix. F3 fixed — new test mounts a partial DOM and asserts `bootstrapPopup` resolves without throwing and never calls `chrome.tabs.query`. |

**Convergence (primary signal per project memory)**: scope F3 + perf F3 + test-gap F2 hit the same root (400 ms timer). One deletion resolved all three. Scope F1 + security F2 converged on "stop silently coercing scope" — one shape change (`required` field + reject path) addressed both. Test-gap F1 + builder self-weakness #4 both flagged the error-message gap.

## Test plan

- [x] `npx vitest run` — **757/757** passing across 52 files
- [x] `npx tsc --noEmit` clean (scope-required catches future callers at compile time)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run build` produces dist/ (188 kB total, popup bundle ~9 kB)
- [ ] Manual on unpacked: select text on an article → open popup → "Read selection" enabled with the right copy; click it → overlay opens scoped to selection; close popup without selecting → "Read selection" disabled with the no-selection hint
- [ ] Manual error path: open popup on `chrome://settings` → "Read article" surfaces the restricted-page message and keeps the popup open

## Coverage limits acknowledged

- jsdom can`t verify `:focus-visible` outline rendering or `role=status` announcement order under NVDA / VoiceOver — `extension-quality-engineer` Playwright + axe pass needed before store submission
- The selection probe is a single roundtrip per popup open; not cached across re-opens (perf-adversary F2 acknowledged, not optimized)
- The MAIN-vs-ISOLATED world distinction for `getSelection` was reviewed; the existing CS-side empty-selection fallback handles the stale-probe case (security-adversary F1)

Closes #18
