### PR TITLE
fix(overlay): dyslexia-friendly font fallback chain (#190)

### DIFF
--- a/src/core/overlay/__tests__/font-picker.test.ts
+++ b/src/core/overlay/__tests__/font-picker.test.ts
@@ -193,10 +193,11 @@ describe('createOverlay — font picker (#28)', () => {
     overlay.unmount();
   });
 
-  test('missing OpenDyslexic binary falls back to system-ui without throwing', () => {
+  test('missing OpenDyslexic binary falls back to system stack without throwing', () => {
     // No openDyslexicFontUrl — the binary is missing per #173 sourcing gap.
     // Mount must succeed and the modal class still flips so the family stack
-    // in styles.ts degrades to system-ui (the fallback list ends in sans-serif).
+    // in styles.ts degrades through the dyslexia-friendly fallback chain
+    // (Atkinson Hyperlegible → Comic Sans MS → Trebuchet MS → system-ui, see #190).
     const overlay = createOverlay(
       makeOpts({ initialSettings: defaultSettings({ font: 'opendyslexic' }) }),
     );
@@ -305,5 +306,106 @@ describe('OVERLAY_CSS — font picker family stacks (#28)', () => {
     const match = OVERLAY_CSS.match(selectorBlock);
     expect(match, `missing .modal.${fontId} reading-surface rule`).not.toBeNull();
     expect(match?.[0]).toMatch(expectedFamily);
+  });
+});
+
+describe('OVERLAY_CSS — opendyslexic dyslexia-friendly fallback chain (#190)', () => {
+  /**
+   * If the bundled OpenDyslexic WOFF2 fails to load (404 from extension
+   * packaging bug, integrity-guard regression, future Chromium tightening
+   * on extension-internal fetches, mid-install offline window), the
+   * font-family chain decides what the user actually reads. Silent
+   * fallback to system-ui (San Francisco / Segoe UI / Roboto) defeats
+   * the headline a11y feature.
+   *
+   * The chain must prefer typefaces with dyslexia-friendly letterforms
+   * BEFORE the generic system stack:
+   *   - Atkinson Hyperlegible (Braille Institute) — explicitly designed for
+   *     low-vision and disambiguation; ships on some platforms, downloadable
+   *   - Comic Sans MS — research-cited dyslexia-friendly (asymmetric
+   *     letterforms, letter disambiguation); preinstalled Windows + macOS
+   *   - Trebuchet MS — also cited in dyslexia-readability research;
+   *     preinstalled cross-platform
+   *
+   * These assertions are ORDER-anchored on the substring positions in the
+   * font-family declaration so a contributor reshuffling the chain (or
+   * deleting one of the dyslexia-friendly fallbacks) surfaces here rather
+   * than silently dropping the floor.
+   */
+  async function getOpenDyslexicFamilyDecl(): Promise<string> {
+    const { OVERLAY_CSS } = await import('../styles');
+    const block = OVERLAY_CSS.match(
+      /\.modal\.opendyslexic\s+\.word-region[\s\S]*?\.context-preview\s*\{([\s\S]*?)\}/,
+    );
+    if (!block) throw new Error('missing .modal.opendyslexic reading-surface rule');
+    const fontFamily = block[1].match(/font-family:\s*([^;]+);/);
+    if (!fontFamily) throw new Error('missing font-family declaration in opendyslexic rule');
+    return fontFamily[1];
+  }
+
+  test('OpenDyslexic is the first family in the stack (index 0)', async () => {
+    const decl = await getOpenDyslexicFamilyDecl();
+    // Strip whitespace then check the first non-whitespace token.
+    const firstFamily = decl.trim().split(',')[0].trim();
+    expect(firstFamily).toBe("'OpenDyslexic'");
+  });
+
+  test.each([
+    ['Atkinson Hyperlegible', /'Atkinson Hyperlegible'/],
+    ['Comic Sans MS', /'Comic Sans MS'/],
+    ['Trebuchet MS', /'Trebuchet MS'/],
+  ])('dyslexia-friendly fallback "%s" is present in the stack', async (_label, pattern) => {
+    const decl = await getOpenDyslexicFamilyDecl();
+    expect(decl).toMatch(pattern);
+  });
+
+  test.each([
+    ['Atkinson Hyperlegible', "'Atkinson Hyperlegible'"],
+    ['Comic Sans MS', "'Comic Sans MS'"],
+    ['Trebuchet MS', "'Trebuchet MS'"],
+  ])('dyslexia-friendly fallback "%s" appears BEFORE system-ui', async (_label, family) => {
+    const decl = await getOpenDyslexicFamilyDecl();
+    const familyIdx = decl.indexOf(family);
+    const systemUiIdx = decl.indexOf('system-ui');
+    expect(familyIdx, `expected ${family} in stack`).toBeGreaterThanOrEqual(0);
+    expect(systemUiIdx, 'expected system-ui in stack as generic floor').toBeGreaterThanOrEqual(0);
+    expect(familyIdx).toBeLessThan(systemUiIdx);
+  });
+
+  test('the dyslexia-friendly trio appears in the canonical order Atkinson → Comic Sans → Trebuchet', async () => {
+    // Order anchor: Atkinson is the highest-fidelity dyslexia face (modern,
+    // designed for the use case), Comic Sans is the most-installed research-
+    // backed fallback, Trebuchet is the third research-cited option. Any
+    // reshuffle (e.g. Comic Sans first) surfaces here so the rationale stays
+    // visible — order is the documented decision, not an accident.
+    const decl = await getOpenDyslexicFamilyDecl();
+    const atkinson = decl.indexOf("'Atkinson Hyperlegible'");
+    const comic = decl.indexOf("'Comic Sans MS'");
+    const trebuchet = decl.indexOf("'Trebuchet MS'");
+    expect(atkinson).toBeGreaterThanOrEqual(0);
+    expect(comic).toBeGreaterThan(atkinson);
+    expect(trebuchet).toBeGreaterThan(comic);
+  });
+
+  test('non-OpenDyslexic themes do NOT carry the dyslexia-friendly fallbacks', async () => {
+    // Surgical-scope guard: the fix changes only the .opendyslexic chain.
+    // If a contributor accidentally bulk-inserts Atkinson into the serif or
+    // monospace themes, this surfaces so we can decide explicitly rather
+    // than drifting the other themes' identities.
+    const { OVERLAY_CSS } = await import('../styles');
+    for (const themeId of ['newYork', 'georgia', 'menlo'] as const) {
+      const block = OVERLAY_CSS.match(
+        new RegExp(
+          `\\.modal\\.${themeId}\\s+\\.word-region[\\s\\S]*?\\.context-preview\\s*\\{([\\s\\S]*?)\\}`,
+        ),
+      );
+      if (!block) throw new Error(`missing .modal.${themeId} reading-surface rule`);
+      const body = block[1];
+      expect(body, `${themeId} should not carry Atkinson Hyperlegible`).not.toMatch(
+        /Atkinson Hyperlegible/,
+      );
+      expect(body, `${themeId} should not carry Comic Sans MS`).not.toMatch(/Comic Sans MS/);
+      expect(body, `${themeId} should not carry Trebuchet MS`).not.toMatch(/Trebuchet MS/);
+    }
   });
 });

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -49,8 +49,16 @@ export const OVERLAY_CSS = `
 .modal.opendyslexic .word-region,
 .modal.opendyslexic .context-current,
 .modal.opendyslexic .context-preview {
+  /* Fallback chain ordered for dyslexia readability — generic system-ui
+   * only as last resort. Atkinson Hyperlegible (Braille Institute,
+   * downloadable / ships on some platforms), Comic Sans MS (research-
+   * cited dyslexia-friendly letter disambiguation; preinstalled on
+   * Windows + macOS), and Trebuchet MS (also research-cited; preinstalled
+   * cross-platform) keep the user on a dyslexia-friendly face when the
+   * bundled OpenDyslexic WOFF2 fails to load. See #190. */
   font-family:
-    'OpenDyslexic', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+    'OpenDyslexic', 'Atkinson Hyperlegible', 'Comic Sans MS',
+    'Trebuchet MS', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
 }
 
 .modal.newYork .word-region,


### PR DESCRIPTION
## Summary

- Extend `.modal.opendyslexic` font-family chain in `src/core/overlay/styles.ts` to insert dyslexia-adjacent system fallbacks before the generic `system-ui` / `sans-serif` floor. New chain: `'OpenDyslexic', 'Atkinson Hyperlegible', 'Comic Sans MS', 'Trebuchet MS', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif`.
- Add a regression-anchor describe block to `src/core/overlay/__tests__/font-picker.test.ts` (6 tests): asserts OpenDyslexic at index 0, dyslexia stack before system-ui, canonical order (Atkinson → Comic Sans → Trebuchet), non-OpenDyslexic themes unchanged.
- Update one pre-existing test docstring that referenced "falls back to system-ui" to reflect the new chain — orphaned by the styles change (Karpathy #3 boundary).

Closes #190 — the last phase-1 issue.

## Rationale

- **Atkinson Hyperlegible** — Braille Institute font; ships preinstalled on some platforms, downloadable elsewhere
- **Comic Sans MS** — research-cited dyslexia-friendly (high letter disambiguation, asymmetric letterforms); preinstalled Windows + macOS
- **Trebuchet MS** — also cited in dyslexia-readability research; preinstalled cross-platform

If the bundled OpenDyslexic WAR 404s (extension bug, future Chromium tightening, integrity-guard regression, mid-install offline), users land on a dyslexia-friendly face rather than silently on San Francisco / Segoe UI / Roboto.

## Mutation evidence

Swapped Atkinson and Comic Sans order in `styles.ts`:
```
'OpenDyslexic', 'Atkinson Hyperlegible', 'Comic Sans MS', …
                ↓ mutated to ↓
'OpenDyslexic', 'Comic Sans MS', 'Atkinson Hyperlegible', …
```
Result — exactly one assertion flipped RED, the canonical-order test:
```
AssertionError: expected 16 to be greater than 33
  expect(comic).toBeGreaterThan(atkinson);
```
Order assertion is non-tautological. Presence + before-system-ui tests stayed green — correct separation (they catch deletion / system-ui regression, a different defect class).

## Test plan

- [x] `npm run lint` — clean (refactored `!` assertions to `if (!x) throw` to satisfy `--max-warnings=0`)
- [x] `npm run format:check` — clean
- [x] `npm run test` — 65 files / 925 tests pass (+6 new)
- [x] `npm run build` — clean
- [x] `npm run verify:fonts` — ok
- [x] Mutation evidence — order swap fires red on exactly the order assertion, leaves the others green

## References

- PR #188 (#173) ring a11y-extension-designer HOLD #2 (origin of this issue)
