### PR TITLE
chore(manifest): adopt use_dynamic_url:true on fonts WAR (#172)

### DIFF
--- a/src/chrome/__tests__/manifest.test.ts
+++ b/src/chrome/__tests__/manifest.test.ts
@@ -28,6 +28,15 @@ describe('manifest — web_accessible_resources for fonts (#10)', () => {
     expect(fontEntry?.matches).toEqual(['<all_urls>']);
   });
 
+  it('sets use_dynamic_url:true to block cross-extension fingerprinting (#172)', () => {
+    // Without use_dynamic_url, any page can probe
+    // `chrome-extension://<static-id>/fonts/OpenDyslexic-Regular.woff2` and
+    // detect SpeedReader installation via a successful fetch. The dynamic
+    // URL rotates per-session, blocking enumeration. Ring security-adversary
+    // flagged this on PR #169.
+    expect(fontEntry?.use_dynamic_url).toBe(true);
+  });
+
   it('chrome.runtime.getURL composes a usable extension URL for the font', () => {
     // Smoke-test the API shape the overlay will call. We stub
     // chrome.runtime.getURL to mirror Chrome's deterministic

--- a/src/chrome/manifest.ts
+++ b/src/chrome/manifest.ts
@@ -90,11 +90,20 @@ export default {
   // URL must be reachable from any origin. Tightening this list to specific
   // origins would require enumerating every page the overlay can ever run on,
   // which the lazy-injection model intentionally avoids.
+  // `use_dynamic_url` is a valid MV3 WAR field (rotates the extension-resource
+  // origin per session so arbitrary pages cannot probe
+  // `chrome-extension://<static-id>/fonts/*` to fingerprint SpeedReader
+  // installation — ring security-adversary flagged this on PR #169, see
+  // issue #172). The `@types/chrome` definition of
+  // `web_accessible_resources` is currently `Array<{ resources: string[];
+  // matches: string[] }>` and does not declare the field, so we widen the
+  // entry type locally rather than adding an ambient `.d.ts` augmentation.
   web_accessible_resources: [
     {
       resources: ['fonts/*'],
       matches: ['<all_urls>'],
-    },
+      use_dynamic_url: true,
+    } as { resources: string[]; matches: string[]; use_dynamic_url: boolean },
   ],
 
   // --- Commands (keyboard shortcuts) --------------------------------------


### PR DESCRIPTION
## Summary

- Add `use_dynamic_url: true` to the fonts WAR entry in `src/chrome/manifest.ts` — rotates a per-session GUID on the extension origin so arbitrary pages cannot enumerate `chrome-extension://<static-id>/fonts/*` to fingerprint SpeedReader installation.
- Extend `src/chrome/__tests__/manifest.test.ts` with an assertion on the new field (mutation-test verified — assertion flips red when the field is removed).
- Cache-audit of the overlay font path: `src/chrome/content/index.ts` resolves the URL per-overlay-mount, no cross-session `chrome.storage` persistence, so URL rotation is safe.

Closes #172.

## Implementation notes

`@types/chrome`'s `Manifest.web_accessible_resources` entry does not declare `use_dynamic_url`. Resolved with a local cast on the single WAR entry + 6-line comment, scoped tighter than an ambient `.d.ts` augmentation.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — `All matched files use Prettier code style!`
- [x] `npm run test` — 64 files / 908 tests pass
- [x] `npm run build` — tsc + vite green; grep'd `dist/manifest.json` for `"use_dynamic_url": true` on fonts WAR — present
- [x] Mutation check — removed the field, manifest assertion flipped red; restored, green
- [x] Overlay cache audit — no cross-session URL caching found

## References

- PR #169 ring security-adversary finding #1
- [MV3 web_accessible_resources docs](https://developer.chrome.com/docs/extensions/reference/manifest/web-accessible-resources)
