### PR TITLE
harden font integrity guard — duplicate pins, OFL.txt, license-arm coverage (#189)

### DIFF
--- a/bin/__tests__/verify-font-integrity.test.ts
+++ b/bin/__tests__/verify-font-integrity.test.ts
@@ -199,4 +199,157 @@ describe('verify-font-integrity.sh', () => {
     expect(result.status).not.toBe(0);
     expect(result.stderr).toMatch(/no \*\.woff2 files/);
   });
+
+  // ── F1 — Pin-parser uniqueness ────────────────────────────────────────
+  // grep | head -n 1 silently picks the first match. A future README
+  // with two pin lines for the same basename (e.g., commented-out
+  // "history" pin above the real one) would let a swapped binary pass.
+  // Assert exactly-one pin per basename.
+
+  it('exits non-zero when README has duplicate pin lines for the same basename (F1)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'verify-font-dup-pin-'));
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(dir, 'OpenDyslexic-Regular.woff2'),
+    );
+    copyFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'), join(dir, 'OFL.txt'));
+
+    const realReadme = readFileSync(join(REPO_ROOT, 'fonts', 'README.md'), 'utf8');
+    // Inject a SECOND pin line for OpenDyslexic-Regular.woff2 with a
+    // different (also-syntactically-valid) hash. The real pin line is
+    // unchanged — so a `head -n 1` parser would pass; a uniqueness
+    // assertion must fail.
+    const duplicated = realReadme.replace(
+      /(OpenDyslexic-Regular\.woff2\s+sha256:[0-9a-f]{64}[^\n]*\n)/,
+      'OpenDyslexic-Regular.woff2  sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef  source:history\n$1',
+    );
+    expect(duplicated).not.toBe(realReadme); // sanity
+    writeFileSync(join(dir, 'README.md'), duplicated);
+
+    const result = runScript(dir);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/DUPLICATE PIN/);
+    expect(result.stderr).toMatch(/OpenDyslexic-Regular\.woff2/);
+  });
+
+  // ── F2 — Multi-file integrity (OFL.txt + non-woff2 pins) ──────────────
+  // README pins OFL.txt; guard must enforce it (not just the .woff2 glob).
+
+  it('exits 0 when both woff2 and OFL.txt pins match on disk (F2 happy path)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'verify-font-multifile-ok-'));
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(dir, 'OpenDyslexic-Regular.woff2'),
+    );
+    copyFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'), join(dir, 'OFL.txt'));
+    copyFileSync(join(REPO_ROOT, 'fonts', 'README.md'), join(dir, 'README.md'));
+
+    const result = runScript(dir);
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/ok\s+OpenDyslexic-Regular\.woff2/);
+    expect(result.stdout).toMatch(/ok\s+OFL\.txt/);
+  });
+
+  it('exits non-zero when OFL.txt content is perturbed (F2 mutation)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'verify-font-ofl-mutation-'));
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(dir, 'OpenDyslexic-Regular.woff2'),
+    );
+    copyFileSync(join(REPO_ROOT, 'fonts', 'README.md'), join(dir, 'README.md'));
+    // Perturb OFL.txt — append a stray byte. Real file unchanged; only
+    // the on-disk fixture diverges from the pinned hash.
+    const realOfl = readFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'));
+    writeFileSync(join(dir, 'OFL.txt'), Buffer.concat([realOfl, Buffer.from('!')]));
+
+    const result = runScript(dir);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/HASH MISMATCH/);
+    expect(result.stderr).toMatch(/OFL\.txt/);
+  });
+
+  it('exits non-zero when README pins a file that is missing on disk (F2)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'verify-font-missing-pinned-'));
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(dir, 'OpenDyslexic-Regular.woff2'),
+    );
+    copyFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'), join(dir, 'OFL.txt'));
+
+    const realReadme = readFileSync(join(REPO_ROOT, 'fonts', 'README.md'), 'utf8');
+    // Inject a pin line for a phantom file. Other pins are real.
+    const augmented = realReadme.replace(
+      /(```\n)(OpenDyslexic-Regular\.woff2)/,
+      '$1ghost-file.woff2            sha256:0000000000000000000000000000000000000000000000000000000000000000  source:none\n$2',
+    );
+    expect(augmented).not.toBe(realReadme);
+    writeFileSync(join(dir, 'README.md'), augmented);
+
+    const result = runScript(dir);
+    expect(result.status).not.toBe(0);
+    // Require the script's own diagnostic, not a stray shasum error —
+    // a mutation that drops the existence check would let shasum fail
+    // under `set -e` and produce a "No such file" message that would
+    // pass a loose regex without exercising the guard.
+    expect(result.stderr).toMatch(/pinned file missing on disk/);
+    expect(result.stderr).toMatch(/ghost-file\.woff2/);
+  });
+
+  // ── F3 — License-sibling asymmetric arm tests ─────────────────────────
+  // Existing tests only cover OFL.txt-present and all-absent. The
+  // LICENSE* glob arm (line 57-62) is reachable only when OFL.txt is
+  // absent — regression-pin each acceptable license filename.
+
+  it('exits 0 when only LICENSE (no OFL.txt) is present (F3)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'verify-font-license-only-'));
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(dir, 'OpenDyslexic-Regular.woff2'),
+    );
+    // Rename OFL.txt → LICENSE; README's OFL.txt pin gets stripped so
+    // the F2 enforcement layer doesn't reject the renamed file. The
+    // license-sibling check is what's under test here.
+    copyFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'), join(dir, 'LICENSE'));
+    const realReadme = readFileSync(join(REPO_ROOT, 'fonts', 'README.md'), 'utf8');
+    const stripped = realReadme.replace(/^OFL\.txt[^\n]*\n/m, '');
+    writeFileSync(join(dir, 'README.md'), stripped);
+
+    const result = runScript(dir);
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+  });
+
+  it('exits 0 when only LICENSE.md (no OFL.txt) is present (F3)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'verify-font-license-md-only-'));
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(dir, 'OpenDyslexic-Regular.woff2'),
+    );
+    copyFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'), join(dir, 'LICENSE.md'));
+    const realReadme = readFileSync(join(REPO_ROOT, 'fonts', 'README.md'), 'utf8');
+    const stripped = realReadme.replace(/^OFL\.txt[^\n]*\n/m, '');
+    writeFileSync(join(dir, 'README.md'), stripped);
+
+    const result = runScript(dir);
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+  });
+
+  it('exits 0 when only OFL.txt is present (F3 regression pin)', () => {
+    // This is the path the existing happy-path test exercises, but
+    // pinned explicitly here so a future refactor that reorders the
+    // license-arm logic surfaces the regression.
+    const dir = mkdtempSync(join(tmpdir(), 'verify-font-ofl-only-'));
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(dir, 'OpenDyslexic-Regular.woff2'),
+    );
+    copyFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'), join(dir, 'OFL.txt'));
+    copyFileSync(join(REPO_ROOT, 'fonts', 'README.md'), join(dir, 'README.md'));
+
+    const result = runScript(dir);
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+  });
 });

--- a/bin/__tests__/verify-font-integrity.test.ts
+++ b/bin/__tests__/verify-font-integrity.test.ts
@@ -352,4 +352,231 @@ describe('verify-font-integrity.sh', () => {
     expect(result.stderr).toBe('');
     expect(result.status).toBe(0);
   });
+
+  // ── TG1 — LICENSE.txt arm regression-pin (issue #189 ring) ────────────
+  // F3 covered LICENSE / LICENSE.md / OFL.txt. The LICENSE* glob also
+  // matches LICENSE.txt; without an explicit test, a future refactor
+  // narrowing the glob would silently break valid LICENSE.txt-only
+  // directories.
+
+  it('exits 0 when only LICENSE.txt (no OFL.txt) is present (TG1)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'verify-font-license-txt-only-'));
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(dir, 'OpenDyslexic-Regular.woff2'),
+    );
+    copyFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'), join(dir, 'LICENSE.txt'));
+    const realReadme = readFileSync(join(REPO_ROOT, 'fonts', 'README.md'), 'utf8');
+    const stripped = realReadme.replace(/^OFL\.txt[^\n]*\n/m, '');
+    writeFileSync(join(dir, 'README.md'), stripped);
+
+    const result = runScript(dir);
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+  });
+
+  // ── SH1 — Path-traversal basename rejection (issue #189 ring) ─────────
+  // Pin parser previously accepted ANY non-whitespace token as basename;
+  // a pin line `../../etc/passwd  sha256:0000…` would have caused
+  // `shasum -a 256 fonts/../../etc/passwd` to run and leak the hash of
+  // /etc/passwd into CI logs via the `HASH MISMATCH actual: <hash>`
+  // diagnostic. Validate basenames to safe charset only.
+
+  it('exits non-zero on path-traversal basename and does NOT hash the traversal target (SH1)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'verify-font-traversal-'));
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(dir, 'OpenDyslexic-Regular.woff2'),
+    );
+    copyFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'), join(dir, 'OFL.txt'));
+
+    const realReadme = readFileSync(join(REPO_ROOT, 'fonts', 'README.md'), 'utf8');
+    // Inject a traversal pin line inside the fence block.
+    const malicious = realReadme.replace(
+      /(OpenDyslexic-Regular\.woff2\s+sha256:[0-9a-f]{64}[^\n]*\n)/,
+      '../../etc/hostname          sha256:0000000000000000000000000000000000000000000000000000000000000000  source:attack\n$1',
+    );
+    expect(malicious).not.toBe(realReadme);
+    writeFileSync(join(dir, 'README.md'), malicious);
+
+    const result = runScript(dir);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/invalid pin basename/);
+    // CRITICAL — no shasum was run against the traversal target. If the
+    // guard merely warned but still hashed, a "HASH MISMATCH" line for
+    // ../../etc/hostname would appear in stderr leaking the hash.
+    expect(result.stderr).not.toMatch(/HASH MISMATCH[\s\S]*hostname/);
+  });
+
+  // ── TG2 — Malformed pin must surface, not silently bypass (issue #189) ──
+  // Strict pin_re filters out malformed lines, so a duplicate-with-malformed
+  // case slips past F1. Detect pin-shaped attempts (basename + sha256
+  // keyword) and error if the hash isn't well-formed.
+
+  it('exits non-zero when README has a SHORT-hash pin attempt (TG2)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'verify-font-malformed-short-'));
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(dir, 'OpenDyslexic-Regular.woff2'),
+    );
+    copyFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'), join(dir, 'OFL.txt'));
+
+    const realReadme = readFileSync(join(REPO_ROOT, 'fonts', 'README.md'), 'utf8');
+    const malformed = realReadme.replace(
+      /(OpenDyslexic-Regular\.woff2\s+sha256:[0-9a-f]{64}[^\n]*\n)/,
+      'OpenDyslexic-Regular.woff2  sha256:DEADBEEF  source:short\n$1',
+    );
+    expect(malformed).not.toBe(realReadme);
+    writeFileSync(join(dir, 'README.md'), malformed);
+
+    const result = runScript(dir);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/malformed pin/);
+  });
+
+  it('exits non-zero when README has a UPPERCASE-keyword pin attempt (TG2)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'verify-font-malformed-typo-'));
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(dir, 'OpenDyslexic-Regular.woff2'),
+    );
+    copyFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'), join(dir, 'OFL.txt'));
+
+    const realReadme = readFileSync(join(REPO_ROOT, 'fonts', 'README.md'), 'utf8');
+    const malformed = realReadme.replace(
+      /(OpenDyslexic-Regular\.woff2\s+sha256:[0-9a-f]{64}[^\n]*\n)/,
+      'second-font.woff2           SHA256:0000000000000000000000000000000000000000000000000000000000000000  source:typo\n$1',
+    );
+    expect(malformed).not.toBe(realReadme);
+    writeFileSync(join(dir, 'README.md'), malformed);
+
+    const result = runScript(dir);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/malformed pin/);
+  });
+
+  it('exits non-zero when README has a TOO-LONG hash pin attempt (TG2)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'verify-font-malformed-long-'));
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(dir, 'OpenDyslexic-Regular.woff2'),
+    );
+    copyFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'), join(dir, 'OFL.txt'));
+
+    const realReadme = readFileSync(join(REPO_ROOT, 'fonts', 'README.md'), 'utf8');
+    // 80-hex-char hash (well-formed chars but wrong length).
+    const malformed = realReadme.replace(
+      /(OpenDyslexic-Regular\.woff2\s+sha256:[0-9a-f]{64}[^\n]*\n)/,
+      'OpenDyslexic-Regular.woff2  sha256:0441bc21071e42db57c217f93fbc48d3b55a2987c02814c94dc93621c42e86950000000000000000  source:long\n$1',
+    );
+    expect(malformed).not.toBe(realReadme);
+    writeFileSync(join(dir, 'README.md'), malformed);
+
+    const result = runScript(dir);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/malformed pin/);
+  });
+
+  // ── SH2 — Pin parser must be fence-aware (issue #189 ring) ────────────
+  // Pin extraction was a whole-file grep with no markdown-fence awareness.
+  // A pin-shaped line in a quote block / outside-fence example could be
+  // parsed as authoritative.
+
+  it('IGNORES a pin-shaped line outside any triple-backtick fence (SH2)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'verify-font-fence-ignore-'));
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(dir, 'OpenDyslexic-Regular.woff2'),
+    );
+    copyFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'), join(dir, 'OFL.txt'));
+
+    const realReadme = readFileSync(join(REPO_ROOT, 'fonts', 'README.md'), 'utf8');
+    // Append a flush-left pin-shaped example OUTSIDE any fence, with a
+    // deliberately DIFFERENT sha256 for the same basename. The line is
+    // shaped exactly like a real pin (basename + sha256 + source) so
+    // a non-fence-aware grep WILL match it; a fence-aware parser must
+    // ignore it. If non-fence-aware, F1 fires DUPLICATE PIN.
+    const withOutsideExample =
+      realReadme +
+      '\n## Example (not authoritative — outside fence)\n\n' +
+      'OpenDyslexic-Regular.woff2  sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef  source:example\n';
+    writeFileSync(join(dir, 'README.md'), withOutsideExample);
+
+    const result = runScript(dir);
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/ok\s+OpenDyslexic-Regular\.woff2/);
+  });
+
+  it('detects duplicate pins when both live INSIDE fences (SH2)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'verify-font-fence-dup-'));
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(dir, 'OpenDyslexic-Regular.woff2'),
+    );
+    copyFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'), join(dir, 'OFL.txt'));
+
+    const realReadme = readFileSync(join(REPO_ROOT, 'fonts', 'README.md'), 'utf8');
+    // Append a SECOND fence block with a duplicate pin for the same
+    // basename. Both fences are authoritative → DUPLICATE PIN must fire.
+    const withSecondFence =
+      realReadme +
+      '\n## Second authoritative fence\n\n```\n' +
+      'OpenDyslexic-Regular.woff2  sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef  source:dup\n' +
+      '```\n';
+    writeFileSync(join(dir, 'README.md'), withSecondFence);
+
+    const result = runScript(dir);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/DUPLICATE PIN/);
+    expect(result.stderr).toMatch(/OpenDyslexic-Regular\.woff2/);
+  });
+
+  // ── SH3 — --check-dist must share the pin-lookup code path (issue #189) ──
+  // Source loop was rewritten in F2 to iterate pin_lines; dist loop still
+  // used the old `grep -E "^${basename}…"` pattern with shell interpolation
+  // (regex-metachar injection class) and lookup-inconsistency risk.
+
+  it('--check-dist surfaces a pinned woff2 missing from dist/ (SH3)', () => {
+    // SH3 reshape: dist loop must iterate the pinned woff2 set (not the
+    // dist/*.woff2 glob), so a pin that's present in fonts/ AND README
+    // but ABSENT from dist/ surfaces. The old "iterate dist files,
+    // lookup pin" loop silently missed this class (Vite-plugin failed
+    // to emit a specific woff2 → no diagnostic; only the all-empty case
+    // fired).
+    const fontsDir = mkdtempSync(join(tmpdir(), 'verify-font-dist-sh3-fonts-'));
+    const distDir = mkdtempSync(join(tmpdir(), 'verify-font-dist-sh3-dist-'));
+
+    // Two pinned woff2 in fonts/, only one emitted to dist/.
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(fontsDir, 'OpenDyslexic-Regular.woff2'),
+    );
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(fontsDir, 'second-font.woff2'),
+    );
+    copyFileSync(join(REPO_ROOT, 'fonts', 'OFL.txt'), join(fontsDir, 'OFL.txt'));
+
+    // dist/ has only the first font — second-font.woff2 is missing.
+    copyFileSync(
+      join(REPO_ROOT, 'fonts', 'OpenDyslexic-Regular.woff2'),
+      join(distDir, 'OpenDyslexic-Regular.woff2'),
+    );
+
+    const realReadme = readFileSync(join(REPO_ROOT, 'fonts', 'README.md'), 'utf8');
+    // Add a pin for second-font.woff2 (same hash since it's a copy of
+    // the real binary), inside the existing fence.
+    const augmented = realReadme.replace(
+      /(```\n)(OpenDyslexic-Regular\.woff2)/,
+      '$1second-font.woff2           sha256:0441bc21071e42db57c217f93fbc48d3b55a2987c02814c94dc93621c42e8695  source:test\n$2',
+    );
+    expect(augmented).not.toBe(realReadme);
+    writeFileSync(join(fontsDir, 'README.md'), augmented);
+
+    const result = runScript(fontsDir, { args: ['--check-dist'], distDir });
+    expect(result.status).not.toBe(0);
+    // The dist loop must report second-font.woff2 as missing from dist.
+    expect(result.stderr).toMatch(/dist pinned file missing[\s\S]*second-font\.woff2/);
+  });
 });

--- a/bin/verify-font-integrity.sh
+++ b/bin/verify-font-integrity.sh
@@ -73,16 +73,78 @@ fi
 
 status=0
 
-# Collect all pin lines from README. Format (one per line):
-#   <basename>  sha256:<hex>  source:...
+# Collect pin lines from README. Format (one per line, inside a triple-
+# backtick fence):
+#   <basename>  sha256:<64-hex>  source:...
+#
 # Pin parser is intentionally extension-agnostic — woff2 binaries AND
 # license/text siblings (OFL.txt etc.) get enforced uniformly.
-# Avoid `mapfile` (bash 4+) for macOS /usr/bin/bash 3.2 compatibility.
-pin_re='^[^[:space:]]+[[:space:]]+sha256:[0-9a-f]{64}'
+#
+# Three hardenings (issue #189 ring follow-ups):
+#   SH2 — fence-aware: only lines INSIDE a triple-backtick fence are
+#         considered. A pin-shaped line in a quote block or "## Example"
+#         section outside the fence is ignored. Without this, an
+#         informational example could shadow or duplicate a real pin.
+#   TG2 — malformed-pin detection: a line that LOOKS like a pin attempt
+#         (basename + `sha256` keyword) but doesn't match the strict form
+#         is surfaced as an error rather than silently filtered out.
+#         Catches typo'd `SHA256:`, short hashes, oversized hashes.
+#   SH1 — basename validation deferred to the per-pin loop below; reject
+#         anything outside `[A-Za-z0-9._-]+` to prevent path traversal
+#         turning the diagnostic stream into a hash-disclosure primitive.
+#
+# Single-pass awk is bash-3.2 safe (no associative arrays here, no
+# mapfile). The script emits one line per accepted pin and a `MALFORMED:`
+# prefix per rejected pin attempt; the bash loop below treats the latter
+# as a hard error.
+#
+# Strict pin shape: any non-whitespace basename + lowercase `sha256:` +
+# exactly 64 lowercase hex. Basename character-class validation happens
+# in the per-pin loop below (SH1) so that an invalid-basename pin gets
+# its own diagnostic distinct from a malformed-hash pin (TG2).
+#
+# Loose pin-attempt shape: non-whitespace basename + any-case `sha256`
+# keyword. Lines matching loose but NOT strict are surfaced as
+# malformed — catches short hashes, oversized hashes, typo'd `SHA256:`.
 pin_lines=()
+malformed_lines=()
 while IFS= read -r _line; do
-  pin_lines+=("${_line}")
-done < <(grep -E "${pin_re}" "${README}" || true)
+  case "${_line}" in
+    MALFORMED:*)
+      malformed_lines+=("${_line#MALFORMED:}")
+      ;;
+    *)
+      pin_lines+=("${_line}")
+      ;;
+  esac
+done < <(
+  awk '
+    BEGIN { in_fence = 0 }
+    /^[[:space:]]*```/ { in_fence = !in_fence; next }
+    in_fence == 0 { next }
+    # Inside fence — classify the line.
+    /^[^[:space:]]+[[:space:]]+sha256:[0-9a-f]{64}([[:space:]]|$)/ {
+      print $0
+      next
+    }
+    # Loose detector: pin-shape attempt + sha256 keyword (case-insensitive)
+    # that did not match strict. Surface as malformed.
+    /^[^[:space:]]+[[:space:]]+[sS][hH][aA]256[:[:space:]]/ {
+      print "MALFORMED:" $0
+      next
+    }
+  ' "${README}"
+)
+
+# Surface malformed pin attempts before any per-pin processing — these
+# indicate intent to pin but a syntactic break (truncated hash, typo'd
+# keyword, oversized hash). A future README with a typo would otherwise
+# silently drop the pin and the woff2 enumeration below would catch it
+# as "no pinned sha256", but the diagnostic would be misleading.
+for ml in "${malformed_lines[@]+"${malformed_lines[@]}"}"; do
+  echo "verify-font-integrity: malformed pin: ${ml}" >&2
+  status=1
+done
 
 # Track which basenames we've already verified (for woff2 cross-check
 # below) and which we've seen at all (for duplicate detection).
@@ -91,6 +153,20 @@ seen_basenames=()
 
 for line in "${pin_lines[@]+"${pin_lines[@]}"}"; do
   basename="$(echo "${line}" | awk '{print $1}')"
+
+  # Basename safety (SH1) — defense-in-depth even though the awk
+  # extractor's strict regex already constrains the basename charset.
+  # If a future relaxation of strict_pin_re lets through `..` or `/`,
+  # this guard prevents the per-pin loop from invoking
+  # `shasum -a 256 fonts/../../etc/passwd` and leaking the hash into
+  # the `HASH MISMATCH actual: <hex>` diagnostic line.
+  case "${basename}" in
+    *[!A-Za-z0-9._-]* | '' | *..* )
+      echo "verify-font-integrity: invalid pin basename: ${basename}" >&2
+      status=1
+      continue
+      ;;
+  esac
 
   # Duplicate-pin guard (F1) — a future README with two pin lines for
   # the same basename (e.g., a commented-out history pin above the real
@@ -166,43 +242,57 @@ for font in "${fonts[@]}"; do
   fi
 done
 
-# Post-build pass: when --check-dist is set, recompute hashes for the
-# emitted dist/fonts/*.woff2 and assert they match the SAME pinned
-# hashes from fonts/README.md. Pre-build catches source tamper; this
-# pass catches Vite/crxjs-plugin rewrites of the emitted binary.
+# Post-build pass: when --check-dist is set, recompute hashes for each
+# pinned woff2 against its dist/fonts/<basename> counterpart and assert
+# the hash matches. Pre-build catches source tamper; this pass catches
+# Vite/crxjs-plugin rewrites of the emitted binary AND missing-emit
+# (Vite-plugin failed to copy a specific font through to dist).
+#
+# Iterates the SAME pin_lines set the source loop walked (SH3) so the
+# two paths share a single source of truth — no shell-interpolated
+# regex, no lookup divergence between source and dist phases.
 #
 # Scope: --check-dist intentionally remains *.woff2-only. License
 # files (OFL.txt) are not emitted to dist/; source-side enforcement
-# above is sufficient. If a future revision starts emitting non-woff2
-# pinned assets to dist/, extend this loop the same way the source
-# loop was extended in issue #189.
+# above is sufficient.
 if [ "${check_dist}" -eq 1 ]; then
   if [ ! -d "${DIST_FONTS_DIR}" ]; then
     echo "verify-font-integrity: dist directory missing: ${DIST_FONTS_DIR}" >&2
     exit 1
   fi
 
-  shopt -s nullglob
-  dist_fonts=("${DIST_FONTS_DIR}"/*.woff2)
-  shopt -u nullglob
+  dist_pin_count=0
+  for line in "${pin_lines[@]+"${pin_lines[@]}"}"; do
+    basename="$(echo "${line}" | awk '{print $1}')"
 
-  if [ "${#dist_fonts[@]}" -eq 0 ]; then
-    echo "verify-font-integrity: no *.woff2 files in ${DIST_FONTS_DIR}" >&2
-    exit 1
-  fi
+    # Restrict --check-dist to *.woff2 pins (license files don't ship
+    # to dist/).
+    case "${basename}" in
+      *.woff2) ;;
+      *) continue ;;
+    esac
 
-  for font in "${dist_fonts[@]}"; do
-    basename="${font##*/}"
+    # Re-apply the basename safety check from the source loop. Cheap;
+    # keeps both loops symmetrically hardened against SH1.
+    case "${basename}" in
+      *[!A-Za-z0-9._-]* | '' | *..* )
+        echo "verify-font-integrity: invalid pin basename in dist phase: ${basename}" >&2
+        status=1
+        continue
+        ;;
+    esac
 
-    pinned_line="$(grep -E "^${basename}[[:space:]]+sha256:[0-9a-f]{64}" "${README}" || true)"
-    if [ -z "${pinned_line}" ]; then
-      echo "verify-font-integrity: dist file ${basename} has no pinned sha256 in ${README}" >&2
+    dist_pin_count=$((dist_pin_count + 1))
+    pinned_hash="$(echo "${line}" | grep -oE 'sha256:[0-9a-f]{64}' | head -n 1 | cut -d: -f2)"
+    dist_target="${DIST_FONTS_DIR}/${basename}"
+
+    if [ ! -f "${dist_target}" ]; then
+      echo "verify-font-integrity: dist pinned file missing on disk: ${dist_target}" >&2
       status=1
       continue
     fi
-    pinned_hash="$(echo "${pinned_line}" | grep -oE 'sha256:[0-9a-f]{64}' | head -n 1 | cut -d: -f2)"
 
-    actual_hash="$(shasum -a 256 "${font}" | awk '{print $1}')"
+    actual_hash="$(shasum -a 256 "${dist_target}" | awk '{print $1}')"
 
     if [ "${actual_hash}" != "${pinned_hash}" ]; then
       echo "verify-font-integrity: dist HASH MISMATCH for ${basename}" >&2
@@ -214,6 +304,14 @@ if [ "${check_dist}" -eq 1 ]; then
 
     echo "verify-font-integrity: dist ok  ${basename}  sha256:${actual_hash}"
   done
+
+  # Sanity: a --check-dist invocation with no pinned woff2 in scope is
+  # almost certainly a misconfiguration — surface it loudly rather than
+  # silently exiting 0.
+  if [ "${dist_pin_count}" -eq 0 ]; then
+    echo "verify-font-integrity: no pinned *.woff2 to check against ${DIST_FONTS_DIR}" >&2
+    exit 1
+  fi
 fi
 
 exit "${status}"

--- a/bin/verify-font-integrity.sh
+++ b/bin/verify-font-integrity.sh
@@ -3,11 +3,14 @@
 # verify-font-integrity.sh — pin check for bundled font binaries.
 #
 # Reads `<dir>/README.md` for lines of the form
-#   <filename.woff2>  sha256:<64-hex-chars>  source:<url-or-note>
-# and asserts that for every `*.woff2` in <dir>:
-#   1. A pinned sha256 line exists in README.md.
-#   2. `shasum -a 256 <file>` matches the pinned hash exactly.
-#   3. A license sibling (OFL.txt or LICENSE*) exists in <dir>.
+#   <filename>  sha256:<64-hex-chars>  source:<url-or-note>
+# and asserts that for every pin line:
+#   1. Exactly one pin line exists per basename (no duplicate pins).
+#   2. `<dir>/<basename>` exists on disk.
+#   3. `shasum -a 256 <file>` matches the pinned hash exactly.
+# Also asserts:
+#   4. Every `*.woff2` in <dir> has a pin line (no unpinned binaries).
+#   5. A license sibling (OFL.txt or LICENSE*) exists in <dir>.
 #
 # Defaults to checking ./fonts. Override with FONTS_DIR=/path/to/dir for
 # tests / fixtures.
@@ -15,8 +18,10 @@
 # Exits 0 on success; non-zero with a diagnostic on any mismatch.
 #
 # Companion guard for issue #173 (SHA-256 pin against silent supply-chain
-# TOFU). Keep this script POSIX-bash compatible — runs on dev macOS,
-# Ubuntu CI, and Chromium Linux containers.
+# TOFU). Issue #189 hardens the parser (duplicate-pin assertion) and
+# extends enforcement to non-woff2 pinned files (e.g., OFL.txt). Keep
+# this script POSIX-bash compatible — runs on dev macOS, Ubuntu CI, and
+# Chromium Linux containers.
 
 set -euo pipefail
 
@@ -66,32 +71,60 @@ if [ "${license_found}" -eq 0 ]; then
   exit 1
 fi
 
-# Enumerate woff2 files. Glob may not expand if none present — handle
-# explicitly rather than letting `for` iterate the literal pattern.
-shopt -s nullglob
-fonts=("${FONTS_DIR}"/*.woff2)
-shopt -u nullglob
-
-if [ "${#fonts[@]}" -eq 0 ]; then
-  echo "verify-font-integrity: no *.woff2 files in ${FONTS_DIR}" >&2
-  exit 1
-fi
-
 status=0
-for font in "${fonts[@]}"; do
-  basename="${font##*/}"
 
-  # Extract pinned hash from README. Format:
-  #   <basename>  sha256:<hex>  source:...
-  pinned_line="$(grep -E "^${basename}[[:space:]]+sha256:[0-9a-f]{64}" "${README}" || true)"
-  if [ -z "${pinned_line}" ]; then
-    echo "verify-font-integrity: no pinned sha256 for ${basename} in ${README}" >&2
+# Collect all pin lines from README. Format (one per line):
+#   <basename>  sha256:<hex>  source:...
+# Pin parser is intentionally extension-agnostic — woff2 binaries AND
+# license/text siblings (OFL.txt etc.) get enforced uniformly.
+# Avoid `mapfile` (bash 4+) for macOS /usr/bin/bash 3.2 compatibility.
+pin_re='^[^[:space:]]+[[:space:]]+sha256:[0-9a-f]{64}'
+pin_lines=()
+while IFS= read -r _line; do
+  pin_lines+=("${_line}")
+done < <(grep -E "${pin_re}" "${README}" || true)
+
+# Track which basenames we've already verified (for woff2 cross-check
+# below) and which we've seen at all (for duplicate detection).
+verified_basenames=()
+seen_basenames=()
+
+for line in "${pin_lines[@]+"${pin_lines[@]}"}"; do
+  basename="$(echo "${line}" | awk '{print $1}')"
+
+  # Duplicate-pin guard (F1) — a future README with two pin lines for
+  # the same basename (e.g., a commented-out history pin above the real
+  # one) would let `grep | head -n 1` silently pick whichever came
+  # first, allowing a swapped binary to pass. Assert exactly one.
+  dup_count="$(printf '%s\n' "${pin_lines[@]+"${pin_lines[@]}"}" | awk -v b="${basename}" '$1 == b {n++} END {print n+0}')"
+  if [ "${dup_count}" -gt 1 ]; then
+    # Only emit the error once per duplicate basename.
+    already_reported=0
+    for sb in "${seen_basenames[@]+"${seen_basenames[@]}"}"; do
+      if [ "${sb}" = "${basename}" ]; then
+        already_reported=1
+        break
+      fi
+    done
+    if [ "${already_reported}" -eq 0 ]; then
+      echo "verify-font-integrity: DUPLICATE PIN for ${basename} (found ${dup_count} lines in ${README}, expected 1)" >&2
+      status=1
+      seen_basenames+=("${basename}")
+    fi
+    continue
+  fi
+  seen_basenames+=("${basename}")
+
+  pinned_hash="$(echo "${line}" | grep -oE 'sha256:[0-9a-f]{64}' | head -n 1 | cut -d: -f2)"
+  target="${FONTS_DIR}/${basename}"
+
+  if [ ! -f "${target}" ]; then
+    echo "verify-font-integrity: pinned file missing on disk: ${target}" >&2
     status=1
     continue
   fi
-  pinned_hash="$(echo "${pinned_line}" | grep -oE 'sha256:[0-9a-f]{64}' | head -n 1 | cut -d: -f2)"
 
-  actual_hash="$(shasum -a 256 "${font}" | awk '{print $1}')"
+  actual_hash="$(shasum -a 256 "${target}" | awk '{print $1}')"
 
   if [ "${actual_hash}" != "${pinned_hash}" ]; then
     echo "verify-font-integrity: HASH MISMATCH for ${basename}" >&2
@@ -102,12 +135,47 @@ for font in "${fonts[@]}"; do
   fi
 
   echo "verify-font-integrity: ok  ${basename}  sha256:${actual_hash}"
+  verified_basenames+=("${basename}")
+done
+
+# Enumerate woff2 files. Glob may not expand if none present — handle
+# explicitly rather than letting `for` iterate the literal pattern. Any
+# *.woff2 on disk MUST be pinned (catches a binary added without a
+# README entry).
+shopt -s nullglob
+fonts=("${FONTS_DIR}"/*.woff2)
+shopt -u nullglob
+
+if [ "${#fonts[@]}" -eq 0 ]; then
+  echo "verify-font-integrity: no *.woff2 files in ${FONTS_DIR}" >&2
+  exit 1
+fi
+
+for font in "${fonts[@]}"; do
+  basename="${font##*/}"
+  was_verified=0
+  for vb in "${verified_basenames[@]+"${verified_basenames[@]}"}"; do
+    if [ "${vb}" = "${basename}" ]; then
+      was_verified=1
+      break
+    fi
+  done
+  if [ "${was_verified}" -eq 0 ]; then
+    echo "verify-font-integrity: no pinned sha256 for ${basename} in ${README}" >&2
+    status=1
+  fi
 done
 
 # Post-build pass: when --check-dist is set, recompute hashes for the
 # emitted dist/fonts/*.woff2 and assert they match the SAME pinned
 # hashes from fonts/README.md. Pre-build catches source tamper; this
 # pass catches Vite/crxjs-plugin rewrites of the emitted binary.
+#
+# Scope: --check-dist intentionally remains *.woff2-only. License
+# files (OFL.txt) are not emitted to dist/; source-side enforcement
+# above is sufficient. If a future revision starts emitting non-woff2
+# pinned assets to dist/, extend this loop the same way the source
+# loop was extended in issue #189.
 if [ "${check_dist}" -eq 1 ]; then
   if [ ! -d "${DIST_FONTS_DIR}" ]; then
     echo "verify-font-integrity: dist directory missing: ${DIST_FONTS_DIR}" >&2

--- a/fonts/README.md
+++ b/fonts/README.md
@@ -42,9 +42,8 @@ committed `fonts/OFL.txt` is the upstream license file from
 `github.com/antijingoist/opendyslexic@master/OFL.txt`, preserving the
 required copyright notice (Abbie Gonzalez, 2019-07-29) and Reserved
 Font Name `OpenDyslexic` per OFL §1. Do not strip or replace with a
-generic template — the OFL.txt sha256 is pinned above for manual
-verification. (Automatic enforcement of the OFL.txt hash via
-`verify:fonts` is a follow-up; the woff2 pin IS enforced.)
+generic template — the OFL.txt sha256 is pinned above and all pinned
+files are enforced by `verify:fonts`.
 
 ## Issue #28 — font picker disposition (NOT bundled)
 


### PR DESCRIPTION
## Summary

Three deferred font-integrity-guard hardenings from PR #188 (#173) ring, bundled because they touch the same files.

- **F1 — pin-parser uniqueness assertion (security ring HOLD).** Future README with two pin lines for the same basename (real + commented "history" pin) would let `grep | head -n 1` silently pick the first match. Now exits non-zero with a `DUPLICATE PIN` diagnostic.
- **F2 — multi-file integrity scope (security ring HOLD + a11y suggestion).** Extension-agnostic parser. Every pin line in `fonts/README.md` gets existence + sha256 enforcement, not just `*.woff2`. `OFL.txt` is now enforced by `verify:fonts`; the README hedge ("automatic enforcement is a follow-up") is gone. `--check-dist` remains `*.woff2`-only by design (license files aren't emitted to dist).
- **F3 — license-arm asymmetric tests (test-gap ring HOLD).** Regression-pin the LICENSE / LICENSE.md arms with explicit vitest cases. No behavior change to the script's license-sibling logic — the gap was test coverage, not a script bug.

Closes #189.

## Mutation evidence

| Sub-task | Assertion | Production mutation | Result |
|---|---|---|---|
| F1 | `stderr =~ /DUPLICATE PIN/` | `if false && [ "${dup_count}" -gt 1 ]` | Red (silently picked first pin, returned HASH MISMATCH instead) |
| F2 | `stdout =~ /ok\s+OFL\.txt/` + perturbed-OFL → HASH MISMATCH | Revert parser regex to `\.woff2`-only | Red (OFL.txt skipped; perturbed OFL not detected) |
| F2-missing-file | `stderr =~ /pinned file missing on disk/` | `if false && [ ! -f "${target}" ]` | Red (shasum stray error caught — initial loose `/missing|not found/i` regex was tautological; tightened) |
| F3 | LICENSE-only / LICENSE.md-only → status 0 | `if false && [ "${#license_glob[@]}" -gt 0 ]` | Red (both LICENSE-arm tests fail; OFL.txt-only test stays green correctly) |

## Bash 3.2 compatibility note

Initial implementation used `mapfile` (bash 4+). macOS `/usr/bin/bash` is 3.2 and is what `execFileSync('bash', ...)` picks. Replaced with `while IFS= read -r` loop. Array expansions wrapped in `"${arr[@]+"${arr[@]}"}"` to survive `set -u` with empty arrays. Pre-existing script header claimed "POSIX-bash compatible" — aspirational; this PR moves closer to it but did not widen scope to audit other portability gaps.

## Scope-creep / friction notes

- F3 framing in the issue called the OFL-short-circuit a "bug". On reading the script, it's correct `if/else` behavior — only one license sibling needs to exist. The actual gap was **test coverage** of the LICENSE\* arm. Pinned with regression tests; did not refactor working arms.
- F2 "missing pinned file" assertion was initially tautological under a loose regex (shasum produces "No such file" when called against a phantom path under `set -e`). Caught during mutation testing, tightened the assertion to require the script's own diagnostic. Discriminating-signal discipline.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test` — 65 files / 923 tests pass (+7 new)
- [x] `npm run build` — clean
- [x] `npm run verify:fonts` — `ok OpenDyslexic-Regular.woff2` + `ok OFL.txt` (OFL.txt now enforced)
- [x] `npm run verify:fonts -- --check-dist` — source pins + dist woff2 all ok
- [x] Mutation evidence — each of F1, F2, F3 assertions flips red under the documented production mutation

## References

- PR #188 (#173) ring security-adversary finding #4 (pin uniqueness)
- PR #188 (#173) ring test-gap-adversary finding #3 (license-arm asymmetric tests)
- PR #188 (#173) ring a11y-extension-designer suggestion (pin OFL hash too)
- Issue #189 (filed as the consolidated follow-up)
