### PR TITLE
feat(overlay): wire OpenDyslexic font toggle (#27)

### DIFF
--- a/src/chrome/content/__tests__/opendyslexic-wire.test.ts
+++ b/src/chrome/content/__tests__/opendyslexic-wire.test.ts
@@ -1,0 +1,172 @@
+/**
+ * opendyslexic-wire.test.ts — issue #27
+ *
+ * End-to-end wire from `chrome.storage.sync.get` → loadSettings →
+ * createOverlay → modal class on the shadow DOM. The unit test in
+ * `core/overlay/__tests__/opendyslexic.test.ts` pins the overlay's local
+ * behaviour; this file pins the chrome-glue path so a regression that
+ * drops `openDyslexic` from the `initialSettings` payload or the
+ * `subscribeSettings` listener (or that strips the `openDyslexicFontUrl`
+ * from `chrome.runtime.getURL`) lands as a test failure rather than a
+ * silent toggle no-op.
+ *
+ * Mutation guard: each assertion's failure mode is explicit. Removing
+ * the `openDyslexic` field from `initialSettings` makes the "modal carries
+ * the class on mount" test fail. Removing `openDyslexicFontUrl` makes the
+ * "shadow CSS contains the WAR URL" test fail. Dropping
+ * `openDyslexic: s.openDyslexic` from the subscribe wiring breaks the
+ * "live toggle re-applies on settings change" test in the overlay suite
+ * — that case is covered there because it does not depend on chrome glue.
+ */
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
+import { OVERLAY_CLASS } from '../../../core/overlay/constants';
+
+const SETTINGS_KEY = 'speedreader.settings';
+const FONT_PATH = 'fonts/OpenDyslexic-Regular.woff2';
+const EXT_ID = 'test-ext';
+const FONT_URL = `chrome-extension://${EXT_ID}/${FONT_PATH}`;
+
+type Listener = (
+  msg: unknown,
+  sender: { id?: string },
+  sendResponse: (r: unknown) => void,
+) => unknown;
+
+interface ChromeMock {
+  runtime: {
+    id: string;
+    onMessage: { addListener: (l: Listener) => void };
+    getURL: ReturnType<typeof vi.fn>;
+  };
+  storage: {
+    sync: {
+      get: ReturnType<typeof vi.fn>;
+      set: ReturnType<typeof vi.fn>;
+    };
+    onChanged: {
+      addListener: ReturnType<typeof vi.fn>;
+      removeListener: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+function installChromeMock(initial: { openDyslexic: boolean } = { openDyslexic: false }): {
+  mock: ChromeMock;
+  getListener: () => Listener;
+} {
+  let capturedListener: Listener | undefined;
+  const stored = { ...DEFAULT_SETTINGS, openDyslexic: initial.openDyslexic };
+  const mock: ChromeMock = {
+    runtime: {
+      id: EXT_ID,
+      onMessage: {
+        addListener: (l: Listener) => {
+          capturedListener = l;
+        },
+      },
+      getURL: vi.fn((path: string) => `chrome-extension://${EXT_ID}/${path}`),
+    },
+    storage: {
+      sync: {
+        get: vi.fn().mockResolvedValue({ [SETTINGS_KEY]: stored }),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      onChanged: { addListener: vi.fn(), removeListener: vi.fn() },
+    },
+  };
+  (globalThis as unknown as { chrome: ChromeMock }).chrome = mock;
+  return {
+    mock,
+    getListener: () => {
+      if (!capturedListener) throw new Error('content script never registered listener');
+      return capturedListener;
+    },
+  };
+}
+
+async function mountOverlay(getListener: () => Listener): Promise<void> {
+  document.body.innerHTML = '<article>The quick brown fox jumps over the lazy dog.</article>';
+  await import('../index');
+  const listener = getListener();
+  const respond = vi.fn();
+  listener({ type: 'activate-reader' }, { id: EXT_ID }, respond);
+  expect(respond).toHaveBeenCalledWith({ ok: true });
+  await vi.runAllTimersAsync();
+}
+
+function getShadow(): ShadowRoot {
+  const host = document.body.querySelector('[data-speedreader-overlay]');
+  if (!(host instanceof HTMLElement) || !host.shadowRoot) {
+    throw new Error('overlay host missing or no shadow root');
+  }
+  return host.shadowRoot;
+}
+
+function getModal(): HTMLElement {
+  const el = getShadow().querySelector<HTMLElement>(`.${OVERLAY_CLASS.MODAL}`);
+  if (!el) throw new Error('overlay shadow: missing modal');
+  return el;
+}
+
+function getShadowCss(): string {
+  const shadow = getShadow();
+  const adopted = (shadow as ShadowRoot & { adoptedStyleSheets?: CSSStyleSheet[] })
+    .adoptedStyleSheets;
+  const adoptedCss =
+    adopted && adopted.length > 0
+      ? adopted
+          .map((s) =>
+            Array.from(s.cssRules ?? [])
+              .map((r) => r.cssText)
+              .join('\n'),
+          )
+          .join('\n')
+      : '';
+  const inlineCss = Array.from(shadow.querySelectorAll('style'))
+    .map((el) => el.textContent ?? '')
+    .join('\n');
+  return `${adoptedCss}\n${inlineCss}`;
+}
+
+describe('content script — OpenDyslexic wire (#27)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (globalThis as unknown as { chrome?: unknown }).chrome;
+    document.body.innerHTML = '';
+    document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+    vi.resetModules();
+  });
+
+  test('openDyslexic=true persisted → modal carries .opendyslexic class on mount', async () => {
+    const { getListener } = installChromeMock({ openDyslexic: true });
+    await mountOverlay(getListener);
+    expect(getModal().classList.contains(OVERLAY_CLASS.OPENDYSLEXIC)).toBe(true);
+  });
+
+  test('openDyslexic=false persisted → modal does NOT carry .opendyslexic class', async () => {
+    const { getListener } = installChromeMock({ openDyslexic: false });
+    await mountOverlay(getListener);
+    expect(getModal().classList.contains(OVERLAY_CLASS.OPENDYSLEXIC)).toBe(false);
+  });
+
+  test('chrome.runtime.getURL is invoked with the bundled font path and the resolved URL is embedded in the shadow @font-face', async () => {
+    const { mock, getListener } = installChromeMock({ openDyslexic: true });
+    await mountOverlay(getListener);
+
+    // Mutation guard: a contributor dropping `openDyslexicFontUrl` from
+    // createOverlay would still pass the class-flip assertions above —
+    // this assertion is what proves the URL flow is live. Bound to the
+    // exact font-path string so a typo in the path also fails here.
+    expect(mock.runtime.getURL).toHaveBeenCalledWith(FONT_PATH);
+
+    const css = getShadowCss();
+    expect(css).toContain('@font-face');
+    expect(css).toContain('OpenDyslexic');
+    expect(css).toContain(FONT_URL);
+  });
+});

--- a/src/chrome/content/index.ts
+++ b/src/chrome/content/index.ts
@@ -121,11 +121,30 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
             theme: settings.theme,
             wpm: settings.wpm,
             fontSize: settings.fontSize,
+            openDyslexic: settings.openDyslexic,
           },
           subscribeSettings: (listener) =>
             subscribeSettings((s) =>
-              listener({ theme: s.theme, wpm: s.wpm, fontSize: s.fontSize }),
+              listener({
+                theme: s.theme,
+                wpm: s.wpm,
+                fontSize: s.fontSize,
+                openDyslexic: s.openDyslexic,
+              }),
             ),
+          // OpenDyslexic font URL (#27, #10). `core/` cannot call
+          // chrome.runtime.getURL, so the WAR URL is resolved here at
+          // overlay-construction time and passed through. PR #169 declared
+          // the `fonts/*` WAR entry; the woff2 binary lands separately under
+          // #173. When the binary is missing the overlay still mounts
+          // correctly — the @font-face load fails silently and the modal
+          // falls back to system-ui via the family stack in styles.ts.
+          //
+          // Defensive: optional-chain on `getURL` because some non-MV3 host
+          // environments (e.g. unit-test harnesses that stub a partial
+          // `chrome.runtime`) omit it. When unavailable, the toggle still
+          // flips the class — pure UI behavior — but no custom font loads.
+          openDyslexicFontUrl: chrome.runtime.getURL?.('fonts/OpenDyslexic-Regular.woff2'),
           engineFactory: createRsvpEngine,
           onClose: (snapshot) => {
             activeOverlay = null;

--- a/src/chrome/content/index.ts
+++ b/src/chrome/content/index.ts
@@ -144,7 +144,16 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
           // environments (e.g. unit-test harnesses that stub a partial
           // `chrome.runtime`) omit it. When unavailable, the toggle still
           // flips the class — pure UI behavior — but no custom font loads.
-          openDyslexicFontUrl: chrome.runtime.getURL?.('fonts/OpenDyslexic-Regular.woff2'),
+          // Warn so the silent-no-font case leaves a breadcrumb.
+          openDyslexicFontUrl: (() => {
+            if (!chrome.runtime.getURL) {
+              console.warn(
+                '[speedreader] chrome.runtime.getURL unavailable; OpenDyslexic font will not load',
+              );
+              return undefined;
+            }
+            return chrome.runtime.getURL('fonts/OpenDyslexic-Regular.woff2');
+          })(),
           engineFactory: createRsvpEngine,
           onClose: (snapshot) => {
             activeOverlay = null;

--- a/src/core/overlay/__tests__/opendyslexic.test.ts
+++ b/src/core/overlay/__tests__/opendyslexic.test.ts
@@ -1,0 +1,218 @@
+/**
+ * opendyslexic.test.ts — issue #27
+ *
+ * The OpenDyslexic font toggle binds the user setting to a class on the
+ * overlay modal. The class flip activates the `.modal.opendyslexic` CSS
+ * rule in `styles.ts` which switches `font-family` to the bundled
+ * OpenDyslexic family with a system-ui fallback.
+ *
+ * The bundled font binary is loaded via an `@font-face` rule the overlay
+ * injects into the shadow root at mount, parameterised by
+ * `OverlayOptions.openDyslexicFontUrl` (since `core/` cannot call
+ * `chrome.runtime.getURL`). Injection is scoped to the shadow root so the
+ * declaration does NOT bleed to host-page CSS — the issue's "applies to
+ * the overlay only" constraint.
+ *
+ * Coverage pins:
+ *  - mount with `openDyslexic: false` → no `.opendyslexic` class
+ *  - mount with `openDyslexic: true` → class present
+ *  - mount with `openDyslexic` omitted (legacy callers) → no class
+ *  - subscribeSettings flips toggle on/off without remount
+ *  - `@font-face` rule injected into the shadow root when URL provided
+ *  - `@font-face` NOT injected when URL omitted (toggle still works as
+ *    a pure class flip — graceful degradation per the issue scope note
+ *    that #173's binary may not yet exist)
+ */
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { createOverlay } from '../overlay';
+import type { OverlayOptions, OverlaySettings, SettingsSubscriber } from '../types';
+import { createRsvpEngine } from '../../rsvp-engine';
+import { OVERLAY_CLASS } from '../constants';
+
+const STREAM = ['hello', 'world', 'foo', 'bar'];
+const FONT_URL = 'chrome-extension://stub-extension-id/fonts/OpenDyslexic-Regular.woff2';
+
+function defaultSettings(overrides: Partial<OverlaySettings> = {}): OverlaySettings {
+  return { theme: 'system', wpm: 300, fontSize: 20, ...overrides };
+}
+
+function makeOpts(overrides: Partial<OverlayOptions> = {}): OverlayOptions {
+  return {
+    doc: document,
+    words: STREAM,
+    initialSettings: defaultSettings(),
+    subscribeSettings: () => () => undefined,
+    engineFactory: createRsvpEngine,
+    ...overrides,
+  };
+}
+
+function getShadow(): ShadowRoot {
+  const host = document.body.querySelector('[data-speedreader-overlay]');
+  if (!(host instanceof HTMLElement) || !host.shadowRoot) {
+    throw new Error('overlay host missing or no shadow root');
+  }
+  return host.shadowRoot;
+}
+
+function getModal(): HTMLElement {
+  const el = getShadow().querySelector<HTMLElement>(`.${OVERLAY_CLASS.MODAL}`);
+  if (!el) throw new Error('overlay shadow: missing modal');
+  return el;
+}
+
+/**
+ * Pull every stylesheet text the overlay attached to the shadow root,
+ * concatenated. Works for both the adoptedStyleSheets path (real browsers,
+ * modern jsdom) and the inline `<style>` fallback.
+ */
+function getShadowCss(): string {
+  const shadow = getShadow();
+  const adopted = (shadow as ShadowRoot & { adoptedStyleSheets?: CSSStyleSheet[] })
+    .adoptedStyleSheets;
+  const adoptedCss =
+    adopted && adopted.length > 0
+      ? adopted
+          .map((s) =>
+            Array.from(s.cssRules ?? [])
+              .map((r) => r.cssText)
+              .join('\n'),
+          )
+          .join('\n')
+      : '';
+  const inlineCss = Array.from(shadow.querySelectorAll('style'))
+    .map((el) => el.textContent ?? '')
+    .join('\n');
+  return `${adoptedCss}\n${inlineCss}`;
+}
+
+describe('createOverlay — OpenDyslexic toggle (#27)', () => {
+  beforeEach(() => {
+    document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+  });
+  afterEach(() => {
+    document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+  });
+
+  test('mount with openDyslexic=false does NOT apply the modal class', () => {
+    const overlay = createOverlay(
+      makeOpts({ initialSettings: defaultSettings({ openDyslexic: false }) }),
+    );
+    overlay.mount();
+    expect(getModal().classList.contains(OVERLAY_CLASS.OPENDYSLEXIC)).toBe(false);
+    overlay.unmount();
+  });
+
+  test('mount with openDyslexic=true applies the modal class', () => {
+    const overlay = createOverlay(
+      makeOpts({ initialSettings: defaultSettings({ openDyslexic: true }) }),
+    );
+    overlay.mount();
+    expect(getModal().classList.contains(OVERLAY_CLASS.OPENDYSLEXIC)).toBe(true);
+    overlay.unmount();
+  });
+
+  test('mount with openDyslexic omitted (legacy callers) does NOT apply the modal class', () => {
+    // Defaults intentionally omit `openDyslexic` to model older callers.
+    const overlay = createOverlay(makeOpts());
+    overlay.mount();
+    expect(getModal().classList.contains(OVERLAY_CLASS.OPENDYSLEXIC)).toBe(false);
+    overlay.unmount();
+  });
+
+  test('subscribeSettings push flips the toggle ON without remount', () => {
+    let listener: SettingsSubscriber | undefined;
+    const subscribeSettings = (l: SettingsSubscriber): (() => void) => {
+      listener = l;
+      return () => undefined;
+    };
+    const overlay = createOverlay(
+      makeOpts({
+        initialSettings: defaultSettings({ openDyslexic: false }),
+        subscribeSettings,
+      }),
+    );
+    overlay.mount();
+    expect(getModal().classList.contains(OVERLAY_CLASS.OPENDYSLEXIC)).toBe(false);
+
+    listener?.(defaultSettings({ openDyslexic: true }));
+    expect(getModal().classList.contains(OVERLAY_CLASS.OPENDYSLEXIC)).toBe(true);
+    overlay.unmount();
+  });
+
+  test('subscribeSettings push flips the toggle OFF without remount', () => {
+    let listener: SettingsSubscriber | undefined;
+    const subscribeSettings = (l: SettingsSubscriber): (() => void) => {
+      listener = l;
+      return () => undefined;
+    };
+    const overlay = createOverlay(
+      makeOpts({
+        initialSettings: defaultSettings({ openDyslexic: true }),
+        subscribeSettings,
+      }),
+    );
+    overlay.mount();
+    expect(getModal().classList.contains(OVERLAY_CLASS.OPENDYSLEXIC)).toBe(true);
+
+    listener?.(defaultSettings({ openDyslexic: false }));
+    expect(getModal().classList.contains(OVERLAY_CLASS.OPENDYSLEXIC)).toBe(false);
+    overlay.unmount();
+  });
+
+  test('@font-face for OpenDyslexic is injected into the shadow root when URL provided', () => {
+    const overlay = createOverlay(
+      makeOpts({
+        initialSettings: defaultSettings({ openDyslexic: true }),
+        openDyslexicFontUrl: FONT_URL,
+      }),
+    );
+    overlay.mount();
+    const css = getShadowCss();
+    expect(css).toContain('@font-face');
+    expect(css).toContain('OpenDyslexic');
+    expect(css).toContain(FONT_URL);
+    overlay.unmount();
+  });
+
+  test('@font-face is NOT injected when openDyslexicFontUrl is omitted', () => {
+    const overlay = createOverlay(
+      makeOpts({ initialSettings: defaultSettings({ openDyslexic: true }) }),
+    );
+    overlay.mount();
+    const css = getShadowCss();
+    expect(css).not.toContain('@font-face');
+    // Class still flips — toggle is a pure class flip independent of the
+    // font binary. When #173 lands and the binary appears, the same class
+    // flip starts applying the bundled face.
+    expect(getModal().classList.contains(OVERLAY_CLASS.OPENDYSLEXIC)).toBe(true);
+    overlay.unmount();
+  });
+});
+
+describe('OVERLAY_CSS — OpenDyslexic family stack (#27)', () => {
+  test('`.modal.opendyslexic` declaration sets font-family with OpenDyslexic first and a system-ui fallback', async () => {
+    const { OVERLAY_CSS } = await import('../styles');
+    // Bound the assertion to the load-bearing selector AND the family-order
+    // contract: OpenDyslexic must be the first family in the stack, and
+    // system-ui must appear in the fallback list so a font-load failure
+    // degrades gracefully. A bare `includes('OpenDyslexic')` would survive
+    // someone reordering the stack to put system-ui first (which would
+    // silently disable the toggle's visible effect on browsers that ship
+    // system-ui).
+    expect(OVERLAY_CSS).toMatch(
+      /\.modal\.opendyslexic\s*\{[^}]*font-family:[\s\S]*?'OpenDyslexic'[^}]*system-ui/,
+    );
+  });
+});
+
+describe('buildOpenDyslexicFontFace — @font-face contract (#27)', () => {
+  test('emits a single @font-face rule binding `OpenDyslexic` to the supplied URL with woff2 format', async () => {
+    const { buildOpenDyslexicFontFace } = await import('../styles');
+    const out = buildOpenDyslexicFontFace(FONT_URL);
+    expect(out).toMatch(/@font-face\s*\{/);
+    expect(out).toMatch(/font-family:\s*'OpenDyslexic'/);
+    expect(out).toContain(FONT_URL);
+    expect(out).toMatch(/format\('woff2'\)/);
+  });
+});

--- a/src/core/overlay/__tests__/opendyslexic.test.ts
+++ b/src/core/overlay/__tests__/opendyslexic.test.ts
@@ -188,31 +188,49 @@ describe('createOverlay — OpenDyslexic toggle (#27)', () => {
     expect(getModal().classList.contains(OVERLAY_CLASS.OPENDYSLEXIC)).toBe(true);
     overlay.unmount();
   });
-});
 
-describe('OVERLAY_CSS — OpenDyslexic family stack (#27)', () => {
-  test('`.modal.opendyslexic` declaration sets font-family with OpenDyslexic first and a system-ui fallback', async () => {
-    const { OVERLAY_CSS } = await import('../styles');
-    // Bound the assertion to the load-bearing selector AND the family-order
-    // contract: OpenDyslexic must be the first family in the stack, and
-    // system-ui must appear in the fallback list so a font-load failure
-    // degrades gracefully. A bare `includes('OpenDyslexic')` would survive
-    // someone reordering the stack to put system-ui first (which would
-    // silently disable the toggle's visible effect on browsers that ship
-    // system-ui).
-    expect(OVERLAY_CSS).toMatch(
-      /\.modal\.opendyslexic\s*\{[^}]*font-family:[\s\S]*?'OpenDyslexic'[^}]*system-ui/,
+  test('@font-face rule binds OpenDyslexic to the supplied URL with woff2 format', () => {
+    const overlay = createOverlay(
+      makeOpts({
+        initialSettings: defaultSettings({ openDyslexic: true }),
+        openDyslexicFontUrl: FONT_URL,
+      }),
     );
+    overlay.mount();
+    const css = getShadowCss();
+    expect(css).toMatch(/@font-face\s*\{/);
+    expect(css).toMatch(/font-family:\s*'OpenDyslexic'/);
+    expect(css).toMatch(/format\('woff2'\)/);
+    overlay.unmount();
+  });
+
+  test('mount rejects a malicious openDyslexicFontUrl that tries to escape the url("…") wrapper', () => {
+    // Adversary string: closes the url("…") + format('…') pair, opens a
+    // new body rule, and exfiltrates via background: url('https://evil/…').
+    // The validation guard MUST refuse interpolation — i.e. mount throws —
+    // rather than silently emitting attacker-controlled CSS into the shadow.
+    const malicious = 'a") format("woff2"); } body { background: url("https://evil/';
+    const overlay = createOverlay(
+      makeOpts({
+        initialSettings: defaultSettings({ openDyslexic: true }),
+        openDyslexicFontUrl: malicious,
+      }),
+    );
+    expect(() => overlay.mount()).toThrow(/untrusted URL/);
   });
 });
 
-describe('buildOpenDyslexicFontFace — @font-face contract (#27)', () => {
-  test('emits a single @font-face rule binding `OpenDyslexic` to the supplied URL with woff2 format', async () => {
-    const { buildOpenDyslexicFontFace } = await import('../styles');
-    const out = buildOpenDyslexicFontFace(FONT_URL);
-    expect(out).toMatch(/@font-face\s*\{/);
-    expect(out).toMatch(/font-family:\s*'OpenDyslexic'/);
-    expect(out).toContain(FONT_URL);
-    expect(out).toMatch(/format\('woff2'\)/);
+describe('OVERLAY_CSS — OpenDyslexic family stack (#27)', () => {
+  test('OpenDyslexic family applies to reading-surface selectors with a system-ui fallback', async () => {
+    const { OVERLAY_CSS } = await import('../styles');
+    // Bound the assertion to the reading-surface selector list AND the
+    // family-order contract: OpenDyslexic must be the first family in the
+    // stack, and system-ui must appear in the fallback list so a font-load
+    // failure degrades gracefully. Scope is .word-region / .context-current
+    // / .context-preview (Safari parity floor — UI chrome stays in system
+    // font; whole-modal font swap is a future Chrome-UX extension).
+    expect(OVERLAY_CSS).toMatch(
+      /\.modal\.opendyslexic\s+\.word-region[\s\S]*?\.context-current[\s\S]*?\.context-preview\s*\{[^}]*font-family:[\s\S]*?'OpenDyslexic'[^}]*system-ui/,
+    );
   });
 });

--- a/src/core/overlay/constants.ts
+++ b/src/core/overlay/constants.ts
@@ -29,6 +29,13 @@ export const OVERLAY_CLASS = Object.freeze({
   FONT_INC_BTN: 'font-inc-btn',
   CONTEXT_PREVIEW: 'context-preview',
   CONTEXT_CURRENT: 'context-current',
+  /**
+   * Modifier applied to `.modal` when the user has enabled OpenDyslexic
+   * (#27). The CSS rule overrides `font-family` to the bundled
+   * OpenDyslexic family with a system-ui fallback (so a font-load failure
+   * degrades gracefully rather than rendering invisible text).
+   */
+  OPENDYSLEXIC: 'opendyslexic',
 });
 
 /** DOM ids referenced by ARIA relationships (e.g., aria-labelledby). */

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -1,6 +1,6 @@
 import { applyTheme } from '../theme';
 import type { ThemeId } from '../theme';
-import { OVERLAY_CSS } from './styles';
+import { OVERLAY_CSS, buildOpenDyslexicFontFace } from './styles';
 import { OVERLAY_ATTR, OVERLAY_CLASS, OVERLAY_ID, OVERLAY_TEXT } from './constants';
 import type {
   OverlayCloseSnapshot,
@@ -147,6 +147,26 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       const styleEl = doc.createElement('style');
       styleEl.textContent = OVERLAY_CSS;
       shadow.appendChild(styleEl);
+    }
+
+    // OpenDyslexic (#27) — when the chrome glue supplies the bundled
+    // woff2 URL, inject the `@font-face` rule as an inline <style> sibling
+    // inside the shadow root. The declaration is scoped to this shadow
+    // (per CSS Scoping spec for shadow-root stylesheets) and does NOT
+    // leak to host-page CSS, which satisfies the issue's "overlay only"
+    // constraint. We use an inline <style> rather than an adoptedStyleSheet
+    // entry because adoptedStyleSheets serialise `src: url(...)` through
+    // the CSSOM round-trip, which jsdom drops — keeping the URL on a raw
+    // <style> textContent preserves it for tests AND matches the
+    // declaration shape browsers parse natively.
+    //
+    // Injection is unconditional on URL presence — the modal class governs
+    // whether the family is actually applied — so toggling the setting
+    // mid-session is a pure class flip, not a fresh font fetch.
+    if (opts.openDyslexicFontUrl) {
+      const fontStyle = doc.createElement('style');
+      fontStyle.textContent = buildOpenDyslexicFontFace(opts.openDyslexicFontUrl);
+      shadow.appendChild(fontStyle);
     }
 
     const backdrop = doc.createElement('div');
@@ -373,6 +393,17 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     // (NaN, Infinity, negative) would otherwise write garbage CSS once.
     applyFontSize(clampFontSize(currentFontSize));
 
+    // OpenDyslexic toggle (#27). Treat undefined as false so callers and
+    // tests that pre-date the field continue to work unchanged. Apply at
+    // mount and re-apply on every settings push so toggling from the
+    // options page updates the live overlay without remount.
+    let currentOpenDyslexic = opts.initialSettings.openDyslexic ?? false;
+    const applyOpenDyslexic = (on: boolean): void => {
+      currentOpenDyslexic = on;
+      modal.classList.toggle(OVERLAY_CLASS.OPENDYSLEXIC, on);
+    };
+    applyOpenDyslexic(currentOpenDyslexic);
+
     unsubscribeSettings = opts.subscribeSettings((s) => {
       const resolved = resolveTheme(s.theme, view);
       applyTheme(resolved, modal);
@@ -385,6 +416,10 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       }
       if (s.fontSize !== currentFontSize) {
         applyFontSize(clampFontSize(s.fontSize));
+      }
+      const nextOd = s.openDyslexic ?? false;
+      if (nextOd !== currentOpenDyslexic) {
+        applyOpenDyslexic(nextOd);
       }
     });
 

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -1,6 +1,6 @@
 import { applyTheme } from '../theme';
 import type { ThemeId } from '../theme';
-import { OVERLAY_CSS, buildOpenDyslexicFontFace } from './styles';
+import { OVERLAY_CSS } from './styles';
 import { OVERLAY_ATTR, OVERLAY_CLASS, OVERLAY_ID, OVERLAY_TEXT } from './constants';
 import type {
   OverlayCloseSnapshot,
@@ -97,6 +97,28 @@ function resolveTheme(theme: ThemeId | 'system', win: Window & typeof globalThis
 }
 
 const HOST_ATTR = OVERLAY_ATTR.HOST;
+
+/**
+ * Build the @font-face rule for the OpenDyslexic bundled woff2 (#27).
+ *
+ * Validates the URL shape before interpolation so an unexpected caller
+ * cannot inject CSS via crafted strings. Only `chrome-extension://` URLs
+ * with a non-empty path and no quote/angle-bracket/whitespace characters
+ * are accepted — anything else throws. The single legitimate caller is
+ * `chrome.runtime.getURL()` for the bundled WAR font path.
+ */
+function buildOpenDyslexicFontFace(url: string): string {
+  if (!/^chrome-extension:\/\/[a-zA-Z0-9_-]+\/[^"<>\s]+$/.test(url)) {
+    throw new Error(`buildOpenDyslexicFontFace: untrusted URL ${url}`);
+  }
+  return `@font-face {
+  font-family: 'OpenDyslexic';
+  src: url("${url}") format('woff2');
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+}`;
+}
 
 export function createOverlay(opts: OverlayOptions): OverlayHandle {
   let status: OverlayStatus = 'unmounted';

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -8,6 +8,31 @@
  * prefers-reduced-motion disables chrome transitions only (RSVP cadence
  * is unaffected per spec, since cadence is the format).
  */
+/**
+ * Build the `@font-face` rule for the OpenDyslexic bundled woff2 (#27).
+ *
+ * Called by the overlay at mount when `openDyslexicFontUrl` is provided.
+ * The returned CSS string is injected into the shadow root as a separate
+ * stylesheet so the URL — known only at runtime, since `core/` cannot
+ * call `chrome.runtime.getURL` — stays out of the static OVERLAY_CSS
+ * template. format('woff2') matches the bundled binary (see fonts/README.md
+ * and PR #169).
+ *
+ * The URL is wrapped in `url("…")` with double-quotes; callers MUST pass a
+ * trusted extension URL (e.g. from `chrome.runtime.getURL`) — this helper
+ * does NOT sanitise. The URL surface is controlled by manifest WAR config,
+ * not user input, so escaping is not load-bearing here.
+ */
+export function buildOpenDyslexicFontFace(url: string): string {
+  return `@font-face {
+  font-family: 'OpenDyslexic';
+  src: url("${url}") format('woff2');
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+}`;
+}
+
 export const OVERLAY_CSS = `
 :host {
   all: initial;
@@ -38,6 +63,21 @@ export const OVERLAY_CSS = `
   position: relative;
   container-type: inline-size;
   container-name: rsvp;
+}
+
+/*
+ * OpenDyslexic toggle (#27). The host (CS) injects the matching
+ * @font-face into the shadow root at mount when the bundled woff2 URL
+ * is supplied; this rule activates the family on the modal subtree when
+ * the user has the toggle on. system-ui sits in the fallback stack so a
+ * @font-face load failure degrades to legible text rather than invisible
+ * boxes. The selector is scoped to .modal, so the chrome (buttons +
+ * header) and the word region both render in OpenDyslexic — the entire
+ * reading surface, which is the point of the toggle.
+ */
+.modal.opendyslexic {
+  font-family:
+    'OpenDyslexic', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
 }
 
 .close-btn {

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -8,31 +8,6 @@
  * prefers-reduced-motion disables chrome transitions only (RSVP cadence
  * is unaffected per spec, since cadence is the format).
  */
-/**
- * Build the `@font-face` rule for the OpenDyslexic bundled woff2 (#27).
- *
- * Called by the overlay at mount when `openDyslexicFontUrl` is provided.
- * The returned CSS string is injected into the shadow root as a separate
- * stylesheet so the URL — known only at runtime, since `core/` cannot
- * call `chrome.runtime.getURL` — stays out of the static OVERLAY_CSS
- * template. format('woff2') matches the bundled binary (see fonts/README.md
- * and PR #169).
- *
- * The URL is wrapped in `url("…")` with double-quotes; callers MUST pass a
- * trusted extension URL (e.g. from `chrome.runtime.getURL`) — this helper
- * does NOT sanitise. The URL surface is controlled by manifest WAR config,
- * not user input, so escaping is not load-bearing here.
- */
-export function buildOpenDyslexicFontFace(url: string): string {
-  return `@font-face {
-  font-family: 'OpenDyslexic';
-  src: url("${url}") format('woff2');
-  font-weight: normal;
-  font-style: normal;
-  font-display: swap;
-}`;
-}
-
 export const OVERLAY_CSS = `
 :host {
   all: initial;
@@ -65,17 +40,10 @@ export const OVERLAY_CSS = `
   container-name: rsvp;
 }
 
-/*
- * OpenDyslexic toggle (#27). The host (CS) injects the matching
- * @font-face into the shadow root at mount when the bundled woff2 URL
- * is supplied; this rule activates the family on the modal subtree when
- * the user has the toggle on. system-ui sits in the fallback stack so a
- * @font-face load failure degrades to legible text rather than invisible
- * boxes. The selector is scoped to .modal, so the chrome (buttons +
- * header) and the word region both render in OpenDyslexic — the entire
- * reading surface, which is the point of the toggle.
- */
-.modal.opendyslexic {
+/* OpenDyslexic toggle (#27) — scoped to reading surface only (Safari parity floor). */
+.modal.opendyslexic .word-region,
+.modal.opendyslexic .context-current,
+.modal.opendyslexic .context-preview {
   font-family:
     'OpenDyslexic', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
 }

--- a/src/core/overlay/types.ts
+++ b/src/core/overlay/types.ts
@@ -23,6 +23,16 @@ export interface OverlaySettings {
    * `core/settings/bounds.ts`.
    */
   fontSize: number;
+  /**
+   * OpenDyslexic font toggle (#27). When true, the modal switches to the
+   * bundled OpenDyslexic typeface; when false (or absent), the modal
+   * falls back to system-ui. Optional so existing callers and tests that
+   * pre-date this field continue to type-check — overlay treats `undefined`
+   * as `false`. The font binary is loaded via `@font-face` injected at
+   * mount time, parameterised by `OverlayOptions.openDyslexicFontUrl`
+   * (since `core/` cannot call `chrome.runtime.getURL`).
+   */
+  openDyslexic?: boolean;
 }
 
 export type SettingsSubscriber = (s: OverlaySettings) => void;
@@ -113,6 +123,18 @@ export interface OverlayOptions {
    * updates its local font size for the session.
    */
   onFontSizeChange?: (next: number) => void;
+  /**
+   * Absolute URL of the bundled OpenDyslexic woff2 (#27, #10). The chrome
+   * glue resolves this via `chrome.runtime.getURL('fonts/...')` and passes
+   * it in; `core/` cannot call `chrome.*`. When the URL is provided, the
+   * overlay injects an `@font-face` rule into the shadow root at mount
+   * (scoped to the shadow — does NOT leak to host-page CSS). When omitted,
+   * the OpenDyslexic toggle has no effect (the family name falls through
+   * to the system fallback stack). Callers that toggle `openDyslexic`
+   * without providing this URL still type-check; the modal class is
+   * applied but no custom font loads.
+   */
+  openDyslexicFontUrl?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Bind `openDyslexic` setting → reading-surface (`.word-region`, `.context-current`, `.context-preview`) only
- Family stack `'OpenDyslexic', system-ui, -apple-system, ...` so missing-font degrades gracefully
- `@font-face` injected into shadow root at mount (URL from `chrome.runtime.getURL('fonts/OpenDyslexic-Regular.woff2')`) with URL-shape guard; shadow-scoped, no host-page leakage
- Live update via existing `subscribeSettings` path

Closes #27

## Decisions

- **Scope = reading surface only** (Safari parity floor). UI chrome (buttons, font stepper, glyphs ⏮⏭ A−A+) stays in system font. Whole-modal swap is opt-in follow-up: #178.
- `OverlaySettings.openDyslexic` optional (defaults false) — avoids churning ~10 test fixtures pre-dating this field
- Inject as inline `<style>` not `adoptedStyleSheets` — preserves `src: url(...)` through jsdom CSSOM round-trip
- URL-shape guard on `@font-face` builder rejects anything not matching `chrome-extension://<id>/<path>` (no quotes/angle-brackets/whitespace). Closes the CSS-injection latent defect even though the single trusted caller is safe today.
- `console.warn` when `chrome.runtime.getURL` is unavailable so the silent-no-font case leaves a breadcrumb (replaces silent optional-chain)
- Does NOT block on #173 (font binary). When woff2 lands, real face starts applying; until then, class flip is harmless

## Known trade-off

Until #172 (`use_dynamic_url`) lands, the bundled font URL is fingerprintable cross-origin. The toggle still degrades gracefully if a host CSP blocks the font load.

## Test plan

- [ ] `npm run lint && npm run format:check && npm run test && npm run build` (passes locally — 797 tests)
- [ ] Load unpacked, toggle OpenDyslexic in options, activate reader, confirm reading-surface font changes (falls back to system-ui until #173)
- [ ] Confirm UI chrome (buttons, stepper, glyphs, header) STAYS in system font
- [ ] Inspect host DOM — confirm no `@font-face` outside overlay shadow root
- [ ] Toggle off → on → off while overlay open; confirm live updates without remount

🤖 Generated with [Claude Code](https://claude.com/claude-code)
