### PR TITLE
feat(reading-position): persist + restore per-URL with LRU cap (#48)

### DIFF
--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -47,14 +47,17 @@ src/
 │   ├── tokenize/             # Pure text → RSVP token stream
 │   ├── orp/                  # Optimal Recognition Point (focus character)
 │   ├── rsvp-engine/          # Word emission cadence (WPM → setTimeout)
-│   └── settings/             # Zod schema + defaults + version migrations
+│   ├── settings/             # Zod schema + defaults + version migrations
+│   ├── storage/              # Adapter-agnostic stores (e.g. reading-position #48)
+│   └── url/                  # URL canonicalization (storage-key join key, #48)
 ├── chrome/                   # Chrome MV3-specific glue
 │   ├── manifest.ts           # Generates manifest.json at build time
 │   ├── background/           # Service worker entry
 │   ├── content/              # Content script entry (lazy-injected)
 │   ├── popup/                # Browser-action popup (HTML + TS)
 │   ├── options/              # Options page (HTML + TS)
-│   └── settings/             # chrome.storage.sync adapter over core/settings
+│   ├── settings/             # chrome.storage.sync adapter over core/settings
+│   └── storage/              # chrome.storage.* glue for core/storage stores (#48)
 └── icons/                    # (build-time icon staging, if used)
 ```
 

--- a/src/chrome/content/__tests__/position-flush.test.ts
+++ b/src/chrome/content/__tests__/position-flush.test.ts
@@ -95,7 +95,10 @@ afterEach(() => {
 });
 
 describe('content script — visibility/pagehide flush wiring (#48)', () => {
-  async function mountOverlayWithPendingWrite(): Promise<{ local: FakeStorageLocal }> {
+  async function mountOverlayWithPendingWrite(): Promise<{
+    local: FakeStorageLocal;
+    pageUrl: string;
+  }> {
     const { local, getListener } = installChromeStub();
     await import('../index');
     const listener = getListener();
@@ -111,12 +114,33 @@ describe('content script — visibility/pagehide flush wiring (#48)', () => {
     // engine. Fast-forward to confirm at least one advance fires:
     await new Promise((r) => setTimeout(r, 250));
 
-    return { local };
+    return { local, pageUrl: 'https://example.com/article-flush-test' };
   }
 
-  test('visibilitychange → hidden triggers a flush of the pending write', async () => {
-    const { local } = await mountOverlayWithPendingWrite();
+  /**
+   * Extracts the wordIndex written under the canonical `position:<url>`
+   * key from a `chrome.storage.local.set` call payload. The flush path
+   * writes the per-URL payload AND the LRU index; we only assert on
+   * the per-URL payload so the test is robust to index-key changes.
+   */
+  function payloadWordIndex(setArg: Record<string, unknown>, pageUrl: string): number | undefined {
+    const key = `position:${pageUrl}`;
+    const v = setArg[key];
+    if (v === null || typeof v !== 'object') return undefined;
+    const wi = (v as { wordIndex?: unknown }).wordIndex;
+    return typeof wi === 'number' ? wi : undefined;
+  }
+
+  test('visibilitychange → hidden flushes the pending write AND cancels the debounce timer', async () => {
+    // TG3 — spy clearTimeout BEFORE the import so the production code's
+    // calls are captured. `setTimeout` returns numeric IDs in jsdom;
+    // we capture the most-recently scheduled debounce timer ID and
+    // assert clearTimeout was called with it BEFORE local.set fires.
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+    const { local, pageUrl } = await mountOverlayWithPendingWrite();
     local.set.mockClear();
+    clearTimeoutSpy.mockClear();
 
     // Default visibilityState in jsdom is 'visible' — override it.
     Object.defineProperty(document, 'visibilityState', {
@@ -129,9 +153,21 @@ describe('content script — visibility/pagehide flush wiring (#48)', () => {
     // microtasks to settle.
     await new Promise((r) => setTimeout(r, 30));
 
-    // Expect at least one set call (position payload) — the flush
-    // path writes the position record AND the LRU index.
+    // (a) clearTimeout was called as part of the flush — proves the
+    // debounce timer was cancelled, not raced against.
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+
+    // (b) The first set call carries the per-URL payload with a
+    // non-zero wordIndex (engine has been running ~250 ms at 600 wpm
+    // → ~2-3 word events) — proves the pending write actually
+    // flushed, not just any storage call.
     expect(local.set).toHaveBeenCalled();
+    const firstCall = local.set.mock.calls[0][0] as Record<string, unknown>;
+    const wi = payloadWordIndex(firstCall, pageUrl);
+    expect(wi).toBeDefined();
+    expect(wi).toBeGreaterThan(0);
+
+    clearTimeoutSpy.mockRestore();
   });
 
   test('visibilitychange → visible does NOT trigger a flush', async () => {
@@ -152,14 +188,90 @@ describe('content script — visibility/pagehide flush wiring (#48)', () => {
     expect(local.set).not.toHaveBeenCalled();
   });
 
-  test('pagehide triggers a flush', async () => {
-    const { local } = await mountOverlayWithPendingWrite();
+  test('pagehide flushes the pending write with the most-recent wordIndex AND cancels the timer', async () => {
+    // TG3 — same tightening as the visibilitychange test: spy
+    // clearTimeout, assert the per-URL payload carries a non-zero
+    // wordIndex (NOT a stale or empty record).
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+    const { local, pageUrl } = await mountOverlayWithPendingWrite();
     local.set.mockClear();
+    clearTimeoutSpy.mockClear();
 
     window.dispatchEvent(new Event('pagehide'));
     await new Promise((r) => setTimeout(r, 30));
 
+    expect(clearTimeoutSpy).toHaveBeenCalled();
     expect(local.set).toHaveBeenCalled();
+    const firstCall = local.set.mock.calls[0][0] as Record<string, unknown>;
+    const wi = payloadWordIndex(firstCall, pageUrl);
+    expect(wi).toBeDefined();
+    expect(wi).toBeGreaterThan(0);
+
+    clearTimeoutSpy.mockRestore();
+  });
+
+  test('TG4 — re-mount: pagehide on second mount flushes the second URL with no stale first-mount payload', async () => {
+    // Mount → close → mount again with a DIFFERENT pageUrl → pagehide.
+    // Asserts:
+    //   (a) the pagehide flush carries the SECOND pageUrl's payload
+    //       (proves the second mount's onWordAdvance closure
+    //       captured the new pageUrl and that pendingWrite isn't
+    //       stuck on a first-mount snapshot).
+    //   (b) no first-mount payload lands during the second mount's
+    //       pagehide (proves onClose's own flushPendingPositionWrite
+    //       drained the first mount's pending state cleanly).
+    //
+    // Mutation honesty: the production handlers `onVisibilityChange`
+    // / `onPageHide` are MODULE-SCOPED functions, not per-mount
+    // closures, so removing `detachPositionFlushListeners()` in
+    // onClose does NOT make this test red on its own — there is
+    // only ever one handler pair. That detach contract is
+    // mutation-validated by the separate `listeners detach after
+    // overlay close` test above. This TG4 test sits one layer up
+    // as an integration check: the full close→remount→pagehide
+    // cycle leaves no payload referencing the prior mount.
+    const { local, getListener } = installChromeStub();
+    await import('../index');
+    const listener = getListener();
+
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: { href: 'https://example.com/first-article' },
+    });
+    listener({ type: 'activate-reader' }, { id: 'test-ext' }, vi.fn());
+    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((r) => setTimeout(r, 250));
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await new Promise((r) => setTimeout(r, 30));
+
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: { href: 'https://example.com/second-article' },
+    });
+    listener({ type: 'activate-reader' }, { id: 'test-ext' }, vi.fn());
+    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((r) => setTimeout(r, 250));
+
+    local.set.mockClear();
+    window.dispatchEvent(new Event('pagehide'));
+    await new Promise((r) => setTimeout(r, 30));
+
+    const calls = local.set.mock.calls as Array<[Record<string, unknown>]>;
+    const firstUrlKey = 'position:https://example.com/first-article';
+    const secondUrlKey = 'position:https://example.com/second-article';
+    const secondPayloadCalls = calls.filter((c) =>
+      Object.prototype.hasOwnProperty.call(c[0], secondUrlKey),
+    );
+    const firstPayloadCalls = calls.filter((c) =>
+      Object.prototype.hasOwnProperty.call(c[0], firstUrlKey),
+    );
+    // (a) Second mount's payload landed.
+    expect(secondPayloadCalls.length).toBeGreaterThan(0);
+    // (b) No stale first-mount payload (the first mount's pendingWrite
+    // was flushed during its own onClose).
+    expect(firstPayloadCalls).toHaveLength(0);
   });
 
   test('listeners detach after overlay close — removeEventListener called for both signals', async () => {

--- a/src/chrome/content/__tests__/position-flush.test.ts
+++ b/src/chrome/content/__tests__/position-flush.test.ts
@@ -1,0 +1,207 @@
+/**
+ * #48 — visibility / pagehide flush wiring (architect HOLD #3).
+ *
+ * The debounced position writer batches up to 1 s of word events. If
+ * the user backgrounds the tab (`visibilitychange` → 'hidden') or
+ * navigates away (`pagehide`) inside that window, the trailing-edge
+ * timer never fires and the position is lost. The content script now
+ * listens for both signals and forces a flush.
+ *
+ * Mutation safety net: removing either listener registration in
+ * `index.ts` (the `addEventListener` calls under
+ * `attachPositionFlushListeners`) drops these tests red — that's how
+ * we know they're actually asserting on the production behaviour and
+ * not just coincidentally passing.
+ */
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+
+type Listener = (
+  msg: unknown,
+  sender: { id?: string },
+  sendResponse: (r: unknown) => void,
+) => unknown;
+
+interface ChromeRuntime {
+  id: string;
+  onMessage: { addListener: (l: Listener) => void };
+}
+interface FakeStorageLocal {
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+}
+
+function installChromeStub(): { local: FakeStorageLocal; getListener: () => Listener } {
+  const localMap = new Map<string, unknown>();
+  const local: FakeStorageLocal = {
+    get: vi.fn(async (keys: string[] | string | null) => {
+      const keyList = Array.isArray(keys) ? keys : keys === null ? [...localMap.keys()] : [keys];
+      const out: Record<string, unknown> = {};
+      for (const k of keyList) if (localMap.has(k)) out[k] = structuredClone(localMap.get(k));
+      return out;
+    }),
+    set: vi.fn(async (items: Record<string, unknown>) => {
+      for (const [k, v] of Object.entries(items)) localMap.set(k, structuredClone(v));
+    }),
+    remove: vi.fn(async (keys: string[] | string) => {
+      const keyList = Array.isArray(keys) ? keys : [keys];
+      for (const k of keyList) localMap.delete(k);
+    }),
+  };
+
+  let captured: Listener | undefined;
+  const runtime: ChromeRuntime = {
+    id: 'test-ext',
+    onMessage: {
+      addListener: (l) => {
+        captured = l;
+      },
+    },
+  };
+
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    runtime,
+    storage: {
+      local,
+      sync: {
+        get: vi.fn().mockResolvedValue({}),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      onChanged: { addListener: vi.fn(), removeListener: vi.fn() },
+    },
+  };
+
+  return {
+    local,
+    getListener: () => {
+      if (!captured) throw new Error('listener not registered');
+      return captured;
+    },
+  };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '<article>alpha beta gamma delta epsilon zeta.</article>';
+  Object.defineProperty(globalThis, 'location', {
+    configurable: true,
+    value: { href: 'https://example.com/article-flush-test' },
+  });
+});
+
+afterEach(() => {
+  delete (globalThis as unknown as { chrome?: unknown }).chrome;
+  document.body.innerHTML = '';
+  vi.resetModules();
+});
+
+describe('content script — visibility/pagehide flush wiring (#48)', () => {
+  async function mountOverlayWithPendingWrite(): Promise<{ local: FakeStorageLocal }> {
+    const { local, getListener } = installChromeStub();
+    await import('../index');
+    const listener = getListener();
+    listener({ type: 'activate-reader' }, { id: 'test-ext' }, vi.fn());
+    // Overlay mount is async — wait for it to finish.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Drive a word-advance manually by calling the overlay's
+    // engine-emit path indirectly: simplest is to drop a synthetic
+    // position into the debounced-writer pending slot via the
+    // exported `onWordAdvance` invocation, which fires during
+    // engine.start(). We rely on the overlay having auto-started the
+    // engine. Fast-forward to confirm at least one advance fires:
+    await new Promise((r) => setTimeout(r, 250));
+
+    return { local };
+  }
+
+  test('visibilitychange → hidden triggers a flush of the pending write', async () => {
+    const { local } = await mountOverlayWithPendingWrite();
+    local.set.mockClear();
+
+    // Default visibilityState in jsdom is 'visible' — override it.
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    // The flush calls store.write → chrome.storage.local.set. Allow
+    // microtasks to settle.
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Expect at least one set call (position payload) — the flush
+    // path writes the position record AND the LRU index.
+    expect(local.set).toHaveBeenCalled();
+  });
+
+  test('visibilitychange → visible does NOT trigger a flush', async () => {
+    const { local } = await mountOverlayWithPendingWrite();
+    local.set.mockClear();
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    // No flush should have happened — the only set calls would be
+    // the debounced timer, which we haven't allowed to fire (250 ms
+    // elapsed in mount, well under the 1 s debounce).
+    expect(local.set).not.toHaveBeenCalled();
+  });
+
+  test('pagehide triggers a flush', async () => {
+    const { local } = await mountOverlayWithPendingWrite();
+    local.set.mockClear();
+
+    window.dispatchEvent(new Event('pagehide'));
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(local.set).toHaveBeenCalled();
+  });
+
+  test('listeners detach after overlay close — removeEventListener called for both signals', async () => {
+    // Spy on add/remove BEFORE the import so the content script's
+    // attach calls go through the spy. Both signal types must be
+    // detached on close so the content script doesn't leak handler
+    // closures across mount cycles.
+    const docAdd = vi.spyOn(document, 'addEventListener');
+    const docRemove = vi.spyOn(document, 'removeEventListener');
+    const winAdd = vi.spyOn(window, 'addEventListener');
+    const winRemove = vi.spyOn(window, 'removeEventListener');
+
+    const { getListener } = installChromeStub();
+    await import('../index');
+    const listener = getListener();
+    listener({ type: 'activate-reader' }, { id: 'test-ext' }, vi.fn());
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Sanity — the attach must have happened.
+    expect(docAdd).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    expect(winAdd).toHaveBeenCalledWith('pagehide', expect.any(Function));
+
+    // Capture the exact handler references the content script
+    // attached so we can compare them to the ones it later removes.
+    const visAttachCall = docAdd.mock.calls.find((c) => c[0] === 'visibilitychange');
+    const hideAttachCall = winAdd.mock.calls.find((c) => c[0] === 'pagehide');
+    if (!visAttachCall) throw new Error('visibilitychange attach not captured');
+    if (!hideAttachCall) throw new Error('pagehide attach not captured');
+
+    // Trigger overlay close via Escape (captured by the overlay's
+    // capture-phase keydown handler on document).
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await new Promise((r) => setTimeout(r, 30));
+
+    // The content script must have called removeEventListener for
+    // BOTH signals with the same handler references it attached.
+    expect(docRemove).toHaveBeenCalledWith('visibilitychange', visAttachCall[1]);
+    expect(winRemove).toHaveBeenCalledWith('pagehide', hideAttachCall[1]);
+
+    docAdd.mockRestore();
+    docRemove.mockRestore();
+    winAdd.mockRestore();
+    winRemove.mockRestore();
+  });
+});

--- a/src/chrome/content/index.ts
+++ b/src/chrome/content/index.ts
@@ -48,6 +48,16 @@ let activeOverlay: OverlayHandle | null = null;
 // hygiene measure.
 const positionStore = createChromePositionStore();
 
+// #48 — single module-load warn when the local-storage surface is
+// missing (test harnesses, non-MV3 hosts). Matches the
+// `chrome.runtime.getURL` branch below — emit ONCE so per-mount
+// retries don't spam the console.
+if (typeof chrome === 'undefined' || !chrome.storage?.local) {
+  console.warn(
+    '[speedreader] chrome.storage.local unavailable, reading-position persistence disabled',
+  );
+}
+
 /**
  * #48 — debounce reading-position writes. The overlay emits an
  * `onWordAdvance` callback for every word event (~10 Hz at 600 wpm).
@@ -97,6 +107,49 @@ function flushPendingPositionWrite(): void {
     .catch((err: unknown) => {
       console.warn('[speedreader] reading-position flush failed', err);
     });
+}
+
+/**
+ * #48 — flush hooks for tab teardown. The browser fires `pagehide`
+ * when the tab navigates away, closes, or enters the back-forward
+ * cache; `visibilitychange` with `document.visibilityState === 'hidden'`
+ * fires when the user switches tabs / minimises the window AND covers
+ * the iOS-Safari case where `pagehide` is the only signal. Catch both
+ * so an article the user just stepped away from has its latest
+ * position pinned before any debounce timer would have fired.
+ *
+ * These are NOT awaited — fire-and-forget is correct here. We can't
+ * meaningfully delay tab unload, and the SW (via `chrome.storage.local`)
+ * will queue the IDB write into its own lifecycle. Tracked separately
+ * by #195: a future SW-owned store may upgrade this to a message-port
+ * `dispatch+ack` if eviction proves to drop writes in the wild.
+ *
+ * Listeners attach on first overlay mount and detach on overlay
+ * teardown so the content script (which outlives the overlay across
+ * close/reopen cycles) doesn't leak handlers across mounts.
+ */
+let positionFlushListenersAttached = false;
+function onVisibilityChange(): void {
+  if (document.visibilityState === 'hidden') {
+    flushPendingPositionWrite();
+  }
+}
+function onPageHide(): void {
+  flushPendingPositionWrite();
+}
+function attachPositionFlushListeners(): void {
+  if (positionFlushListenersAttached) return;
+  if (typeof document === 'undefined' || typeof window === 'undefined') return;
+  document.addEventListener('visibilitychange', onVisibilityChange);
+  window.addEventListener('pagehide', onPageHide);
+  positionFlushListenersAttached = true;
+}
+function detachPositionFlushListeners(): void {
+  if (!positionFlushListenersAttached) return;
+  if (typeof document === 'undefined' || typeof window === 'undefined') return;
+  document.removeEventListener('visibilitychange', onVisibilityChange);
+  window.removeEventListener('pagehide', onPageHide);
+  positionFlushListenersAttached = false;
 }
 
 /**
@@ -176,10 +229,14 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
         // The chrome.storage.local guard handles test harnesses + non-MV3
         // host environments that stub a partial `chrome` surface without
         // the local namespace; the persistence path silently degrades
-        // when storage is unavailable rather than firing a console
-        // warning on every mount.
+        // when storage is unavailable. The single module-load warn at
+        // the top of the file leaves a breadcrumb without spamming
+        // per-mount.
         const pageUrl = window.location.href;
         const persistAvailable = !!chrome.storage?.local;
+        if (persistAvailable && scope === 'full') {
+          attachPositionFlushListeners();
+        }
         let persistentResume: number | undefined;
         if (persistAvailable && scope === 'full' && sessionResume === undefined) {
           try {
@@ -297,6 +354,14 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
             // the page may unload. setTimeout(0) inside flush would
             // race; we call the store directly.
             flushPendingPositionWrite();
+            // Drop the visibility / pagehide listeners — the content
+            // script outlives the overlay across close/reopen cycles,
+            // so leaving them attached would (a) hold dead closures
+            // referencing this mount's `pageUrl` and (b) re-fire the
+            // flush every time the user backgrounds the tab, even
+            // with no overlay active. They're re-attached on the next
+            // mount.
+            detachPositionFlushListeners();
           },
           // Font-size stepper (#29) — overlay clamps to FONT_SIZE_MIN/MAX
           // before invoking. saveSettings is debounced (300 ms trailing

--- a/src/chrome/content/index.ts
+++ b/src/chrome/content/index.ts
@@ -36,10 +36,68 @@ import { loadSettings, saveSettings, subscribeSettings } from '../settings/stora
 import { tokenize } from '../../core/tokenize';
 import { recordClose, resumeIndex } from './session-position';
 import { resolveFontId } from '../../core/overlay/font-ids';
+import { createChromePositionStore } from '../storage/chrome-position-store';
 
 console.log('[SpeedReader] Content script loaded');
 
 let activeOverlay: OverlayHandle | null = null;
+
+// #48 — persistent per-URL reading-position store. Module-scoped so a
+// fresh activation reuses the same chrome.storage.local adapter. The
+// store itself is stateless; the singleton is just an allocation
+// hygiene measure.
+const positionStore = createChromePositionStore();
+
+/**
+ * #48 — debounce reading-position writes. The overlay emits an
+ * `onWordAdvance` callback for every word event (~10 Hz at 600 wpm).
+ * `chrome.storage.local` has no published per-minute write quota the
+ * way `.sync` does, but writing 10×/sec for the duration of a long
+ * article is wasteful disk I/O. A 1 s trailing-edge debounce keeps
+ * the on-disk position no more than a second stale, which is well
+ * within the resume-experience floor.
+ */
+const POSITION_WRITE_DEBOUNCE_MS = 1_000;
+
+interface PendingWrite {
+  url: string;
+  wordIndex: number;
+  totalWords: number;
+}
+
+let pendingWrite: PendingWrite | null = null;
+let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+
+function schedulePositionWrite(write: PendingWrite): void {
+  pendingWrite = write;
+  if (pendingTimer !== null) clearTimeout(pendingTimer);
+  pendingTimer = setTimeout(() => {
+    pendingTimer = null;
+    const w = pendingWrite;
+    pendingWrite = null;
+    if (!w) return;
+    positionStore
+      .write(w.url, { wordIndex: w.wordIndex, totalWords: w.totalWords })
+      .catch((err: unknown) => {
+        console.warn('[speedreader] reading-position write failed', err);
+      });
+  }, POSITION_WRITE_DEBOUNCE_MS);
+}
+
+function flushPendingPositionWrite(): void {
+  if (pendingTimer !== null) {
+    clearTimeout(pendingTimer);
+    pendingTimer = null;
+  }
+  const w = pendingWrite;
+  pendingWrite = null;
+  if (!w) return;
+  positionStore
+    .write(w.url, { wordIndex: w.wordIndex, totalWords: w.totalWords })
+    .catch((err: unknown) => {
+      console.warn('[speedreader] reading-position flush failed', err);
+    });
+}
 
 /**
  * Issue #142 — resident-cost trade-off (surfaced by the antagonistic-ring
@@ -106,7 +164,34 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
         // stream length so a mutated page falls back to start-of-stream
         // rather than seeking into a stale offset.
         const activeStreamLength = scope === 'selection' ? selectionWords.length : fullWords.length;
-        const initialIndex = resumeIndex(scope, activeStreamLength);
+        const sessionResume = resumeIndex(scope, activeStreamLength);
+
+        // #48 — persistent per-URL resume. Only applies to full-article
+        // mounts; selection scope is a per-session ephemeral construct
+        // (the selection itself doesn't survive page navigation, so a
+        // persisted selection position cannot be replayed). The
+        // in-session sessionResume above still handles selection-scope
+        // close/reopen within the same content-script lifetime.
+        //
+        // The chrome.storage.local guard handles test harnesses + non-MV3
+        // host environments that stub a partial `chrome` surface without
+        // the local namespace; the persistence path silently degrades
+        // when storage is unavailable rather than firing a console
+        // warning on every mount.
+        const pageUrl = window.location.href;
+        const persistAvailable = !!chrome.storage?.local;
+        let persistentResume: number | undefined;
+        if (persistAvailable && scope === 'full' && sessionResume === undefined) {
+          try {
+            const saved = await positionStore.read(pageUrl);
+            if (saved !== undefined && saved.wordIndex > 0 && saved.wordIndex < fullWords.length) {
+              persistentResume = saved.wordIndex;
+            }
+          } catch (err: unknown) {
+            console.warn('[speedreader] reading-position read failed', err);
+          }
+        }
+        const initialIndex = sessionResume ?? persistentResume;
         activeOverlay = createOverlay({
           doc: document,
           // Legacy single-list field retained for the type contract; the
@@ -163,9 +248,55 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
             return chrome.runtime.getURL('fonts/OpenDyslexic-Regular.woff2');
           })(),
           engineFactory: createRsvpEngine,
+          // #48 — toast the persistent resume so the user knows their
+          // position was restored AND has a one-click escape hatch to
+          // start the article over. We pass the toast ONLY when the
+          // persistent path supplied the index — session-resume (#25)
+          // happens silently within the same page lifetime where the
+          // user implicitly knows they just closed and reopened.
+          resumeToast:
+            persistentResume !== undefined
+              ? {
+                  totalWords: fullWords.length,
+                  onStartOver: () => {
+                    // Drop the persisted position so the next visit
+                    // starts fresh. Cancel any pending write so the
+                    // debounced flush doesn't immediately re-create
+                    // the entry against the rewound index.
+                    if (pendingTimer !== null) {
+                      clearTimeout(pendingTimer);
+                      pendingTimer = null;
+                    }
+                    pendingWrite = null;
+                    positionStore.clear(pageUrl).catch((err: unknown) => {
+                      console.warn('[speedreader] reading-position clear failed', err);
+                    });
+                  },
+                }
+              : undefined,
+          // #48 — per-word advance. Only persisted for full-scope
+          // mounts (selection-scope positions cannot be replayed across
+          // navigation). The store is keyed by canonical URL so utm
+          // tags, fragments, and host casing all collapse into one
+          // slot. Writes are debounced so we land at most one set per
+          // second; closing the overlay flushes any pending write.
+          onWordAdvance:
+            persistAvailable && scope === 'full'
+              ? (index, total) => {
+                  schedulePositionWrite({
+                    url: pageUrl,
+                    wordIndex: index,
+                    totalWords: total,
+                  });
+                }
+              : undefined,
           onClose: (snapshot) => {
             activeOverlay = null;
             recordClose(snapshot);
+            // #48 — flush any pending debounced position write before
+            // the page may unload. setTimeout(0) inside flush would
+            // race; we call the store directly.
+            flushPendingPositionWrite();
           },
           // Font-size stepper (#29) — overlay clamps to FONT_SIZE_MIN/MAX
           // before invoking. saveSettings is debounced (300 ms trailing

--- a/src/chrome/storage/__tests__/chrome-position-store.test.ts
+++ b/src/chrome/storage/__tests__/chrome-position-store.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the `chrome.storage.local` adapter used by the persistent
+ * reading-position store (#48).
+ *
+ * Asserts the adapter shape only — round-trip semantics live in the
+ * core store's test file. Test uses sinon-chrome to provide a real
+ * chrome.storage.local surface.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createChromePositionStore } from '../chrome-position-store';
+
+interface FakeLocalStorage {
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+}
+
+let fakeStore: Map<string, unknown>;
+let local: FakeLocalStorage;
+let originalChrome: typeof globalThis.chrome | undefined;
+
+beforeEach(() => {
+  fakeStore = new Map();
+  local = {
+    get: vi.fn(async (keys: string[] | string | null) => {
+      const keyList = Array.isArray(keys) ? keys : keys === null ? [...fakeStore.keys()] : [keys];
+      const out: Record<string, unknown> = {};
+      for (const k of keyList) {
+        if (fakeStore.has(k)) out[k] = structuredClone(fakeStore.get(k));
+      }
+      return out;
+    }),
+    set: vi.fn(async (items: Record<string, unknown>) => {
+      for (const [k, v] of Object.entries(items)) {
+        fakeStore.set(k, structuredClone(v));
+      }
+    }),
+    remove: vi.fn(async (keys: string[] | string) => {
+      const keyList = Array.isArray(keys) ? keys : [keys];
+      for (const k of keyList) fakeStore.delete(k);
+    }),
+  };
+  originalChrome = globalThis.chrome;
+  // Minimal cast — we only stub the surface the adapter uses.
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    storage: { local },
+  };
+});
+
+afterEach(() => {
+  (globalThis as unknown as { chrome: typeof globalThis.chrome | undefined }).chrome =
+    originalChrome;
+});
+
+describe('chrome-position-store adapter', () => {
+  test('round-trips a write through chrome.storage.local', async () => {
+    const store = createChromePositionStore();
+    await store.write('https://example.com/article', { wordIndex: 42, totalWords: 200 });
+
+    const got = await store.read('https://example.com/article');
+    expect(got?.wordIndex).toBe(42);
+    expect(got?.totalWords).toBe(200);
+    expect(typeof got?.lastReadAt).toBe('number');
+  });
+
+  test('write reaches the real chrome.storage.local.set (smoke)', async () => {
+    const store = createChromePositionStore();
+    await store.write('https://example.com/a', { wordIndex: 1, totalWords: 10 });
+    expect(local.set).toHaveBeenCalled();
+  });
+});

--- a/src/chrome/storage/chrome-position-store.ts
+++ b/src/chrome/storage/chrome-position-store.ts
@@ -23,6 +23,15 @@ import {
   type StorageAdapter,
 } from '../../core/storage/reading-position';
 
+/**
+ * Thin wrapper over `chrome.storage.local` matching the
+ * `StorageAdapter` interface. Each call returns a fresh adapter object
+ * but the underlying `chrome.storage.local` surface is process-wide —
+ * the adapter itself carries no state. Serialization of writes lives
+ * one layer up in `createReadingPositionStore`'s internal write-queue;
+ * see `createChromePositionStore` for the construction discipline that
+ * preserves that queue.
+ */
 function chromeStorageAdapter(): StorageAdapter {
   return {
     async get(keys) {
@@ -41,9 +50,19 @@ function chromeStorageAdapter(): StorageAdapter {
 
 /**
  * Constructs a `ReadingPositionStore` wired to `chrome.storage.local`
- * with `Date.now` as the time source. Returned instance is stateless —
- * safe to construct per-call or reuse across the content-script
- * lifetime.
+ * with `Date.now` as the time source. Each call returns a NEW store
+ * carrying its own internal write-queue.
+ *
+ * Concurrency invariant: to preserve cross-call write serialization
+ * (the queue that protects the LRU index read-modify-write cycle from
+ * interleaving), construct ONCE per content-script lifetime and reuse
+ * the same store instance for every `read`/`write`/`touch`/`clear`/
+ * `clearAll` call. Constructing per-mount or per-call yields fresh
+ * queues that cannot coordinate with each other and reintroduces the
+ * race the queue exists to prevent. The call site in
+ * `src/chrome/content/index.ts` constructs at module scope to honour
+ * this; if a future refactor moves construction inside `attachOverlay`
+ * or any per-mount path, the serialization guarantee is lost.
  */
 export function createChromePositionStore(): ReadingPositionStore {
   return createReadingPositionStore({

--- a/src/chrome/storage/chrome-position-store.ts
+++ b/src/chrome/storage/chrome-position-store.ts
@@ -1,0 +1,53 @@
+/**
+ * Chrome glue for the reading-position store (#48).
+ *
+ * Thin adapter over `chrome.storage.local` that satisfies the
+ * platform-agnostic `StorageAdapter` contract from
+ * `core/storage/reading-position.ts`. Lives in `src/chrome/` so the
+ * core stays free of `chrome.*` imports per `src/core/README.md`.
+ *
+ * Why `chrome.storage.local`, not `.sync`:
+ *   - `sync` is capped at 100 KB total and 8 KB per item, with a
+ *     120 writes/min rate limit. With a 100-entry LRU and the
+ *     position-write-on-every-word-advance hot path, even debounced
+ *     writes would risk quota exhaustion.
+ *   - `local` is 5 MB total, no per-item cap, no rate limit — fits the
+ *     access pattern.
+ *   - Cross-device sync is explicitly out of scope for #48 (would
+ *     require dedup + last-write-wins reconciliation; deferred).
+ */
+
+import {
+  createReadingPositionStore,
+  type ReadingPositionStore,
+  type StorageAdapter,
+} from '../../core/storage/reading-position';
+
+function chromeStorageAdapter(): StorageAdapter {
+  return {
+    async get(keys) {
+      // `chrome.storage.local.get` accepts string[] | string | null;
+      // string[] returns only the requested keys, which is what we want.
+      return (await chrome.storage.local.get(keys)) as Record<string, unknown>;
+    },
+    async set(items) {
+      await chrome.storage.local.set(items);
+    },
+    async remove(keys) {
+      await chrome.storage.local.remove(keys);
+    },
+  };
+}
+
+/**
+ * Constructs a `ReadingPositionStore` wired to `chrome.storage.local`
+ * with `Date.now` as the time source. Returned instance is stateless —
+ * safe to construct per-call or reuse across the content-script
+ * lifetime.
+ */
+export function createChromePositionStore(): ReadingPositionStore {
+  return createReadingPositionStore({
+    adapter: chromeStorageAdapter(),
+    now: () => Date.now(),
+  });
+}

--- a/src/core/overlay/__tests__/reading-position-restore.test.ts
+++ b/src/core/overlay/__tests__/reading-position-restore.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for the reading-position resume toast + word-advance callback (#48).
+ *
+ * Anti-tautology stance:
+ *   - Toast assertion matches by accessible role (`status`) + the text
+ *     content, not by raw class names — a CSS rename must not false-pass.
+ *   - Mount-with-saved-position test asserts the OBSERVED first word
+ *     rendered, not "engine.seekTo was called".
+ *   - The dismiss-after-5s assertion uses fake timers AND asserts the
+ *     toast region is hidden AFTER, not just that a timeout was scheduled.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createOverlay } from '../overlay';
+import type { OverlayOptions } from '../types';
+import { createRsvpEngine, type RsvpEngine, type RsvpEngineOptions } from '../../rsvp-engine';
+
+const STREAM = [
+  'Alpha.',
+  'Beta',
+  'gamma',
+  'delta.',
+  'Epsilon',
+  'zeta',
+  'eta.',
+  'Theta',
+  'iota',
+  'kappa.',
+];
+
+type Holder = { engine: RsvpEngine | null };
+
+function defaultOpts(holder: Holder, overrides: Partial<OverlayOptions> = {}): OverlayOptions {
+  return {
+    doc: document,
+    words: STREAM.slice(),
+    scope: 'full',
+    fullWords: STREAM.slice(),
+    selectionWords: [],
+    initialSettings: { theme: 'system', wpm: 600, fontSize: 20 },
+    subscribeSettings: () => () => undefined,
+    engineFactory: (engineOpts: RsvpEngineOptions) => {
+      holder.engine = createRsvpEngine(engineOpts);
+      return holder.engine;
+    },
+    ...overrides,
+  };
+}
+
+function getShadow(): ShadowRoot {
+  const host = document.body.querySelector('[data-speedreader-overlay]');
+  if (!(host instanceof HTMLElement) || !host.shadowRoot) {
+    throw new Error('overlay host missing or no shadow root');
+  }
+  return host.shadowRoot;
+}
+
+function getWordText(): string {
+  return getShadow().querySelector('.word-region')?.textContent ?? '';
+}
+
+function getToast(): HTMLElement | null {
+  // role="status" is the WCAG-aligned non-blocking polite announcement.
+  // Querying by role + name keeps the test resilient to CSS renames.
+  return getShadow().querySelector('[role="status"][data-sr-resume-toast]');
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+});
+
+describe('overlay — reading-position restore toast (#48)', () => {
+  test('mount with a saved position shows the toast AND resumes at that word', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialIndex: 4,
+        resumeToast: { totalWords: STREAM.length },
+      }),
+    );
+    overlay.mount();
+
+    // OBSERVED behavior: the first word rendered is the resume word
+    // (STREAM[3] — engine emits words[resume-1] on start after seekTo(resume)).
+    // Per overlay.ts comment: seekTo(N) is silent then start() emits words[N].
+    // Indexing here is 1-based progress; initialIndex=4 means resume at 4 words
+    // already consumed → next emission is STREAM[4] = 'Epsilon'. We assert on
+    // OBSERVED text rather than internal state.
+    expect(getWordText()).toBe('Epsilon');
+
+    const toast = getToast();
+    expect(toast).not.toBeNull();
+    // Visible text describes the resume position.
+    expect(toast?.textContent).toContain('4');
+    expect(toast?.textContent).toContain(String(STREAM.length));
+  });
+
+  test('mount without a saved position (no initialIndex) does NOT render the toast', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        // No initialIndex; resumeToast also omitted because the caller
+        // only sends it when there's a real resume.
+      }),
+    );
+    overlay.mount();
+    expect(getWordText()).toBe('Alpha.');
+    expect(getToast()).toBeNull();
+  });
+
+  test('mount with resumeToast but no real resume (initialIndex=0) does NOT render the toast', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialIndex: 0,
+        resumeToast: { totalWords: STREAM.length },
+      }),
+    );
+    overlay.mount();
+    // No resume occurred → toast must not appear.
+    expect(getToast()).toBeNull();
+  });
+
+  test('mount with initialIndex >= total silently starts at 0 with no toast', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        // Out-of-bounds resume target — overlay's existing guard ignores
+        // it; the toast wire here must respect the same guard.
+        initialIndex: STREAM.length + 5,
+        resumeToast: { totalWords: STREAM.length },
+      }),
+    );
+    overlay.mount();
+    expect(getWordText()).toBe('Alpha.');
+    expect(getToast()).toBeNull();
+  });
+
+  test('Start over link resets to word 0 and invokes onStartOver', () => {
+    const holder: Holder = { engine: null };
+    const onStartOver = vi.fn();
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialIndex: 4,
+        resumeToast: { totalWords: STREAM.length, onStartOver },
+      }),
+    );
+    overlay.mount();
+    expect(getWordText()).toBe('Epsilon');
+
+    const startOverBtn = getShadow().querySelector('[data-sr-resume-toast] [data-sr-start-over]');
+    if (!(startOverBtn instanceof HTMLButtonElement)) {
+      throw new Error('start-over button not found');
+    }
+    startOverBtn.click();
+
+    // OBSERVED: word region now shows the first word of the stream.
+    expect(getWordText()).toBe('Alpha.');
+    // Toast is dismissed on click.
+    expect(getToast()).toBeNull();
+    // Callback fired so the host can clear the persisted position.
+    expect(onStartOver).toHaveBeenCalledTimes(1);
+  });
+
+  test('toast auto-dismisses after 5 seconds', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialIndex: 4,
+        resumeToast: { totalWords: STREAM.length },
+      }),
+    );
+    overlay.mount();
+    expect(getToast()).not.toBeNull();
+
+    vi.advanceTimersByTime(4_999);
+    expect(getToast()).not.toBeNull();
+
+    vi.advanceTimersByTime(2);
+    expect(getToast()).toBeNull();
+  });
+});
+
+describe('overlay — onWordAdvance callback (#48)', () => {
+  test('fires for each word event with the engine progress index', () => {
+    const holder: Holder = { engine: null };
+    const advances: Array<{ index: number; total: number }> = [];
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        onWordAdvance: (index, total) => {
+          advances.push({ index, total });
+        },
+      }),
+    );
+    overlay.mount();
+
+    // start() emits word[0] synchronously → one advance recorded with
+    // index === 1 (progress is 1-based count of emitted words).
+    expect(advances.length).toBeGreaterThanOrEqual(1);
+    expect(advances[0].index).toBe(1);
+    expect(advances[0].total).toBe(STREAM.length);
+
+    // Advance the engine three more ticks at 600 wpm = 100 ms per word.
+    vi.advanceTimersByTime(400);
+    expect(advances.length).toBeGreaterThanOrEqual(4);
+    expect(advances[advances.length - 1].index).toBe(advances.length);
+  });
+
+  test('fires once on the resume word when initialIndex seeks the engine', () => {
+    const holder: Holder = { engine: null };
+    const advances: Array<{ index: number; total: number }> = [];
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialIndex: 4,
+        onWordAdvance: (index, total) => {
+          advances.push({ index, total });
+        },
+      }),
+    );
+    overlay.mount();
+    // After seekTo(4) + start(), the first word emitted is words[4] and
+    // progress.index === 5. Per the close-snapshot test conventions in
+    // this directory.
+    expect(advances[0].index).toBe(5);
+    expect(advances[0].total).toBe(STREAM.length);
+  });
+
+  test('not fired when overlay mounts without the callback (no observable behaviour change)', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    // No onWordAdvance — should not throw, should not affect rendering.
+    overlay.mount();
+    expect(getWordText()).toBe('Alpha.');
+  });
+});

--- a/src/core/overlay/constants.ts
+++ b/src/core/overlay/constants.ts
@@ -33,6 +33,9 @@ export const OVERLAY_CLASS = Object.freeze({
   WPM_READOUT: 'wpm-readout',
   CONTEXT_PREVIEW: 'context-preview',
   CONTEXT_CURRENT: 'context-current',
+  /** Reading-position resume toast (#48). */
+  RESUME_TOAST: 'resume-toast',
+  RESUME_TOAST_BTN: 'resume-toast-start-over',
   /**
    * Modifier applied to `.modal` when the user has enabled OpenDyslexic
    * (#27). The CSS rule overrides `font-family` to the bundled
@@ -118,4 +121,11 @@ export const OVERLAY_TEXT = Object.freeze({
   expandedAnnouncement(totalWords: number): string {
     return `Expanded to full article. Restarting from word 1 of ${totalWords}. Paused.`;
   },
+
+  /** Reading-position resume toast template (#48). */
+  resumeToast(wordIndex: number, totalWords: number): string {
+    return `Resumed at word ${wordIndex} of ${totalWords}`;
+  },
+  RESUME_TOAST_START_OVER: 'Start over',
+  RESUME_TOAST_DISMISS_MS: 5_000,
 });

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -134,6 +134,10 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
   // theme between `'system'` and an explicit override.
   let uninstallSystemThemeListener: (() => void) | null = null;
   let priorOverflow: string | null = null;
+  // #48 — toast auto-dismiss timer. Hoisted so unmount can clear it if
+  // the user closes the overlay inside the 5 s window (otherwise the
+  // setTimeout pins the removed shadow root + toast node until it fires).
+  let resumeToastTimer: ReturnType<typeof setTimeout> | null = null;
   // Lifted into the outer closure so `unmount()` can build the close
   // snapshot for `onClose` (#25). Reassigned on scope-swap so the
   // snapshot reflects the active stream at close time, not the mount
@@ -587,6 +591,15 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       if (ev.type === 'word') {
         renderWord(word, ev.word);
         ariaLive.textContent = ev.word;
+        // #48 — emit the post-emit 1-based progress count so the host can
+        // persist it. Reading `engine.progress().index` AFTER the emit
+        // matches the persistence semantics: closing after the last word
+        // stores `wordIndex === totalWords`, which the resume check then
+        // treats as "finished, start fresh."
+        if (opts.onWordAdvance && engine) {
+          const p = engine.progress();
+          opts.onWordAdvance(p.index, p.total);
+        }
         // Only re-render the preview if the just-emitted word landed
         // while the engine was already paused (paused-state seekTo emits
         // a replacement `word` event — see RsvpEngine.seekTo docs). On
@@ -613,13 +626,15 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     // conditional is here so we skip the no-op when there's nothing to
     // restore.
     const resume = opts.initialIndex;
-    if (
+    const resumedAt: number | null =
       typeof resume === 'number' &&
       Number.isInteger(resume) &&
       resume > 0 &&
       resume < engineWords.length
-    ) {
-      engine.seekTo(resume);
+        ? resume
+        : null;
+    if (resumedAt !== null) {
+      engine.seekTo(resumedAt);
     }
     engine.start();
     if (scopeView?.fallback === 'empty-selection') {
@@ -631,6 +646,61 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     }
     reflectEngineState();
     renderPreview();
+
+    // #48 — resume toast. Only renders when the mount actually resumed
+    // AND the caller opted in via `resumeToast`. The toast lives inside
+    // the modal as a `role="status"` chip so it announces politely
+    // alongside the visible chip. Auto-dismisses after 5 s; Start Over
+    // rewinds the engine to word 0 and invokes `onStartOver` so the
+    // host can clear the persisted entry.
+    if (resumedAt !== null && opts.resumeToast) {
+      const toast = opts.doc.createElement('div');
+      toast.className = OVERLAY_CLASS.RESUME_TOAST;
+      toast.setAttribute('role', 'status');
+      toast.setAttribute('aria-live', 'polite');
+      // Custom data attribute pins the element for tests + the Start Over
+      // descendant selector without depending on the visual class name.
+      toast.setAttribute('data-sr-resume-toast', '');
+
+      const label = opts.doc.createElement('span');
+      label.textContent = OVERLAY_TEXT.resumeToast(resumedAt, opts.resumeToast.totalWords);
+      toast.appendChild(label);
+
+      const startOver = opts.doc.createElement('button');
+      startOver.type = 'button';
+      startOver.className = OVERLAY_CLASS.RESUME_TOAST_BTN;
+      startOver.setAttribute('data-sr-start-over', '');
+      startOver.textContent = OVERLAY_TEXT.RESUME_TOAST_START_OVER;
+      toast.appendChild(startOver);
+
+      const onStartOverCb = opts.resumeToast.onStartOver;
+      const dismissToast = (): void => {
+        if (resumeToastTimer !== null) {
+          clearTimeout(resumeToastTimer);
+          resumeToastTimer = null;
+        }
+        toast.remove();
+      };
+      startOver.addEventListener('click', () => {
+        // Rewind the engine to word 0. seekTo(0) handles both PLAYING
+        // (clearPending + tick from 0) and PAUSED (replacement word
+        // event for words[0]) state transitions in-place, so we don't
+        // need a separate pause/start dance here.
+        engine?.seekTo(0);
+        dismissToast();
+        reflectEngineState();
+        onStartOverCb?.();
+      });
+
+      // Insert above the word region so the toast sits visually at the
+      // top of the reading surface without disturbing the dialog header.
+      word.parentNode?.insertBefore(toast, word);
+
+      resumeToastTimer = setTimeout(() => {
+        resumeToastTimer = null;
+        toast.remove();
+      }, OVERLAY_TEXT.RESUME_TOAST_DISMISS_MS);
+    }
 
     const togglePlayPause = (): void => {
       if (!engine) return;
@@ -847,6 +917,12 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
 
   function unmount(): void {
     if (status === 'unmounted') return;
+    // #48 — drop the toast auto-dismiss timer first so a late fire after
+    // unmount can't reach into a detached shadow root.
+    if (resumeToastTimer !== null) {
+      clearTimeout(resumeToastTimer);
+      resumeToastTimer = null;
+    }
     uninstallTrap?.();
     uninstallTrap = null;
     if (onKeydown) opts.doc.removeEventListener('keydown', onKeydown, true);

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -331,6 +331,39 @@ export const OVERLAY_CSS = `
   pointer-events: none;
 }
 
+/* Reading-position resume toast (#48). Non-blocking polite status
+ * region pinned to the top of the modal. role="status" carries the
+ * polite announcement; the visual style is a subdued chip so the eye
+ * lands on the word region, not the toast. */
+.resume-toast {
+  margin-block-end: clamp(8px, 2cqi, 16px);
+  padding: clamp(8px, 1.5cqi + 4px, 14px) clamp(12px, 2cqi + 6px, 20px);
+  border-radius: 8px;
+  background: var(--surface-alt, rgba(0, 0, 0, 0.06));
+  color: var(--text, #111111);
+  font-size: clamp(0.85rem, 1cqi + 0.4rem, 1rem);
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(8px, 1.5cqi, 16px);
+  align-items: center;
+  justify-content: center;
+}
+
+.resume-toast-start-over {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: var(--accent, #2563eb);
+  text-decoration: underline;
+  cursor: pointer;
+  font: inherit;
+}
+
+.resume-toast-start-over:focus-visible {
+  outline: 2px solid var(--accent, #2563eb);
+  outline-offset: 2px;
+}
+
 @media (forced-colors: active) {
   .modal { background: Canvas; color: CanvasText; }
   .close-btn { border-color: ButtonText; color: ButtonText; }
@@ -370,6 +403,9 @@ export const OVERLAY_CSS = `
   .wpm-readout { color: CanvasText; }
   .context-preview { color: CanvasText; opacity: 1; }
   .context-current { color: Highlight; }
+  .resume-toast { background: Canvas; color: CanvasText; border: 1px solid CanvasText; }
+  .resume-toast-start-over { color: LinkText; }
+  .resume-toast-start-over:focus-visible { outline-color: Highlight; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/core/overlay/types.ts
+++ b/src/core/overlay/types.ts
@@ -181,6 +181,13 @@ export interface OverlayOptions {
    * `chrome.storage.local` so a later visit can resume. Optional —
    * omitting it disables persistence; the overlay still operates
    * normally.
+   *
+   * Invoked only on full-scope mounts; selection-scope mounts do not
+   * persist position because selection text does not survive
+   * navigation. The host wires `onWordAdvance` only when
+   * `scope === 'full'` — passing it for a selection-scope mount has
+   * no defined meaning and may be removed by a future contract
+   * cleanup.
    */
   onWordAdvance?: (index: number, total: number) => void;
   /**

--- a/src/core/overlay/types.ts
+++ b/src/core/overlay/types.ts
@@ -153,6 +153,37 @@ export interface OverlayOptions {
    */
   onWpmChange?: (next: number) => void;
   /**
+   * Resume toast (#48). When provided AND the mount actually resumes
+   * (i.e. `initialIndex` is a positive in-range integer), the overlay
+   * renders a non-blocking `role="status"` toast inside the shadow root
+   * with text "Resumed at word N of M" and a "Start over" link. The
+   * toast auto-dismisses after 5 s; clicking "Start over" rewinds the
+   * engine to word 0 and invokes `onStartOver` so the host can clear
+   * the persisted entry.
+   *
+   * Omitted when no resume is in flight — the toast must never render
+   * on a fresh first-time mount.
+   */
+  resumeToast?: {
+    /** Total words in the active stream (denominator of the toast). */
+    totalWords: number;
+    /**
+     * Called when the user clicks "Start over". The overlay has
+     * already rewound the engine; the callback exists so the host can
+     * delete the persisted position for the canonical URL.
+     */
+    onStartOver?: () => void;
+  };
+  /**
+   * Called on every `word` event with the post-emit progress index
+   * (1-based count of words consumed) and the active stream's total
+   * (#48). The host debounces and persists this value to
+   * `chrome.storage.local` so a later visit can resume. Optional —
+   * omitting it disables persistence; the overlay still operates
+   * normally.
+   */
+  onWordAdvance?: (index: number, total: number) => void;
+  /**
    * Absolute URL of the bundled OpenDyslexic woff2 (#27, #10). The chrome
    * glue resolves this via `chrome.runtime.getURL('fonts/...')` and passes
    * it in; `core/` cannot call `chrome.*`. When the URL is provided, the

--- a/src/core/storage/__tests__/reading-position.test.ts
+++ b/src/core/storage/__tests__/reading-position.test.ts
@@ -166,16 +166,18 @@ describe('reading-position store — LRU eviction at cap', () => {
   test('overwriting an existing URL does NOT count as a new LRU slot', async () => {
     for (let i = 0; i < POSITION_LRU_MAX; i++) {
       now = 1_700_000_000_000 + i;
-      await store.write(`https://example.com/a-${i}`, { wordIndex: i + 1, totalWords: 100 });
+      // totalWords must strictly exceed every wordIndex written below;
+      // we cap at POSITION_LRU_MAX (=100) so use 1000 to stay clear.
+      await store.write(`https://example.com/a-${i}`, { wordIndex: i + 1, totalWords: 1000 });
     }
     // Overwrite the FIRST entry — should NOT evict a-1 (and a-0 should
     // remain present, just moved to the most-recent slot).
     now = 1_700_000_001_000;
-    await store.write('https://example.com/a-0', { wordIndex: 99, totalWords: 100 });
+    await store.write('https://example.com/a-0', { wordIndex: 99, totalWords: 1000 });
 
     expect(await store.read('https://example.com/a-0')).toEqual({
       wordIndex: 99,
-      totalWords: 100,
+      totalWords: 1000,
       lastReadAt: now,
     });
     // a-1 must still be present (NOT evicted by the overwrite).
@@ -213,7 +215,7 @@ describe('reading-position store — touch reorders LRU without changing positio
   test('touching the oldest entry protects it from the NEXT eviction', async () => {
     for (let i = 0; i < POSITION_LRU_MAX; i++) {
       now = 1_700_000_000_000 + i;
-      await store.write(`https://example.com/x-${i}`, { wordIndex: i + 1, totalWords: 100 });
+      await store.write(`https://example.com/x-${i}`, { wordIndex: i + 1, totalWords: 1000 });
     }
     // Touch x-0 — now x-1 is the oldest.
     now = 1_700_000_002_000;
@@ -378,23 +380,19 @@ describe('reading-position store — non-canonicalizable URLs skip persistence',
 });
 
 describe('reading-position store — concurrent writes serialize through the queue', () => {
-  test('10 concurrent writes for distinct URLs all land in the index with no corruption', async () => {
-    // Adapter with a deterministic delay between the get() and set()
-    // phases — this is the window that would let two concurrent writes
-    // each compute filtered = [] and end up overwriting each other's
-    // index update if mutations weren't serialised.
+  /**
+   * Builds a slow `StorageAdapter` where every `get()` and `set()`
+   * yields to the macrotask queue (`setTimeout(0)`) before completing.
+   * The yields make the read-modify-write window observable: a
+   * non-serialised implementation will let a second dispatch's `get()`
+   * resolve against an adapter snapshot that pre-dates the first
+   * dispatch's `set()`, then both writes will race on the LRU index.
+   */
+  function createSlowAdapter(): StorageAdapter & { snapshot(): Record<string, unknown> } {
     const map = new Map<string, unknown>();
-    let getCount = 0;
-    const slowAdapter: StorageAdapter = {
+    return {
       async get(keys) {
-        // First call (and every odd call) yields to the microtask queue
-        // BEFORE returning, mimicking an adapter where get() resolves
-        // asynchronously after a tick — long enough for a concurrent
-        // dispatch to interleave under a non-serialised implementation.
-        getCount++;
-        if (getCount % 1 === 0) {
-          await new Promise<void>((resolve) => setTimeout(resolve, 0));
-        }
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
         const out: Record<string, unknown> = {};
         for (const k of keys) {
           if (map.has(k)) out[k] = structuredClone(map.get(k));
@@ -402,8 +400,6 @@ describe('reading-position store — concurrent writes serialize through the que
         return out;
       },
       async set(items) {
-        // Set also yields so the race window spans the entire
-        // read-modify-write cycle.
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
         for (const [k, v] of Object.entries(items)) {
           map.set(k, structuredClone(v));
@@ -412,39 +408,229 @@ describe('reading-position store — concurrent writes serialize through the que
       async remove(keys) {
         for (const k of keys) map.delete(k);
       },
+      snapshot() {
+        return Object.fromEntries(map.entries());
+      },
     };
+  }
 
+  test('concurrent writes for DISTINCT URLs serialize on the LRU index: all entries land in dispatch order', async () => {
+    // Three writes dispatched without awaits — each performs a
+    // read-modify-write on the SHARED `position-index` key. Under the
+    // slow adapter, a non-serialised implementation lets each
+    // dispatch's `get(index)` resolve against the EMPTY initial
+    // snapshot, then each one independently sets the index to its own
+    // single-entry array. The last `set()` of `position-index` wins,
+    // so the index ends up with ONE entry instead of THREE.
+    //
+    // Under the queue, dispatch N's `get(index)` only runs after
+    // dispatch N-1's `set(index)` has resolved, so each dispatch sees
+    // the prior writes accumulated. Final index = [A, B, C].
+    //
+    // Assertions discriminate: index length AND order both must
+    // survive — a non-serialised impl produces length 1.
+    const slowAdapter = createSlowAdapter();
     const slowStore = createReadingPositionStore({
       adapter: slowAdapter,
       now: () => now,
     });
 
-    // Dispatch all 10 writes WITHOUT awaiting between them — this is
-    // the race the queue is supposed to prevent.
-    const pending: Array<Promise<void>> = [];
-    for (let i = 0; i < 10; i++) {
-      pending.push(
-        slowStore.write(`https://example.com/article-${i}`, {
-          wordIndex: i + 1,
-          totalWords: 100,
-        }),
-      );
-    }
-    await Promise.all(pending);
+    const dispatched = [
+      slowStore.write('https://example.com/a', { wordIndex: 1, totalWords: 10 }),
+      slowStore.write('https://example.com/b', { wordIndex: 2, totalWords: 10 }),
+      slowStore.write('https://example.com/c', { wordIndex: 3, totalWords: 10 }),
+    ];
+    await Promise.all(dispatched);
 
-    // Index must carry every URL, in insertion order (the queue
-    // preserves dispatch order).
     const index = (await slowAdapter.get([POSITION_INDEX_KEY]))[POSITION_INDEX_KEY] as string[];
-    expect(index).toHaveLength(10);
-    for (let i = 0; i < 10; i++) {
-      expect(index[i]).toBe(keyOf(`https://example.com/article-${i}`));
-    }
+    expect(index).toEqual([
+      keyOf('https://example.com/a'),
+      keyOf('https://example.com/b'),
+      keyOf('https://example.com/c'),
+    ]);
 
-    // Every payload must be readable.
-    for (let i = 0; i < 10; i++) {
-      const got = await slowStore.read(`https://example.com/article-${i}`);
-      expect(got?.wordIndex).toBe(i + 1);
-    }
+    // Every payload must be readable — proves no payload was lost
+    // even though the index races on the shared key.
+    expect((await slowStore.read('https://example.com/a'))?.wordIndex).toBe(1);
+    expect((await slowStore.read('https://example.com/b'))?.wordIndex).toBe(2);
+    expect((await slowStore.read('https://example.com/c'))?.wordIndex).toBe(3);
+  });
+
+  test('concurrent writes for the SAME URL serialize: last dispatched write wins', async () => {
+    // Three writes against the SAME URL with the slow adapter.
+    // Without serialisation, the final stored payload is whichever
+    // `adapter.set(payload)` happens to land last — which under the
+    // setTimeout(0) scheduler is dispatch-order dependent but not
+    // dispatch-order GUARANTEED. With the queue, dispatch order is
+    // strictly preserved, so wordIndex=30 wins deterministically.
+    const slowAdapter = createSlowAdapter();
+    const slowStore = createReadingPositionStore({
+      adapter: slowAdapter,
+      now: () => now,
+    });
+    const url = 'https://example.com/same';
+
+    const dispatched = [
+      slowStore.write(url, { wordIndex: 10, totalWords: 100 }),
+      slowStore.write(url, { wordIndex: 20, totalWords: 100 }),
+      slowStore.write(url, { wordIndex: 30, totalWords: 100 }),
+    ];
+    await Promise.all(dispatched);
+
+    const got = await slowStore.read(url);
+    expect(got?.wordIndex).toBe(30);
+
+    const expectedKey = keyOf(url);
+    const index = (await slowAdapter.get([POSITION_INDEX_KEY]))[POSITION_INDEX_KEY] as string[];
+    expect(index.filter((k) => k === expectedKey)).toHaveLength(1);
+  });
+
+  test('a rejected write does NOT poison the queue: subsequent writes still land', async () => {
+    // Adapter where the FIRST set() rejects (mimicking a transient
+    // quota error). The store's queue chains `then(undefined, () => undefined)`
+    // so the rejection is swallowed AFTER the caller-facing promise
+    // rejects; the queue itself stays resumable.
+    const map = new Map<string, unknown>();
+    let setCalls = 0;
+    const flakeyAdapter: StorageAdapter = {
+      async get(keys) {
+        const out: Record<string, unknown> = {};
+        for (const k of keys) {
+          if (map.has(k)) out[k] = structuredClone(map.get(k));
+        }
+        return out;
+      },
+      async set(items) {
+        setCalls++;
+        if (setCalls === 1) throw new Error('quota');
+        for (const [k, v] of Object.entries(items)) {
+          map.set(k, structuredClone(v));
+        }
+      },
+      async remove(keys) {
+        for (const k of keys) map.delete(k);
+      },
+    };
+    const flakeyStore = createReadingPositionStore({
+      adapter: flakeyAdapter,
+      now: () => now,
+    });
+
+    // (a) The first write rejects with the adapter's error.
+    await expect(
+      flakeyStore.write('https://example.com/a', { wordIndex: 1, totalWords: 10 }),
+    ).rejects.toThrow('quota');
+
+    // (b) A subsequent write against the same store must resolve and
+    // land the payload. If the queue's rejection handling were dropped
+    // (e.g. the head `writeQueue.then(op, op)` changed to
+    // `writeQueue.then(op)` so the next dispatch's op never runs when
+    // the prior chain rejected), this second dispatch would reject
+    // with the prior error.
+    await expect(
+      flakeyStore.write('https://example.com/b', { wordIndex: 5, totalWords: 50 }),
+    ).resolves.toBeUndefined();
+    expect(await flakeyStore.read('https://example.com/b')).toEqual({
+      wordIndex: 5,
+      totalWords: 50,
+      lastReadAt: now,
+    });
+  });
+});
+
+describe('reading-position store — makeReadingPosition smart constructor (via parseStored)', () => {
+  // The smart constructor is module-private; we exercise it through
+  // `read()` (which routes raw adapter payloads through `parseStored`).
+  // Each test pre-seeds the adapter with a payload that exercises one
+  // invariant and asserts `read()` returns undefined.
+  test('valid construction: payload with 0 <= wordIndex < totalWords round-trips', async () => {
+    await store.write('https://example.com/ok', { wordIndex: 5, totalWords: 10 });
+    expect(await store.read('https://example.com/ok')).toEqual({
+      wordIndex: 5,
+      totalWords: 10,
+      lastReadAt: now,
+    });
+  });
+
+  test('rejects when wordIndex >= totalWords (cross-field invariant)', async () => {
+    const key = keyOf('https://example.com/bad');
+    // Pre-seed a payload where wordIndex equals totalWords — would be
+    // "past end of stream" and the engine cannot resume from it.
+    await adapter.set({
+      [key]: {
+        schemaVersion: POSITION_SCHEMA_VERSION,
+        wordIndex: 10,
+        totalWords: 10,
+        lastReadAt: now,
+      },
+      [POSITION_INDEX_KEY]: [key],
+    });
+    expect(await store.read('https://example.com/bad')).toBeUndefined();
+  });
+
+  test('rejects when wordIndex exceeds totalWords', async () => {
+    const key = keyOf('https://example.com/over');
+    await adapter.set({
+      [key]: {
+        schemaVersion: POSITION_SCHEMA_VERSION,
+        wordIndex: 50,
+        totalWords: 10,
+        lastReadAt: now,
+      },
+      [POSITION_INDEX_KEY]: [key],
+    });
+    expect(await store.read('https://example.com/over')).toBeUndefined();
+  });
+
+  test.each<[string, Record<string, unknown>]>([
+    ['negative wordIndex', { wordIndex: -1, totalWords: 10, lastReadAt: 1 }],
+    ['non-integer wordIndex', { wordIndex: 1.5, totalWords: 10, lastReadAt: 1 }],
+    ['totalWords = 0', { wordIndex: 0, totalWords: 0, lastReadAt: 1 }],
+    ['non-integer totalWords', { wordIndex: 1, totalWords: 3.2, lastReadAt: 1 }],
+    ['NaN wordIndex', { wordIndex: NaN, totalWords: 10, lastReadAt: 1 }],
+    ['Infinity totalWords', { wordIndex: 1, totalWords: Infinity, lastReadAt: 1 }],
+    ['negative lastReadAt', { wordIndex: 1, totalWords: 10, lastReadAt: -1 }],
+    ['Infinity lastReadAt', { wordIndex: 1, totalWords: 10, lastReadAt: Infinity }],
+  ])('rejects malformed numeric field: %s', async (_label, payload) => {
+    const key = keyOf('https://example.com/x');
+    await adapter.set({
+      [key]: { schemaVersion: POSITION_SCHEMA_VERSION, ...payload },
+      [POSITION_INDEX_KEY]: [key],
+    });
+    expect(await store.read('https://example.com/x')).toBeUndefined();
+  });
+
+  test('write() rejects when caller supplies wordIndex >= totalWords (smart-constructor guard)', async () => {
+    await expect(
+      store.write('https://example.com/bad', { wordIndex: 10, totalWords: 10 }),
+    ).rejects.toThrow();
+    await expect(
+      store.write('https://example.com/bad', { wordIndex: 50, totalWords: 10 }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('reading-position store — clearAll() orphan-key contract', () => {
+  test('orphan position:* keys NOT referenced by the index are LEFT in place', async () => {
+    // Document the pragmatic boundary of `clearAll`: it removes only
+    // what the LRU index tracks. Orphans from a crashed write that
+    // updated the payload but not the index survive — sweeping them
+    // would require a full `get(null)` over chrome.storage.local on a
+    // user-facing hot path. Pinning this so a future "extend clearAll
+    // to also sweep orphans" change has to flip an explicit test.
+    const orphanKey = `${'position:'}https://orphan.example.com/`;
+    await adapter.set({ [orphanKey]: { schemaVersion: 1, wordIndex: 1, totalWords: 10 } });
+    // Plus a tracked entry to prove clearAll DID run.
+    await store.write('https://example.com/tracked', { wordIndex: 1, totalWords: 10 });
+
+    await store.clearAll();
+
+    const snap = adapter.snapshot();
+    // Tracked entry and index are gone.
+    expect(snap[keyOf('https://example.com/tracked')]).toBeUndefined();
+    expect(snap[POSITION_INDEX_KEY]).toBeUndefined();
+    // Orphan remains — documented behavior.
+    expect(snap[orphanKey]).toEqual({ schemaVersion: 1, wordIndex: 1, totalWords: 10 });
   });
 });
 

--- a/src/core/storage/__tests__/reading-position.test.ts
+++ b/src/core/storage/__tests__/reading-position.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for the platform-agnostic reading-position store (#48).
+ *
+ * The store is constructed around a `StorageAdapter` so the test can
+ * run against an in-memory fake. The real `chrome.storage.local` glue
+ * lives in `src/chrome/storage/chrome-position-store.ts` and is
+ * exercised separately.
+ *
+ * Anti-tautology stance:
+ *   - LRU eviction is verified by adding 101 entries and asserting the
+ *     FIRST inserted URL is the one evicted AND that the 100 most-recent
+ *     remain — not by asserting `list().length === 100`.
+ *   - Restore behavior asserts the OBSERVED stored value, not
+ *     "adapter.get was called".
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import {
+  POSITION_INDEX_KEY,
+  POSITION_LRU_MAX,
+  POSITION_SCHEMA_VERSION,
+  positionKey,
+  createReadingPositionStore,
+  type ReadingPositionStore,
+  type StorageAdapter,
+} from '../reading-position';
+
+/**
+ * In-memory storage adapter. Uses a plain `Map<string, unknown>` and
+ * structuredClone on read/write to match `chrome.storage.local`'s
+ * serialization contract (no shared references between caller state
+ * and persisted state).
+ */
+function createMemoryAdapter(): StorageAdapter & { snapshot(): Record<string, unknown> } {
+  const map = new Map<string, unknown>();
+  return {
+    async get(keys) {
+      const out: Record<string, unknown> = {};
+      for (const k of keys) {
+        if (map.has(k)) out[k] = structuredClone(map.get(k));
+      }
+      return out;
+    },
+    async set(items) {
+      for (const [k, v] of Object.entries(items)) {
+        map.set(k, structuredClone(v));
+      }
+    },
+    async remove(keys) {
+      for (const k of keys) {
+        map.delete(k);
+      }
+    },
+    snapshot() {
+      return Object.fromEntries(map.entries());
+    },
+  };
+}
+
+let adapter: ReturnType<typeof createMemoryAdapter>;
+let store: ReadingPositionStore;
+let now: number;
+
+beforeEach(() => {
+  adapter = createMemoryAdapter();
+  now = 1_700_000_000_000;
+  store = createReadingPositionStore({
+    adapter,
+    now: () => now,
+  });
+});
+
+afterEach(() => {
+  // Nothing — fresh adapter per test.
+});
+
+describe('reading-position store — write + read round-trip', () => {
+  test('write persists wordIndex, totalWords, lastReadAt under the canonical key', async () => {
+    await store.write('https://example.com/a', { wordIndex: 42, totalWords: 200 });
+    const got = await store.read('https://example.com/a');
+    expect(got).toEqual({
+      wordIndex: 42,
+      totalWords: 200,
+      lastReadAt: now,
+    });
+  });
+
+  test('read returns undefined when no entry exists for the URL', async () => {
+    expect(await store.read('https://example.com/never-visited')).toBeUndefined();
+  });
+
+  test('write overwrites a previous entry for the same URL', async () => {
+    await store.write('https://example.com/a', { wordIndex: 10, totalWords: 100 });
+    now += 5_000;
+    await store.write('https://example.com/a', { wordIndex: 55, totalWords: 100 });
+    expect(await store.read('https://example.com/a')).toEqual({
+      wordIndex: 55,
+      totalWords: 100,
+      lastReadAt: now,
+    });
+  });
+
+  test('persists a schema version on the stored payload (forward-compat)', async () => {
+    await store.write('https://example.com/a', { wordIndex: 1, totalWords: 2 });
+    const raw = adapter.snapshot()[positionKey('https://example.com/a')] as {
+      schemaVersion: number;
+    };
+    expect(raw.schemaVersion).toBe(POSITION_SCHEMA_VERSION);
+  });
+
+  test('write rejects negative or non-integer wordIndex (defensive — caller must clamp)', async () => {
+    await expect(
+      store.write('https://example.com/a', { wordIndex: -1, totalWords: 10 }),
+    ).rejects.toThrow();
+    await expect(
+      store.write('https://example.com/a', { wordIndex: 1.5, totalWords: 10 }),
+    ).rejects.toThrow();
+    await expect(
+      store.write('https://example.com/a', { wordIndex: 0, totalWords: 0 }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('reading-position store — LRU eviction at cap', () => {
+  test('keeps at most POSITION_LRU_MAX entries; drops the oldest first', async () => {
+    // Add POSITION_LRU_MAX + 1 distinct URLs with monotonically-increasing
+    // timestamps so insertion order === LRU order.
+    const overflow = POSITION_LRU_MAX + 1;
+    for (let i = 0; i < overflow; i++) {
+      now = 1_700_000_000_000 + i;
+      await store.write(`https://example.com/article-${i}`, {
+        wordIndex: i + 1,
+        totalWords: 1000,
+      });
+    }
+
+    // The FIRST-inserted URL must be gone.
+    expect(await store.read('https://example.com/article-0')).toBeUndefined();
+
+    // EVERY one of the remaining 100 must still be readable with the
+    // exact wordIndex we wrote. Asserting just `list().length === 100`
+    // would let a bug where the wrong entry was evicted slip through.
+    for (let i = 1; i < overflow; i++) {
+      const got = await store.read(`https://example.com/article-${i}`);
+      expect(got, `expected article-${i} to survive eviction`).toBeDefined();
+      expect(got?.wordIndex).toBe(i + 1);
+    }
+
+    // Index must also reflect the eviction.
+    const index = (await adapter.get([POSITION_INDEX_KEY]))[POSITION_INDEX_KEY] as string[];
+    expect(index).toHaveLength(POSITION_LRU_MAX);
+    expect(index).not.toContain(positionKey('https://example.com/article-0'));
+  });
+
+  test('overwriting an existing URL does NOT count as a new LRU slot', async () => {
+    for (let i = 0; i < POSITION_LRU_MAX; i++) {
+      now = 1_700_000_000_000 + i;
+      await store.write(`https://example.com/a-${i}`, { wordIndex: i + 1, totalWords: 100 });
+    }
+    // Overwrite the FIRST entry — should NOT evict a-1 (and a-0 should
+    // remain present, just moved to the most-recent slot).
+    now = 1_700_000_001_000;
+    await store.write('https://example.com/a-0', { wordIndex: 99, totalWords: 100 });
+
+    expect(await store.read('https://example.com/a-0')).toEqual({
+      wordIndex: 99,
+      totalWords: 100,
+      lastReadAt: now,
+    });
+    // a-1 must still be present (NOT evicted by the overwrite).
+    expect(await store.read('https://example.com/a-1')).toBeDefined();
+  });
+});
+
+describe('reading-position store — touch reorders LRU without changing position', () => {
+  test('touch moves a URL to the most-recent slot and updates lastReadAt', async () => {
+    await store.write('https://example.com/old', { wordIndex: 1, totalWords: 10 });
+    await store.write('https://example.com/mid', { wordIndex: 2, totalWords: 10 });
+    await store.write('https://example.com/new', { wordIndex: 3, totalWords: 10 });
+
+    now += 10_000;
+    await store.touch('https://example.com/old');
+
+    const index = (await adapter.get([POSITION_INDEX_KEY]))[POSITION_INDEX_KEY] as string[];
+    // The touched URL should be at the END of the index (most-recent).
+    expect(index[index.length - 1]).toBe(positionKey('https://example.com/old'));
+    // Position data unchanged — only lastReadAt moves.
+    const got = await store.read('https://example.com/old');
+    expect(got).toEqual({ wordIndex: 1, totalWords: 10, lastReadAt: now });
+  });
+
+  test('touch on an unknown URL is a no-op (no entry created)', async () => {
+    await store.touch('https://example.com/never');
+    expect(await store.read('https://example.com/never')).toBeUndefined();
+    const index = (await adapter.get([POSITION_INDEX_KEY]))[POSITION_INDEX_KEY] as
+      | string[]
+      | undefined;
+    // Either no index yet, or an empty one — both acceptable.
+    expect(index === undefined || index.length === 0).toBe(true);
+  });
+
+  test('touching the oldest entry protects it from the NEXT eviction', async () => {
+    for (let i = 0; i < POSITION_LRU_MAX; i++) {
+      now = 1_700_000_000_000 + i;
+      await store.write(`https://example.com/x-${i}`, { wordIndex: i + 1, totalWords: 100 });
+    }
+    // Touch x-0 — now x-1 is the oldest.
+    now = 1_700_000_002_000;
+    await store.touch('https://example.com/x-0');
+
+    // Adding a NEW entry should evict x-1, not x-0.
+    now = 1_700_000_003_000;
+    await store.write('https://example.com/new', { wordIndex: 1, totalWords: 100 });
+
+    expect(await store.read('https://example.com/x-0')).toBeDefined();
+    expect(await store.read('https://example.com/x-1')).toBeUndefined();
+  });
+});
+
+describe('reading-position store — clear', () => {
+  test('clear removes the entry and drops it from the index', async () => {
+    await store.write('https://example.com/a', { wordIndex: 5, totalWords: 50 });
+    await store.clear('https://example.com/a');
+    expect(await store.read('https://example.com/a')).toBeUndefined();
+    const index = (await adapter.get([POSITION_INDEX_KEY]))[POSITION_INDEX_KEY] as
+      | string[]
+      | undefined;
+    expect(index === undefined || index.length === 0).toBe(true);
+  });
+
+  test('clear on an unknown URL is a silent no-op', async () => {
+    await expect(store.clear('https://example.com/never')).resolves.toBeUndefined();
+  });
+});
+
+describe('reading-position store — canonicalization is applied on every API', () => {
+  test('read with a non-canonical URL matches a previous canonical write', async () => {
+    await store.write('https://example.com/post', { wordIndex: 12, totalWords: 100 });
+    // Read using a URL that canonicalizes to the same key.
+    const got = await store.read('https://EXAMPLE.com/post?utm_source=twitter#section');
+    expect(got?.wordIndex).toBe(12);
+  });
+
+  test('write with a non-canonical URL is keyed against the canonical form', async () => {
+    await store.write('https://EXAMPLE.com/post?utm_source=fb#x', {
+      wordIndex: 7,
+      totalWords: 50,
+    });
+    expect(await store.read('https://example.com/post')).toEqual({
+      wordIndex: 7,
+      totalWords: 50,
+      lastReadAt: now,
+    });
+  });
+});
+
+describe('reading-position store — schema version guard', () => {
+  test('reads with a future schemaVersion are ignored (forward-incompat payload)', async () => {
+    const key = positionKey('https://example.com/a');
+    await adapter.set({
+      [key]: {
+        schemaVersion: POSITION_SCHEMA_VERSION + 1,
+        wordIndex: 12,
+        totalWords: 100,
+        lastReadAt: now,
+      },
+      [POSITION_INDEX_KEY]: [key],
+    });
+    expect(await store.read('https://example.com/a')).toBeUndefined();
+  });
+
+  test('reads of malformed payloads silently return undefined (not throw)', async () => {
+    const key = positionKey('https://example.com/a');
+    await adapter.set({
+      [key]: { totally: 'wrong shape' },
+      [POSITION_INDEX_KEY]: [key],
+    });
+    expect(await store.read('https://example.com/a')).toBeUndefined();
+  });
+});

--- a/src/core/storage/__tests__/reading-position.test.ts
+++ b/src/core/storage/__tests__/reading-position.test.ts
@@ -60,6 +60,18 @@ let adapter: ReturnType<typeof createMemoryAdapter>;
 let store: ReadingPositionStore;
 let now: number;
 
+/**
+ * Test helper: every URL these tests pass in is a valid https URL, so
+ * `positionKey` always returns a string. Throwing on null surfaces a
+ * test-data typo instead of letting the assertion downstream blow up
+ * with a confusing message.
+ */
+function keyOf(url: string): string {
+  const k = positionKey(url);
+  if (k === null) throw new Error(`test setup error — positionKey null for ${url}`);
+  return k;
+}
+
 beforeEach(() => {
   adapter = createMemoryAdapter();
   now = 1_700_000_000_000;
@@ -101,7 +113,7 @@ describe('reading-position store — write + read round-trip', () => {
 
   test('persists a schema version on the stored payload (forward-compat)', async () => {
     await store.write('https://example.com/a', { wordIndex: 1, totalWords: 2 });
-    const raw = adapter.snapshot()[positionKey('https://example.com/a')] as {
+    const raw = adapter.snapshot()[keyOf('https://example.com/a')] as {
       schemaVersion: number;
     };
     expect(raw.schemaVersion).toBe(POSITION_SCHEMA_VERSION);
@@ -148,7 +160,7 @@ describe('reading-position store — LRU eviction at cap', () => {
     // Index must also reflect the eviction.
     const index = (await adapter.get([POSITION_INDEX_KEY]))[POSITION_INDEX_KEY] as string[];
     expect(index).toHaveLength(POSITION_LRU_MAX);
-    expect(index).not.toContain(positionKey('https://example.com/article-0'));
+    expect(index).not.toContain(keyOf('https://example.com/article-0'));
   });
 
   test('overwriting an existing URL does NOT count as a new LRU slot', async () => {
@@ -182,7 +194,7 @@ describe('reading-position store — touch reorders LRU without changing positio
 
     const index = (await adapter.get([POSITION_INDEX_KEY]))[POSITION_INDEX_KEY] as string[];
     // The touched URL should be at the END of the index (most-recent).
-    expect(index[index.length - 1]).toBe(positionKey('https://example.com/old'));
+    expect(index[index.length - 1]).toBe(keyOf('https://example.com/old'));
     // Position data unchanged — only lastReadAt moves.
     const got = await store.read('https://example.com/old');
     expect(got).toEqual({ wordIndex: 1, totalWords: 10, lastReadAt: now });
@@ -255,7 +267,7 @@ describe('reading-position store — canonicalization is applied on every API', 
 
 describe('reading-position store — schema version guard', () => {
   test('reads with a future schemaVersion are ignored (forward-incompat payload)', async () => {
-    const key = positionKey('https://example.com/a');
+    const key = keyOf('https://example.com/a');
     await adapter.set({
       [key]: {
         schemaVersion: POSITION_SCHEMA_VERSION + 1,
@@ -269,11 +281,254 @@ describe('reading-position store — schema version guard', () => {
   });
 
   test('reads of malformed payloads silently return undefined (not throw)', async () => {
-    const key = positionKey('https://example.com/a');
+    const key = keyOf('https://example.com/a');
     await adapter.set({
       [key]: { totally: 'wrong shape' },
       [POSITION_INDEX_KEY]: [key],
     });
     expect(await store.read('https://example.com/a')).toBeUndefined();
+  });
+
+  test('write does NOT clobber a stored record carrying a higher schemaVersion (downgrade preserve)', async () => {
+    // Pre-populate with a v2 (future) record. Index points at it.
+    const key = keyOf('https://example.com/future');
+    const futureRecord = {
+      schemaVersion: POSITION_SCHEMA_VERSION + 1,
+      wordIndex: 999,
+      totalWords: 1234,
+      lastReadAt: now,
+      // A field a hypothetical v2 might add — preserved as-is.
+      futureExtraField: 'newer-build-data',
+    };
+    await adapter.set({
+      [key]: futureRecord,
+      [POSITION_INDEX_KEY]: [key],
+    });
+
+    // A v1 (downgrade) build tries to write the same URL — must be a
+    // silent no-op so the newer record survives.
+    await store.write('https://example.com/future', { wordIndex: 7, totalWords: 50 });
+
+    const snap = adapter.snapshot();
+    expect(snap[key]).toEqual(futureRecord);
+    // Index must not be modified — no LRU promotion for an aborted write.
+    expect(snap[POSITION_INDEX_KEY]).toEqual([key]);
+  });
+
+  test('touch does NOT clobber a stored record carrying a higher schemaVersion', async () => {
+    const key = keyOf('https://example.com/future');
+    const futureRecord = {
+      schemaVersion: POSITION_SCHEMA_VERSION + 1,
+      wordIndex: 5,
+      totalWords: 10,
+      lastReadAt: now,
+    };
+    await adapter.set({
+      [key]: futureRecord,
+      [POSITION_INDEX_KEY]: [key],
+    });
+
+    await store.touch('https://example.com/future');
+    expect(adapter.snapshot()[key]).toEqual(futureRecord);
+  });
+});
+
+describe('reading-position store — non-canonicalizable URLs skip persistence', () => {
+  test.each([
+    ['javascript:alert(1)'],
+    ['data:text/plain,hello'],
+    ['chrome-extension://abcdefghijklmnopabcdefghijklmnop/popup.html'],
+    ['file:///tmp/x'],
+    ['about:blank'],
+    ['ws://example.com/'],
+    ['not a url'],
+  ])('write on %s is a no-op', async (url) => {
+    await store.write(url, { wordIndex: 1, totalWords: 10 });
+    const snap = adapter.snapshot();
+    // No keys at all should have been written — neither a payload nor
+    // the index.
+    expect(Object.keys(snap)).toHaveLength(0);
+  });
+
+  test('read on a non-canonicalizable URL returns undefined without touching the adapter', async () => {
+    expect(await store.read('javascript:alert(1)')).toBeUndefined();
+    expect(await store.read('chrome://settings/')).toBeUndefined();
+    // Adapter state unchanged.
+    expect(Object.keys(adapter.snapshot())).toHaveLength(0);
+  });
+
+  test('clear on a non-canonicalizable URL is a no-op', async () => {
+    await expect(store.clear('javascript:alert(1)')).resolves.toBeUndefined();
+    expect(Object.keys(adapter.snapshot())).toHaveLength(0);
+  });
+
+  test('touch on a non-canonicalizable URL is a no-op', async () => {
+    await expect(store.touch('javascript:alert(1)')).resolves.toBeUndefined();
+    expect(Object.keys(adapter.snapshot())).toHaveLength(0);
+  });
+
+  test('valid https URL still writes through after the guard', async () => {
+    await store.write('https://example.com/a', { wordIndex: 3, totalWords: 30 });
+    expect(await store.read('https://example.com/a')).toEqual({
+      wordIndex: 3,
+      totalWords: 30,
+      lastReadAt: now,
+    });
+  });
+});
+
+describe('reading-position store — concurrent writes serialize through the queue', () => {
+  test('10 concurrent writes for distinct URLs all land in the index with no corruption', async () => {
+    // Adapter with a deterministic delay between the get() and set()
+    // phases — this is the window that would let two concurrent writes
+    // each compute filtered = [] and end up overwriting each other's
+    // index update if mutations weren't serialised.
+    const map = new Map<string, unknown>();
+    let getCount = 0;
+    const slowAdapter: StorageAdapter = {
+      async get(keys) {
+        // First call (and every odd call) yields to the microtask queue
+        // BEFORE returning, mimicking an adapter where get() resolves
+        // asynchronously after a tick — long enough for a concurrent
+        // dispatch to interleave under a non-serialised implementation.
+        getCount++;
+        if (getCount % 1 === 0) {
+          await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        }
+        const out: Record<string, unknown> = {};
+        for (const k of keys) {
+          if (map.has(k)) out[k] = structuredClone(map.get(k));
+        }
+        return out;
+      },
+      async set(items) {
+        // Set also yields so the race window spans the entire
+        // read-modify-write cycle.
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        for (const [k, v] of Object.entries(items)) {
+          map.set(k, structuredClone(v));
+        }
+      },
+      async remove(keys) {
+        for (const k of keys) map.delete(k);
+      },
+    };
+
+    const slowStore = createReadingPositionStore({
+      adapter: slowAdapter,
+      now: () => now,
+    });
+
+    // Dispatch all 10 writes WITHOUT awaiting between them — this is
+    // the race the queue is supposed to prevent.
+    const pending: Array<Promise<void>> = [];
+    for (let i = 0; i < 10; i++) {
+      pending.push(
+        slowStore.write(`https://example.com/article-${i}`, {
+          wordIndex: i + 1,
+          totalWords: 100,
+        }),
+      );
+    }
+    await Promise.all(pending);
+
+    // Index must carry every URL, in insertion order (the queue
+    // preserves dispatch order).
+    const index = (await slowAdapter.get([POSITION_INDEX_KEY]))[POSITION_INDEX_KEY] as string[];
+    expect(index).toHaveLength(10);
+    for (let i = 0; i < 10; i++) {
+      expect(index[i]).toBe(keyOf(`https://example.com/article-${i}`));
+    }
+
+    // Every payload must be readable.
+    for (let i = 0; i < 10; i++) {
+      const got = await slowStore.read(`https://example.com/article-${i}`);
+      expect(got?.wordIndex).toBe(i + 1);
+    }
+  });
+});
+
+describe('reading-position store — list()', () => {
+  test('returns empty array when no entries exist', async () => {
+    expect(await store.list()).toEqual([]);
+  });
+
+  test('returns entries in LRU order, most-recent first', async () => {
+    await store.write('https://example.com/oldest', { wordIndex: 1, totalWords: 10 });
+    now += 1_000;
+    await store.write('https://example.com/middle', { wordIndex: 2, totalWords: 10 });
+    now += 1_000;
+    await store.write('https://example.com/newest', { wordIndex: 3, totalWords: 10 });
+
+    const got = await store.list();
+    expect(got).toHaveLength(3);
+    expect(got[0].url).toBe('https://example.com/newest');
+    expect(got[0].position.wordIndex).toBe(3);
+    expect(got[1].url).toBe('https://example.com/middle');
+    expect(got[2].url).toBe('https://example.com/oldest');
+  });
+
+  test('reflects touch — touched entry moves to the front of list output', async () => {
+    await store.write('https://example.com/a', { wordIndex: 1, totalWords: 10 });
+    now += 1_000;
+    await store.write('https://example.com/b', { wordIndex: 2, totalWords: 10 });
+    now += 1_000;
+    await store.touch('https://example.com/a');
+
+    const got = await store.list();
+    expect(got[0].url).toBe('https://example.com/a');
+    expect(got[1].url).toBe('https://example.com/b');
+  });
+
+  test('skips malformed records silently (does not throw)', async () => {
+    const goodKey = keyOf('https://example.com/good');
+    const badKey = keyOf('https://example.com/bad');
+    await adapter.set({
+      [goodKey]: {
+        schemaVersion: POSITION_SCHEMA_VERSION,
+        wordIndex: 5,
+        totalWords: 50,
+        lastReadAt: now,
+      },
+      [badKey]: { totally: 'wrong' },
+      [POSITION_INDEX_KEY]: [badKey, goodKey],
+    });
+
+    const got = await store.list();
+    expect(got).toHaveLength(1);
+    expect(got[0].url).toBe('https://example.com/good');
+  });
+});
+
+describe('reading-position store — clearAll()', () => {
+  test('removes every persisted position and the index', async () => {
+    await store.write('https://example.com/a', { wordIndex: 1, totalWords: 10 });
+    await store.write('https://example.com/b', { wordIndex: 2, totalWords: 10 });
+    await store.write('https://example.com/c', { wordIndex: 3, totalWords: 10 });
+
+    await store.clearAll();
+
+    expect(await store.read('https://example.com/a')).toBeUndefined();
+    expect(await store.read('https://example.com/b')).toBeUndefined();
+    expect(await store.read('https://example.com/c')).toBeUndefined();
+    expect(await store.list()).toEqual([]);
+
+    // Adapter snapshot — no position:* keys, no index.
+    const snap = adapter.snapshot();
+    expect(Object.keys(snap)).toHaveLength(0);
+  });
+
+  test('clearAll on an empty store is a no-op (does not throw)', async () => {
+    await expect(store.clearAll()).resolves.toBeUndefined();
+  });
+
+  test('clearAll leaves unrelated adapter keys untouched', async () => {
+    await adapter.set({ 'unrelated-key': { keep: true } });
+    await store.write('https://example.com/a', { wordIndex: 1, totalWords: 10 });
+
+    await store.clearAll();
+
+    const snap = adapter.snapshot();
+    expect(snap['unrelated-key']).toEqual({ keep: true });
   });
 });

--- a/src/core/storage/reading-position.ts
+++ b/src/core/storage/reading-position.ts
@@ -118,9 +118,19 @@ export interface ReadingPositionStore {
    */
   list(): Promise<Array<{ url: string; position: ReadingPosition }>>;
   /**
-   * Removes every persisted position and the LRU index itself. Exposed
-   * for #49 (popup "clear reading history" affordance). Non-position
-   * keys in the adapter are left untouched.
+   * Removes every position currently tracked in the LRU index, plus
+   * the index itself. Exposed for #49 (popup "clear reading history"
+   * affordance). Non-position keys in the adapter are left untouched.
+   *
+   * Orphaned `position:*` keys that are NOT referenced by the index
+   * (e.g. from a crashed write that updated the payload but not the
+   * index) are NOT cleaned by this call — they remain dormant in
+   * `chrome.storage.local` and are only recovered when their URL is
+   * next written. `chrome.storage.local` has no prefix-scan API; a
+   * full sweep would require `get(null)` which loads the entire
+   * extension storage (settings, session state, future feature
+   * payloads) into memory on a hot user-facing path. Tracked as a
+   * separate maintenance follow-up.
    */
   clearAll(): Promise<void>;
 }
@@ -164,6 +174,26 @@ export function createReadingPositionStore(
     await adapter.set({ [POSITION_INDEX_KEY]: next });
   }
 
+  /**
+   * Smart constructor for `ReadingPosition`. Centralises the cross-field
+   * invariant `0 <= wordIndex < totalWords` so the runtime guard isn't
+   * scattered across `parseStored` and `write`. Returns `undefined`
+   * when any field is missing, non-integer, out-of-range, or violates
+   * the cross-field bound. Module-private — callers reach this through
+   * `parseStored` or the `write` path.
+   */
+  function makeReadingPosition(
+    wordIndex: number,
+    totalWords: number,
+    lastReadAt: number,
+  ): ReadingPosition | undefined {
+    if (!Number.isInteger(wordIndex) || wordIndex < 0) return undefined;
+    if (!Number.isInteger(totalWords) || totalWords <= 0) return undefined;
+    if (wordIndex >= totalWords) return undefined;
+    if (!Number.isFinite(lastReadAt) || lastReadAt < 0) return undefined;
+    return { wordIndex, totalWords, lastReadAt };
+  }
+
   function parseStored(raw: unknown): ReadingPosition | undefined {
     if (raw === null || typeof raw !== 'object') return undefined;
     const r = raw as Partial<StoredPayload>;
@@ -171,20 +201,10 @@ export function createReadingPositionStore(
     // Forward-incompat — let a newer build's payload pass through
     // untouched rather than silently downgrade it.
     if (r.schemaVersion > POSITION_SCHEMA_VERSION) return undefined;
-    if (typeof r.wordIndex !== 'number' || !Number.isInteger(r.wordIndex) || r.wordIndex < 0) {
-      return undefined;
-    }
-    if (typeof r.totalWords !== 'number' || !Number.isInteger(r.totalWords) || r.totalWords <= 0) {
-      return undefined;
-    }
-    if (typeof r.lastReadAt !== 'number' || !Number.isFinite(r.lastReadAt)) {
-      return undefined;
-    }
-    return {
-      wordIndex: r.wordIndex,
-      totalWords: r.totalWords,
-      lastReadAt: r.lastReadAt,
-    };
+    if (typeof r.wordIndex !== 'number') return undefined;
+    if (typeof r.totalWords !== 'number') return undefined;
+    if (typeof r.lastReadAt !== 'number') return undefined;
+    return makeReadingPosition(r.wordIndex, r.totalWords, r.lastReadAt);
   }
 
   /**
@@ -210,12 +230,10 @@ export function createReadingPositionStore(
     write(url, position) {
       const key = positionKey(url);
       if (key === null) return Promise.resolve();
-      if (
-        !Number.isInteger(position.wordIndex) ||
-        position.wordIndex < 0 ||
-        !Number.isInteger(position.totalWords) ||
-        position.totalWords <= 0
-      ) {
+      // Validate via the smart constructor BEFORE enqueuing so a bad
+      // call rejects synchronously and the queue stays unblocked.
+      const validated = makeReadingPosition(position.wordIndex, position.totalWords, now());
+      if (validated === undefined) {
         return Promise.reject(
           new RangeError(`reading-position.write: invalid position ${JSON.stringify(position)}`),
         );
@@ -227,10 +245,13 @@ export function createReadingPositionStore(
         const existing = await adapter.get([key]);
         if (isForwardIncompat(existing[key])) return;
 
+        // Re-stamp `lastReadAt` at the moment the write actually
+        // executes (post-queue) so the LRU timestamp reflects when
+        // the record landed, not when the caller dispatched.
         const payload: StoredPayload = {
           schemaVersion: POSITION_SCHEMA_VERSION,
-          wordIndex: position.wordIndex,
-          totalWords: position.totalWords,
+          wordIndex: validated.wordIndex,
+          totalWords: validated.totalWords,
           lastReadAt: now(),
         };
 

--- a/src/core/storage/reading-position.ts
+++ b/src/core/storage/reading-position.ts
@@ -13,6 +13,10 @@
  *     so it can run against the real `chrome.storage.local` in the
  *     extension AND against an in-memory fake in unit tests, without
  *     dragging `chrome.*` into `src/core/`.
+ *   - Mutation paths (write / touch / clear / clearAll) serialise
+ *     through a per-instance promise queue so concurrent dispatches
+ *     cannot corrupt the LRU index by interleaving read-modify-write
+ *     cycles. Reads remain concurrent — they only consult the adapter.
  *
  * Storage layout:
  *   - `position:<canonicalUrl>` → `{ schemaVersion, wordIndex, totalWords, lastReadAt }`
@@ -21,8 +25,11 @@
  *
  * Schema versioning: payloads with a `schemaVersion` greater than
  * `POSITION_SCHEMA_VERSION` are ignored on read so an older build
- * cannot misinterpret a newer payload's shape. Lower versions would be
- * migrated by a follow-up; today we only have v1.
+ * cannot misinterpret a newer payload's shape. Write paths also
+ * pre-check the stored record and abort silently when it already
+ * carries a higher version — preserves the newer record across a
+ * downgrade. Lower versions would be migrated by a follow-up; today
+ * we only have v1.
  */
 
 import { canonicalizeUrl } from '../url/canonicalize';
@@ -43,9 +50,16 @@ export const POSITION_KEY_PREFIX = 'position:';
 /** Key for the LRU order array. */
 export const POSITION_INDEX_KEY = 'position-index';
 
-/** Computes the storage key for a canonical URL. */
-export function positionKey(url: string): string {
-  return `${POSITION_KEY_PREFIX}${canonicalizeUrl(url)}`;
+/**
+ * Computes the storage key for a canonical URL, or `null` when the
+ * URL is not persistable (disallowed scheme, length cap, unparseable
+ * — see `core/url/canonicalize.ts`). Callers MUST treat `null` as
+ * "skip persistence".
+ */
+export function positionKey(url: string): string | null {
+  const canonical = canonicalizeUrl(url);
+  if (canonical === null) return null;
+  return `${POSITION_KEY_PREFIX}${canonical}`;
 }
 
 /**
@@ -80,15 +94,35 @@ export interface ReadingPositionStore {
    * Persist a position for `url`. Updates `lastReadAt` to `now()` and
    * promotes the entry to the most-recent LRU slot. Evicts the oldest
    * URL if the write would exceed `POSITION_LRU_MAX` distinct entries.
+   *
+   * Silently no-ops when `url` does not canonicalize (non-http(s)
+   * scheme, exceeds length cap, unparseable). Silently no-ops when
+   * the existing stored record carries a higher schema version (an
+   * older build must not clobber a newer build's payload).
    */
   write(url: string, position: { wordIndex: number; totalWords: number }): Promise<void>;
   /**
    * Bump `lastReadAt` and the LRU slot for `url` without changing the
-   * stored `wordIndex`/`totalWords`. No-op when `url` has no record.
+   * stored `wordIndex`/`totalWords`. No-op when `url` has no record,
+   * does not canonicalize, or the record carries a higher schema
+   * version.
    */
   touch(url: string): Promise<void>;
-  /** Delete the entry for `url`. No-op when absent. */
+  /** Delete the entry for `url`. No-op when absent or non-canonicalizable. */
   clear(url: string): Promise<void>;
+  /**
+   * Returns every stored entry in LRU order, most-recent first
+   * (reverse of the on-disk index, which is oldest-first). Skips
+   * malformed and forward-incompat records silently. Exposed for #49
+   * (popup "recently read" surface).
+   */
+  list(): Promise<Array<{ url: string; position: ReadingPosition }>>;
+  /**
+   * Removes every persisted position and the LRU index itself. Exposed
+   * for #49 (popup "clear reading history" affordance). Non-position
+   * keys in the adapter are left untouched.
+   */
+  clearAll(): Promise<void>;
 }
 
 export interface CreateReadingPositionStoreOptions {
@@ -100,6 +134,22 @@ export function createReadingPositionStore(
   opts: CreateReadingPositionStoreOptions,
 ): ReadingPositionStore {
   const { adapter, now } = opts;
+
+  // Per-instance mutation queue. Every write/touch/clear/clearAll
+  // chains onto this so the read-modify-write of the LRU index never
+  // interleaves with another mutation against the same adapter. Reads
+  // remain concurrent — they only sample the adapter snapshot.
+  let writeQueue: Promise<void> = Promise.resolve();
+  function enqueue<T>(op: () => Promise<T>): Promise<T> {
+    const run = writeQueue.then(op, op);
+    // Drop the value from the queue chain and swallow rejections so a
+    // single failed op doesn't poison the queue for subsequent calls.
+    writeQueue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
 
   async function readIndex(): Promise<string[]> {
     const got = await adapter.get([POSITION_INDEX_KEY]);
@@ -137,75 +187,133 @@ export function createReadingPositionStore(
     };
   }
 
+  /**
+   * Returns true when the raw stored value at `key` carries a
+   * schemaVersion higher than the current build. Write paths consult
+   * this before clobbering so a downgrade never overwrites a record
+   * an upgrade installed.
+   */
+  function isForwardIncompat(raw: unknown): boolean {
+    if (raw === null || typeof raw !== 'object') return false;
+    const r = raw as { schemaVersion?: unknown };
+    return typeof r.schemaVersion === 'number' && r.schemaVersion > POSITION_SCHEMA_VERSION;
+  }
+
   return {
     async read(url) {
       const key = positionKey(url);
+      if (key === null) return undefined;
       const got = await adapter.get([key]);
       return parseStored(got[key]);
     },
 
-    async write(url, position) {
+    write(url, position) {
+      const key = positionKey(url);
+      if (key === null) return Promise.resolve();
       if (
         !Number.isInteger(position.wordIndex) ||
         position.wordIndex < 0 ||
         !Number.isInteger(position.totalWords) ||
         position.totalWords <= 0
       ) {
-        throw new RangeError(
-          `reading-position.write: invalid position ${JSON.stringify(position)}`,
+        return Promise.reject(
+          new RangeError(`reading-position.write: invalid position ${JSON.stringify(position)}`),
         );
       }
+      return enqueue(async () => {
+        // Forward-incompat guard — preserve the newer record. Re-read
+        // the raw payload BEFORE touching the index so a downgrade can
+        // never strand the LRU slot pointing at an unreadable record.
+        const existing = await adapter.get([key]);
+        if (isForwardIncompat(existing[key])) return;
+
+        const payload: StoredPayload = {
+          schemaVersion: POSITION_SCHEMA_VERSION,
+          wordIndex: position.wordIndex,
+          totalWords: position.totalWords,
+          lastReadAt: now(),
+        };
+
+        const index = await readIndex();
+        // Remove an existing slot for this URL so the new write promotes it
+        // to the most-recent end rather than counting as a new slot.
+        const filtered = index.filter((k) => k !== key);
+        filtered.push(key);
+
+        // Evict from the FRONT until we are at or under the cap.
+        const toEvict: string[] = [];
+        while (filtered.length > POSITION_LRU_MAX) {
+          const oldest = filtered.shift();
+          if (oldest !== undefined) toEvict.push(oldest);
+        }
+
+        await adapter.set({ [key]: payload });
+        await writeIndex(filtered);
+        if (toEvict.length > 0) await adapter.remove(toEvict);
+      });
+    },
+
+    touch(url) {
       const key = positionKey(url);
-      const payload: StoredPayload = {
-        schemaVersion: POSITION_SCHEMA_VERSION,
-        wordIndex: position.wordIndex,
-        totalWords: position.totalWords,
-        lastReadAt: now(),
-      };
+      if (key === null) return Promise.resolve();
+      return enqueue(async () => {
+        const got = await adapter.get([key]);
+        // Forward-incompat — the record is newer than we understand;
+        // do not rewrite it (parseStored would return undefined and
+        // we'd silently drop the index slot, stranding the record).
+        if (isForwardIncompat(got[key])) return;
+        const existing = parseStored(got[key]);
+        if (!existing) return;
 
+        const payload: StoredPayload = {
+          schemaVersion: POSITION_SCHEMA_VERSION,
+          wordIndex: existing.wordIndex,
+          totalWords: existing.totalWords,
+          lastReadAt: now(),
+        };
+        const index = await readIndex();
+        const filtered = index.filter((k) => k !== key);
+        filtered.push(key);
+        await adapter.set({ [key]: payload });
+        await writeIndex(filtered);
+      });
+    },
+
+    clear(url) {
+      const key = positionKey(url);
+      if (key === null) return Promise.resolve();
+      return enqueue(async () => {
+        const index = await readIndex();
+        const filtered = index.filter((k) => k !== key);
+        await adapter.remove([key]);
+        if (filtered.length !== index.length) await writeIndex(filtered);
+      });
+    },
+
+    async list() {
       const index = await readIndex();
-      // Remove an existing slot for this URL so the new write promotes it
-      // to the most-recent end rather than counting as a new slot.
-      const filtered = index.filter((k) => k !== key);
-      filtered.push(key);
-
-      // Evict from the FRONT until we are at or under the cap.
-      const toEvict: string[] = [];
-      while (filtered.length > POSITION_LRU_MAX) {
-        const oldest = filtered.shift();
-        if (oldest !== undefined) toEvict.push(oldest);
+      if (index.length === 0) return [];
+      // Fetch payloads + index in one round trip when the adapter
+      // supports batched gets.
+      const got = await adapter.get(index);
+      // Reverse — index is oldest-first; callers want most-recent first.
+      const out: Array<{ url: string; position: ReadingPosition }> = [];
+      for (let i = index.length - 1; i >= 0; i--) {
+        const key = index[i];
+        const parsed = parseStored(got[key]);
+        if (!parsed) continue;
+        const url = key.slice(POSITION_KEY_PREFIX.length);
+        out.push({ url, position: parsed });
       }
-
-      await adapter.set({ [key]: payload });
-      await writeIndex(filtered);
-      if (toEvict.length > 0) await adapter.remove(toEvict);
+      return out;
     },
 
-    async touch(url) {
-      const key = positionKey(url);
-      const got = await adapter.get([key]);
-      const existing = parseStored(got[key]);
-      if (!existing) return;
-
-      const payload: StoredPayload = {
-        schemaVersion: POSITION_SCHEMA_VERSION,
-        wordIndex: existing.wordIndex,
-        totalWords: existing.totalWords,
-        lastReadAt: now(),
-      };
-      const index = await readIndex();
-      const filtered = index.filter((k) => k !== key);
-      filtered.push(key);
-      await adapter.set({ [key]: payload });
-      await writeIndex(filtered);
-    },
-
-    async clear(url) {
-      const key = positionKey(url);
-      const index = await readIndex();
-      const filtered = index.filter((k) => k !== key);
-      await adapter.remove([key]);
-      if (filtered.length !== index.length) await writeIndex(filtered);
+    clearAll() {
+      return enqueue(async () => {
+        const index = await readIndex();
+        if (index.length > 0) await adapter.remove(index);
+        await adapter.remove([POSITION_INDEX_KEY]);
+      });
     },
   };
 }

--- a/src/core/storage/reading-position.ts
+++ b/src/core/storage/reading-position.ts
@@ -1,0 +1,211 @@
+/**
+ * Persistent per-URL reading-position store (#48).
+ *
+ * Persists the user's RSVP reading position so closing the overlay on
+ * an article and revisiting later auto-resumes at the same word. Keyed
+ * by the canonical URL (`src/core/url/canonicalize.ts`) so utm tags,
+ * fragments, and host casing collapse into the same slot.
+ *
+ * Constraints:
+ *   - LRU-capped at `POSITION_LRU_MAX` (100). The oldest URL by
+ *     `lastReadAt` is evicted when adding the 101st distinct URL.
+ *   - Storage-adapter agnostic. This module accepts a `StorageAdapter`
+ *     so it can run against the real `chrome.storage.local` in the
+ *     extension AND against an in-memory fake in unit tests, without
+ *     dragging `chrome.*` into `src/core/`.
+ *
+ * Storage layout:
+ *   - `position:<canonicalUrl>` → `{ schemaVersion, wordIndex, totalWords, lastReadAt }`
+ *   - `position-index` → `string[]` of position keys in LRU order
+ *     (oldest at index 0, most-recent at index N-1)
+ *
+ * Schema versioning: payloads with a `schemaVersion` greater than
+ * `POSITION_SCHEMA_VERSION` are ignored on read so an older build
+ * cannot misinterpret a newer payload's shape. Lower versions would be
+ * migrated by a follow-up; today we only have v1.
+ */
+
+import { canonicalizeUrl } from '../url/canonicalize';
+
+/**
+ * Soft cap on the number of distinct URLs the store retains. Chosen to
+ * stay well under the 5 MB total quota for `chrome.storage.local`
+ * (~0.5 KB per entry × 100 = ~50 KB, ~1% of quota).
+ */
+export const POSITION_LRU_MAX = 100;
+
+/** Bumped when the stored payload shape changes. */
+export const POSITION_SCHEMA_VERSION = 1;
+
+/** Key prefix for the per-URL payload. */
+export const POSITION_KEY_PREFIX = 'position:';
+
+/** Key for the LRU order array. */
+export const POSITION_INDEX_KEY = 'position-index';
+
+/** Computes the storage key for a canonical URL. */
+export function positionKey(url: string): string {
+  return `${POSITION_KEY_PREFIX}${canonicalizeUrl(url)}`;
+}
+
+/**
+ * Persisted record shape. `lastReadAt` is the wall-clock ms epoch of
+ * the most recent write/touch; used by the LRU index for ordering.
+ */
+export interface ReadingPosition {
+  readonly wordIndex: number;
+  readonly totalWords: number;
+  readonly lastReadAt: number;
+}
+
+interface StoredPayload extends ReadingPosition {
+  readonly schemaVersion: number;
+}
+
+/**
+ * Minimal storage contract — matches the subset of
+ * `chrome.storage.local` the store uses. Test fakes implement the same
+ * three methods against an in-memory map.
+ */
+export interface StorageAdapter {
+  get(keys: string[]): Promise<Record<string, unknown>>;
+  set(items: Record<string, unknown>): Promise<void>;
+  remove(keys: string[]): Promise<void>;
+}
+
+export interface ReadingPositionStore {
+  /** Returns the stored position for `url`, or undefined. */
+  read(url: string): Promise<ReadingPosition | undefined>;
+  /**
+   * Persist a position for `url`. Updates `lastReadAt` to `now()` and
+   * promotes the entry to the most-recent LRU slot. Evicts the oldest
+   * URL if the write would exceed `POSITION_LRU_MAX` distinct entries.
+   */
+  write(url: string, position: { wordIndex: number; totalWords: number }): Promise<void>;
+  /**
+   * Bump `lastReadAt` and the LRU slot for `url` without changing the
+   * stored `wordIndex`/`totalWords`. No-op when `url` has no record.
+   */
+  touch(url: string): Promise<void>;
+  /** Delete the entry for `url`. No-op when absent. */
+  clear(url: string): Promise<void>;
+}
+
+export interface CreateReadingPositionStoreOptions {
+  adapter: StorageAdapter;
+  now: () => number;
+}
+
+export function createReadingPositionStore(
+  opts: CreateReadingPositionStoreOptions,
+): ReadingPositionStore {
+  const { adapter, now } = opts;
+
+  async function readIndex(): Promise<string[]> {
+    const got = await adapter.get([POSITION_INDEX_KEY]);
+    const raw = got[POSITION_INDEX_KEY];
+    if (!Array.isArray(raw)) return [];
+    // Defensive — filter out non-strings so a corrupted payload can't
+    // crash the LRU recomputation.
+    return raw.filter((x): x is string => typeof x === 'string');
+  }
+
+  async function writeIndex(next: string[]): Promise<void> {
+    await adapter.set({ [POSITION_INDEX_KEY]: next });
+  }
+
+  function parseStored(raw: unknown): ReadingPosition | undefined {
+    if (raw === null || typeof raw !== 'object') return undefined;
+    const r = raw as Partial<StoredPayload>;
+    if (typeof r.schemaVersion !== 'number') return undefined;
+    // Forward-incompat — let a newer build's payload pass through
+    // untouched rather than silently downgrade it.
+    if (r.schemaVersion > POSITION_SCHEMA_VERSION) return undefined;
+    if (typeof r.wordIndex !== 'number' || !Number.isInteger(r.wordIndex) || r.wordIndex < 0) {
+      return undefined;
+    }
+    if (typeof r.totalWords !== 'number' || !Number.isInteger(r.totalWords) || r.totalWords <= 0) {
+      return undefined;
+    }
+    if (typeof r.lastReadAt !== 'number' || !Number.isFinite(r.lastReadAt)) {
+      return undefined;
+    }
+    return {
+      wordIndex: r.wordIndex,
+      totalWords: r.totalWords,
+      lastReadAt: r.lastReadAt,
+    };
+  }
+
+  return {
+    async read(url) {
+      const key = positionKey(url);
+      const got = await adapter.get([key]);
+      return parseStored(got[key]);
+    },
+
+    async write(url, position) {
+      if (
+        !Number.isInteger(position.wordIndex) ||
+        position.wordIndex < 0 ||
+        !Number.isInteger(position.totalWords) ||
+        position.totalWords <= 0
+      ) {
+        throw new RangeError(
+          `reading-position.write: invalid position ${JSON.stringify(position)}`,
+        );
+      }
+      const key = positionKey(url);
+      const payload: StoredPayload = {
+        schemaVersion: POSITION_SCHEMA_VERSION,
+        wordIndex: position.wordIndex,
+        totalWords: position.totalWords,
+        lastReadAt: now(),
+      };
+
+      const index = await readIndex();
+      // Remove an existing slot for this URL so the new write promotes it
+      // to the most-recent end rather than counting as a new slot.
+      const filtered = index.filter((k) => k !== key);
+      filtered.push(key);
+
+      // Evict from the FRONT until we are at or under the cap.
+      const toEvict: string[] = [];
+      while (filtered.length > POSITION_LRU_MAX) {
+        const oldest = filtered.shift();
+        if (oldest !== undefined) toEvict.push(oldest);
+      }
+
+      await adapter.set({ [key]: payload });
+      await writeIndex(filtered);
+      if (toEvict.length > 0) await adapter.remove(toEvict);
+    },
+
+    async touch(url) {
+      const key = positionKey(url);
+      const got = await adapter.get([key]);
+      const existing = parseStored(got[key]);
+      if (!existing) return;
+
+      const payload: StoredPayload = {
+        schemaVersion: POSITION_SCHEMA_VERSION,
+        wordIndex: existing.wordIndex,
+        totalWords: existing.totalWords,
+        lastReadAt: now(),
+      };
+      const index = await readIndex();
+      const filtered = index.filter((k) => k !== key);
+      filtered.push(key);
+      await adapter.set({ [key]: payload });
+      await writeIndex(filtered);
+    },
+
+    async clear(url) {
+      const key = positionKey(url);
+      const index = await readIndex();
+      const filtered = index.filter((k) => k !== key);
+      await adapter.remove([key]);
+      if (filtered.length !== index.length) await writeIndex(filtered);
+    },
+  };
+}

--- a/src/core/url/__tests__/canonicalize.test.ts
+++ b/src/core/url/__tests__/canonicalize.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for `canonicalizeUrl` (#48).
+ *
+ * The canonicalization is the join key for persisted reading positions.
+ * Two URLs that differ only in fragment, utm_* tracking params, or host
+ * casing should collapse to the same key so a returning reader resumes
+ * regardless of how they re-arrived at the page.
+ */
+import { describe, expect, test } from 'vitest';
+import { canonicalizeUrl } from '../canonicalize';
+
+describe('canonicalizeUrl', () => {
+  test('strips the URL fragment', () => {
+    expect(canonicalizeUrl('https://example.com/article#section-2')).toBe(
+      'https://example.com/article',
+    );
+  });
+
+  test('strips a single utm_* query param while preserving other params', () => {
+    expect(canonicalizeUrl('https://example.com/post?id=42&utm_source=twitter')).toBe(
+      'https://example.com/post?id=42',
+    );
+  });
+
+  test('strips multiple utm_* params (utm_source, utm_medium, utm_campaign, utm_term, utm_content)', () => {
+    const input =
+      'https://example.com/x?a=1&utm_source=fb&utm_medium=cpc&utm_campaign=spring&utm_term=foo&utm_content=bar&b=2';
+    expect(canonicalizeUrl(input)).toBe('https://example.com/x?a=1&b=2');
+  });
+
+  test('strips arbitrary utm_-prefixed params (utm_xyz)', () => {
+    expect(canonicalizeUrl('https://example.com/?utm_custom=abc&keep=yes')).toBe(
+      'https://example.com/?keep=yes',
+    );
+  });
+
+  test('lowercases the host while leaving the path case-sensitive', () => {
+    expect(canonicalizeUrl('https://EXAMPLE.COM/CaseSensitive/Path')).toBe(
+      'https://example.com/CaseSensitive/Path',
+    );
+  });
+
+  test('preserves non-utm query params (id, q, page, etc.)', () => {
+    expect(canonicalizeUrl('https://example.com/search?q=rsvp&page=3')).toBe(
+      'https://example.com/search?q=rsvp&page=3',
+    );
+  });
+
+  test('preserves params whose names contain but do not start with utm_', () => {
+    // `not_utm_source` is NOT a tracking param — only utm_-prefixed names
+    // should be dropped.
+    expect(canonicalizeUrl('https://example.com/?not_utm_source=x&kutm_source=y')).toBe(
+      'https://example.com/?not_utm_source=x&kutm_source=y',
+    );
+  });
+
+  test('combines fragment strip + utm strip + host lowercase in a single pass', () => {
+    const input = 'https://EXAMPLE.com/post?id=5&utm_source=fb#fragment';
+    expect(canonicalizeUrl(input)).toBe('https://example.com/post?id=5');
+  });
+
+  test('is idempotent — canonicalize(canonicalize(u)) === canonicalize(u)', () => {
+    const inputs = [
+      'https://example.com/x?a=1&utm_source=fb#frag',
+      'http://EXAMPLE.org/path',
+      'https://example.com/page?q=test',
+      'https://example.com/?utm_a=1&utm_b=2',
+    ];
+    for (const input of inputs) {
+      const once = canonicalizeUrl(input);
+      const twice = canonicalizeUrl(once);
+      expect(twice).toBe(once);
+    }
+  });
+
+  test('returns the input verbatim when URL parsing fails (defensive)', () => {
+    // Malformed input — caller should never pass this, but the canonical
+    // form must never throw because it is on the activation hot path.
+    expect(canonicalizeUrl('not a url')).toBe('not a url');
+  });
+
+  test('handles URLs with no path (only host) without inserting a stray slash beyond what URL produces', () => {
+    // `new URL('https://example.com').toString()` adds a trailing slash;
+    // we accept that as the canonical form (matches WHATWG URL spec).
+    expect(canonicalizeUrl('https://example.com')).toBe('https://example.com/');
+  });
+
+  test('preserves port and userinfo unchanged (out of scope for this canonicalization)', () => {
+    expect(canonicalizeUrl('https://example.com:8080/path?utm_source=x')).toBe(
+      'https://example.com:8080/path',
+    );
+  });
+});

--- a/src/core/url/__tests__/canonicalize.test.ts
+++ b/src/core/url/__tests__/canonicalize.test.ts
@@ -5,9 +5,13 @@
  * Two URLs that differ only in fragment, utm_* tracking params, or host
  * casing should collapse to the same key so a returning reader resumes
  * regardless of how they re-arrived at the page.
+ *
+ * Also asserts the scheme allow-list (http/https only) and the
+ * `MAX_CANONICAL_URL_LENGTH` cap — both return `null` so the store
+ * skips persistence on non-readable origins.
  */
 import { describe, expect, test } from 'vitest';
-import { canonicalizeUrl } from '../canonicalize';
+import { MAX_CANONICAL_URL_LENGTH, canonicalizeUrl } from '../canonicalize';
 
 describe('canonicalizeUrl', () => {
   test('strips the URL fragment', () => {
@@ -68,15 +72,16 @@ describe('canonicalizeUrl', () => {
     ];
     for (const input of inputs) {
       const once = canonicalizeUrl(input);
-      const twice = canonicalizeUrl(once);
+      expect(once).not.toBeNull();
+      const twice = canonicalizeUrl(once as string);
       expect(twice).toBe(once);
     }
   });
 
-  test('returns the input verbatim when URL parsing fails (defensive)', () => {
-    // Malformed input — caller should never pass this, but the canonical
-    // form must never throw because it is on the activation hot path.
-    expect(canonicalizeUrl('not a url')).toBe('not a url');
+  test('returns null when URL parsing fails (defensive)', () => {
+    // Malformed input — caller MUST skip persistence rather than write
+    // a slot that cannot be matched against on revisit.
+    expect(canonicalizeUrl('not a url')).toBeNull();
   });
 
   test('handles URLs with no path (only host) without inserting a stray slash beyond what URL produces', () => {
@@ -89,5 +94,61 @@ describe('canonicalizeUrl', () => {
     expect(canonicalizeUrl('https://example.com:8080/path?utm_source=x')).toBe(
       'https://example.com:8080/path',
     );
+  });
+});
+
+describe('canonicalizeUrl — scheme allow-list', () => {
+  test.each([
+    ['javascript:alert(1)'],
+    ['data:text/plain;base64,SGVsbG8='],
+    ['blob:https://example.com/abc-123'],
+    ['chrome://settings/'],
+    ['chrome-extension://abcdefghijklmnopabcdefghijklmnop/popup.html'],
+    ['file:///Users/alice/notes.md'],
+    ['about:blank'],
+    ['ws://example.com:8080/'],
+    ['wss://example.com/socket'],
+    ['mailto:user@example.com'],
+    ['tel:+15551234567'],
+    ['ftp://example.com/pub/file'],
+    ['view-source:https://example.com/'],
+  ])('rejects %s with null', (input) => {
+    expect(canonicalizeUrl(input)).toBeNull();
+  });
+
+  test('accepts http:', () => {
+    expect(canonicalizeUrl('http://example.com/x')).toBe('http://example.com/x');
+  });
+
+  test('accepts https:', () => {
+    expect(canonicalizeUrl('https://example.com/x')).toBe('https://example.com/x');
+  });
+});
+
+describe('canonicalizeUrl — length cap', () => {
+  test('returns null when the canonical form exceeds MAX_CANONICAL_URL_LENGTH', () => {
+    // Build a URL whose canonical form will exceed the cap. Use a long
+    // path segment of `a` characters; canonicalization doesn't shorten
+    // the path so we can predict the post-cap length precisely.
+    const base = 'https://example.com/';
+    const padding = 'a'.repeat(MAX_CANONICAL_URL_LENGTH); // base + padding > cap
+    const input = base + padding;
+    expect(canonicalizeUrl(input)).toBeNull();
+  });
+
+  test('accepts URLs at exactly MAX_CANONICAL_URL_LENGTH', () => {
+    const base = 'https://example.com/';
+    const padding = 'a'.repeat(MAX_CANONICAL_URL_LENGTH - base.length);
+    const input = base + padding;
+    const got = canonicalizeUrl(input);
+    expect(got).not.toBeNull();
+    expect(got?.length).toBe(MAX_CANONICAL_URL_LENGTH);
+  });
+
+  test('accepts URLs one byte below the cap (boundary)', () => {
+    const base = 'https://example.com/';
+    const padding = 'a'.repeat(MAX_CANONICAL_URL_LENGTH - base.length - 1);
+    const input = base + padding;
+    expect(canonicalizeUrl(input)?.length).toBe(MAX_CANONICAL_URL_LENGTH - 1);
   });
 });

--- a/src/core/url/canonicalize.ts
+++ b/src/core/url/canonicalize.ts
@@ -7,15 +7,24 @@
  * still triggers the resume path.
  *
  * Rules:
+ *   - Only `http:` and `https:` URLs canonicalize; every other scheme
+ *     (javascript:, data:, blob:, chrome:, chrome-extension:, file:,
+ *     about:, ws/wss, mailto:, tel:, etc.) returns `null`. The store's
+ *     read/write paths treat `null` as "skip persistence" so reader
+ *     state is never written for non-readable origins.
+ *   - Length-capped at `MAX_CANONICAL_URL_LENGTH`. The cap protects the
+ *     storage layer (per-entry size budget against the 5 MB
+ *     chrome.storage.local quota) AND limits the attack surface for
+ *     pathological URLs that would dominate the LRU index.
  *   - Drop the URL fragment (`#...`).
  *   - Drop any query param whose name starts with `utm_` (tracking).
  *   - Lowercase the host (path remains case-sensitive — many servers
  *     still serve content keyed off path case).
  *   - Preserve everything else (query order, other params, port,
  *     userinfo).
- *   - Defensive: if the input cannot be parsed as a URL, return it
- *     verbatim. Canonicalization runs on the activation hot path and
- *     MUST NOT throw.
+ *   - Defensive: if the input cannot be parsed as a URL, return `null`.
+ *     Canonicalization runs on the activation hot path and MUST NOT
+ *     throw — but garbage in cannot become a valid storage key.
  *
  * Pure — no `chrome.*`, no DOM. Lives under `src/core/` per the
  * boundary contract in `src/core/README.md`.
@@ -23,12 +32,51 @@
 
 const UTM_PREFIX = 'utm_';
 
-export function canonicalizeUrl(input: string): string {
+/**
+ * Allow-list of URL schemes the store will persist. Anything else
+ * resolves to `null` (skip persistence).
+ *
+ * - `http:` / `https:` — the only schemes for which a "reading
+ *   position" has any meaning. The reader resumes on revisit to the
+ *   same URL; non-web schemes either don't navigate (`javascript:`),
+ *   carry the content in the URL itself (`data:`, `blob:`), or expose
+ *   sensitive extension/system surfaces (`chrome:`,
+ *   `chrome-extension:`, `file:`, `about:`).
+ *
+ * Persisting non-web URLs is also a privacy hazard — `data:` and
+ * `blob:` URLs can be megabytes long; `chrome-extension://<id>/...`
+ * leaks extension IDs across the store; `file://` exposes local paths.
+ */
+const ALLOWED_SCHEMES = new Set(['http:', 'https:']);
+
+/**
+ * Cap on the canonical URL length. 2048 is the historical practical
+ * cap most servers honor and a safe upper bound for storage-key
+ * budgets. Anything longer is either pathological tracker noise or a
+ * server-rendered URL we can't reliably re-derive on revisit, so the
+ * store skips persistence rather than write a slot we cannot match
+ * against later.
+ */
+export const MAX_CANONICAL_URL_LENGTH = 2048;
+
+/**
+ * Returns the canonical URL string for `input`, or `null` when `input`
+ * is not a persistable URL (disallowed scheme, unparseable, or longer
+ * than `MAX_CANONICAL_URL_LENGTH` after canonicalization).
+ *
+ * Callers that persist data keyed by URL MUST treat `null` as "skip"
+ * — do not coerce to empty string, do not fall back to `input`.
+ */
+export function canonicalizeUrl(input: string): string | null {
   let url: URL;
   try {
     url = new URL(input);
   } catch {
-    return input;
+    return null;
+  }
+
+  if (!ALLOWED_SCHEMES.has(url.protocol)) {
+    return null;
   }
 
   // Lowercase host. `URL.host` setter handles port preservation.
@@ -47,5 +95,9 @@ export function canonicalizeUrl(input: string): string {
     url.searchParams.delete(key);
   }
 
-  return url.toString();
+  const canonical = url.toString();
+  if (canonical.length > MAX_CANONICAL_URL_LENGTH) {
+    return null;
+  }
+  return canonical;
 }

--- a/src/core/url/canonicalize.ts
+++ b/src/core/url/canonicalize.ts
@@ -1,0 +1,51 @@
+/**
+ * URL canonicalization for the reading-position store (#48).
+ *
+ * Two browser visits to "the same article" should collapse to the same
+ * storage key so that closing and revisiting via a fresh share link
+ * (with utm tags, with a #fragment, or with a differently-cased host)
+ * still triggers the resume path.
+ *
+ * Rules:
+ *   - Drop the URL fragment (`#...`).
+ *   - Drop any query param whose name starts with `utm_` (tracking).
+ *   - Lowercase the host (path remains case-sensitive — many servers
+ *     still serve content keyed off path case).
+ *   - Preserve everything else (query order, other params, port,
+ *     userinfo).
+ *   - Defensive: if the input cannot be parsed as a URL, return it
+ *     verbatim. Canonicalization runs on the activation hot path and
+ *     MUST NOT throw.
+ *
+ * Pure — no `chrome.*`, no DOM. Lives under `src/core/` per the
+ * boundary contract in `src/core/README.md`.
+ */
+
+const UTM_PREFIX = 'utm_';
+
+export function canonicalizeUrl(input: string): string {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return input;
+  }
+
+  // Lowercase host. `URL.host` setter handles port preservation.
+  url.host = url.host.toLowerCase();
+
+  // Drop the fragment. Setting hash = '' yields a URL with no `#`.
+  url.hash = '';
+
+  // Drop utm_* params. URLSearchParams.delete mutates in place and
+  // preserves the relative order of remaining entries.
+  const drop: string[] = [];
+  for (const key of url.searchParams.keys()) {
+    if (key.startsWith(UTM_PREFIX)) drop.push(key);
+  }
+  for (const key of drop) {
+    url.searchParams.delete(key);
+  }
+
+  return url.toString();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
       'src/chrome/content/**/__tests__/**/*.test.ts',
       'src/chrome/options/**/__tests__/**/*.test.ts',
       'src/chrome/popup/**/__tests__/**/*.test.ts',
+      'src/chrome/storage/**/__tests__/**/*.test.ts',
       'src/chrome/welcome/**/__tests__/**/*.test.ts',
     ],
     exclude: ['node_modules/**', 'dist/**'],


### PR DESCRIPTION
## Summary

- Persists RSVP reading position per canonical URL via `chrome.storage.local` with a 100-entry LRU cap.
- Auto-resumes the saved word index on overlay mount + shows a non-blocking `role="status" aria-live="polite"` toast offering a Start Over link (5 s auto-dismiss).
- Adapter-agnostic core (`src/core/storage/reading-position.ts`) + thin Chrome adapter (`src/chrome/storage/chrome-position-store.ts`). `src/core/**` boundary preserved: no `chrome.*` imports.

Closes #48 — first of M2 "v1 remaining" batch A (#48 storage layer → #49 history view consumes the same canonical-URL keyspace).

## Locked design decisions (none re-litigated mid-build)

| Axis | Decision | Why |
|---|---|---|
| URL canonicalization | Strip fragment + `utm_*`, lowercase host, preserve other query params | Same article reachable via tracking-tagged links should resume |
| Position granularity | Word index (`number`, 0-based) | RSVP renders per-word; natural restore unit; survives minor text drift |
| Restore UX | Auto-resume + dismissable toast | Industry default (Pocket, Instapaper); zero-click for users who want it |
| LRU cap | 100 URLs, evict oldest by `lastReadAt`, touch on every write | Bounded local storage; survives chrome.storage.local quotas |
| Onboarding interaction | None | New users have no positions; restore path is a no-op |

## Decisions beyond the locked five (surfaced for review)

1. **Persistence is full-scope only.** Selection-scope (`#25`) has no replay surface — selection text doesn't survive navigation. The session-scope shim still handles in-tab selection resume.
2. **1 s trailing-edge debounce on writes** + flush-on-close. At 600 wpm undebounced = 600 writes/min; the 1 s staleness window is invisible during reading.
3. **Resume precedence: session > persistent.** Same-session reopen is more current than a previous-session persisted value.
4. **`chrome.storage.local` availability guard** in the adapter — silently degrades on harnesses with a partial `chrome` namespace.

## Mutation evidence (assertion discrimination)

| Production line mutated | Mutation | Test that caught it |
|---|---|---|
| `canonicalize.ts:43` `key.startsWith(UTM_PREFIX)` | → `key.includes(UTM_PREFIX)` | `preserves params whose names contain but do not start with utm_` |
| `reading-position.ts:168` `while (filtered.length > POSITION_LRU_MAX)` | → `>=` (over-eviction) | 3 LRU tests went red (cap, overwrite-doesn't-promote, touch-protects-oldest) |
| `overlay.ts` toast guard `resumedAt !== null && opts.resumeToast` | dropped left clause | `mount with resumeToast but no real resume (initialIndex=0) does NOT render the toast` |
| `chrome-position-store.ts` adapter `get` | returned `{}` instead of delegating | `round-trips a write through chrome.storage.local` |

All mutations reverted; 979/979 still green after re-run.

## Files changed

**New (7):** `src/core/url/canonicalize.ts` + test, `src/core/storage/reading-position.ts` + test, `src/chrome/storage/chrome-position-store.ts` + test, `src/core/overlay/__tests__/reading-position-restore.test.ts`.

**Modified (6):** `src/chrome/content/index.ts` (store singleton + debounced writer + restore wiring), `src/core/overlay/overlay.ts` (toast DOM + auto-dismiss + onWordAdvance emission), `src/core/overlay/types.ts` (OverlayOptions extension), `src/core/overlay/constants.ts` (toast constants), `src/core/overlay/styles.ts` (`.resume-toast` + forced-colors block), `vitest.config.ts` (chrome/storage test glob).

## Test plan

- [x] `npm run lint` — clean (0 warnings, `--max-warnings=0`)
- [x] `npm run format:check` — all formatted
- [x] `npm test` — 979 passed / 979 (+39 vs base)
- [x] `npm run build` — clean, no TS errors
- [ ] Manual smoke: load unpacked dist/, read an article past word 50, close + reopen → toast shows "Resumed at word N of M", Start Over resets to 0
- [ ] Manual smoke: read 101 distinct articles → first article's position is gone, last 100 preserved (verify via DevTools → Application → Storage → Extension)

## Deferred follow-ups (not in this PR)

- Cross-device sync via `chrome.storage.sync` (quota constraints make it a redesign, not a parameter swap)
- History view consumer of `store.list()` — covered by #49
- URL-pattern allow/deny list ("never remember this site")
- Per-domain disable toggle in options
- Migration scaffold when `POSITION_SCHEMA_VERSION` bumps past 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
