### PR TITLE
feat(popup): reading history list (opt-in, clearable) (#49)

### DIFF
--- a/src/chrome/background/context-menu/__tests__/factory.test.ts
+++ b/src/chrome/background/context-menu/__tests__/factory.test.ts
@@ -6,13 +6,13 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { SettingsV4 } from '../../../../core/settings';
+import type { SettingsV5 } from '../../../../core/settings';
 import { DEFAULT_SETTINGS } from '../../../../core/settings/defaults';
 import { buildMenuItems, type CtxMenuItemId } from '../factory';
 
 const HTTP = ['http://*/*', 'https://*/*'];
 
-function withSettings(partial: Partial<SettingsV4>): SettingsV4 {
+function withSettings(partial: Partial<SettingsV5>): SettingsV5 {
   return { ...DEFAULT_SETTINGS, ...partial };
 }
 

--- a/src/chrome/background/context-menu/__tests__/install.test.ts
+++ b/src/chrome/background/context-menu/__tests__/install.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
-import type { SettingsV4 } from '../../../../core/settings';
+import type { SettingsV5 } from '../../../../core/settings';
 import { DEFAULT_SETTINGS } from '../../../../core/settings/defaults';
 
 vi.mock('../../../settings/storage', () => ({
@@ -101,7 +101,7 @@ describe('ensureContextMenu', () => {
     stub.contextMenus.create.mockClear();
     stub.contextMenus.update.mockClear();
 
-    const nextSettings: SettingsV4 = { ...DEFAULT_SETTINGS, lastUsedWpm: 420 };
+    const nextSettings: SettingsV5 = { ...DEFAULT_SETTINGS, lastUsedWpm: 420 };
     loadSettings.mockResolvedValueOnce(nextSettings);
     await ensureContextMenu();
 
@@ -122,7 +122,7 @@ describe('ensureContextMenu', () => {
     stub.contextMenus.create.mockClear();
     stub.contextMenus.update.mockClear();
 
-    const nextSettings: SettingsV4 = { ...DEFAULT_SETTINGS, contextLine: true };
+    const nextSettings: SettingsV5 = { ...DEFAULT_SETTINGS, contextLine: true };
     loadSettings.mockResolvedValueOnce(nextSettings);
     await ensureContextMenu();
 
@@ -155,7 +155,7 @@ describe('ensureContextMenu', () => {
     let loadResolved = false;
     loadSettings.mockImplementationOnce(
       () =>
-        new Promise<SettingsV4>((resolve) => {
+        new Promise<SettingsV5>((resolve) => {
           setTimeout(() => {
             loadResolved = true;
             resolve(DEFAULT_SETTINGS);

--- a/src/chrome/background/context-menu/factory.ts
+++ b/src/chrome/background/context-menu/factory.ts
@@ -4,7 +4,7 @@
  * No `chrome.*` calls — `install.ts` owns the adapter side. Keeping this
  * file pure means every shape decision (titles, checkbox state, separator
  * placement) is exercised by `factory.test.ts` against a plain
- * `SettingsV4` input without any chrome-stub scaffolding.
+ * `SettingsV5` input without any chrome-stub scaffolding.
  *
  * See:
  * - `docs/superpowers/specs/2026-05-25-context-menu-integration.md`
@@ -13,7 +13,7 @@
  *   §"File Layout" — the factory / adapter / listener split.
  */
 
-import type { SettingsV4 } from '../../../core/settings';
+import type { SettingsV5 } from '../../../core/settings';
 
 /**
  * Stable, versioned menu-item IDs. The `v1` suffix lets a future shape
@@ -63,7 +63,7 @@ const HTTP_PATTERNS = ['http://*/*', 'https://*/*'] as const;
  * `chrome.*` references. Items are emitted in the order they should
  * appear in the submenu; the adapter preserves order on `create`.
  */
-export function buildMenuItems(settings: SettingsV4): CtxItemSpec[] {
+export function buildMenuItems(settings: SettingsV5): CtxItemSpec[] {
   const PARENT_ID: CtxMenuItemId = 'speedreader.ctx.parent.v1';
 
   const parent: CtxItemSpec = {

--- a/src/chrome/content/__tests__/font-wire.test.ts
+++ b/src/chrome/content/__tests__/font-wire.test.ts
@@ -17,7 +17,7 @@
  */
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
-import type { SettingsV4 } from '../../../core/settings/schema';
+import type { SettingsV5 } from '../../../core/settings/schema';
 import { OVERLAY_CLASS } from '../../../core/overlay/constants';
 
 const SETTINGS_KEY = 'speedreader.settings';
@@ -52,10 +52,10 @@ interface ChromeMock {
   };
 }
 
-function installChromeMock(stored: SettingsV4): {
+function installChromeMock(stored: SettingsV5): {
   mock: ChromeMock;
   getListener: () => Listener;
-  emitStorageChange: (next: SettingsV4) => void;
+  emitStorageChange: (next: SettingsV5) => void;
 } {
   let capturedListener: Listener | undefined;
   const storageListeners: StorageChangedListener[] = [];
@@ -89,7 +89,7 @@ function installChromeMock(stored: SettingsV4): {
       if (!capturedListener) throw new Error('content script never registered listener');
       return capturedListener;
     },
-    emitStorageChange: (next: SettingsV4) => {
+    emitStorageChange: (next: SettingsV5) => {
       for (const l of storageListeners) {
         l({ [SETTINGS_KEY]: { newValue: next, oldValue: stored } }, 'sync');
       }

--- a/src/chrome/options/__tests__/controller.test.ts
+++ b/src/chrome/options/__tests__/controller.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { bindOptionsForm, FIELD_IDS, type SettingsApi } from '../controller';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
-import type { SettingsV4 } from '../../../core/settings/schema';
+import type { SettingsV5 } from '../../../core/settings/schema';
 
 const HTML = `
   <div id="load-error-banner"></div>
@@ -30,6 +30,8 @@ const HTML = `
   <input type="checkbox" id="${FIELD_IDS.punctuationPacing}" />
   <input type="checkbox" id="${FIELD_IDS.contextLine}" />
   <input type="checkbox" id="${FIELD_IDS.startFromWordOne}" />
+  <input type="checkbox" id="${FIELD_IDS.historyEnabled}" />
+  <input type="checkbox" id="historyClearOnDisable" />
   <div id="saved"></div>
   <div id="save-error"></div>
 `;
@@ -39,15 +41,15 @@ interface Stub extends SettingsApi {
   saveMock: ReturnType<typeof vi.fn>;
   flushMock: ReturnType<typeof vi.fn>;
   subscribeMock: ReturnType<typeof vi.fn>;
-  emit(s: SettingsV4): void;
+  emit(s: SettingsV5): void;
 }
 
-function makeStub(initial: SettingsV4 = DEFAULT_SETTINGS): Stub {
-  let listener: ((s: SettingsV4) => void) | null = null;
+function makeStub(initial: SettingsV5 = DEFAULT_SETTINGS): Stub {
+  let listener: ((s: SettingsV5) => void) | null = null;
   const loadMock = vi.fn(async () => initial);
   const saveMock = vi.fn(async () => undefined);
   const flushMock = vi.fn(async () => undefined);
-  const subscribeMock = vi.fn((cb: (s: SettingsV4) => void) => {
+  const subscribeMock = vi.fn((cb: (s: SettingsV5) => void) => {
     listener = cb;
     return () => {
       listener = null;
@@ -433,6 +435,104 @@ describe('options controller', () => {
         expect.arrayContaining(['wpm']),
       );
       err.mockRestore();
+    });
+  });
+
+  // #49 — historyEnabled toggle + onHistoryDisabled side-effect hook.
+  // The controller's settings data model is pure SettingsV5; the hook
+  // is the bridge to the position-store wipe action wired in index.ts.
+  describe('history toggle (#49)', () => {
+    it('populates historyEnabled checkbox from loaded settings', async () => {
+      const stub = makeStub({ ...DEFAULT_SETTINGS, historyEnabled: true });
+      await bindOptionsForm(document, window, stub);
+      expect((document.getElementById(FIELD_IDS.historyEnabled) as HTMLInputElement).checked).toBe(
+        true,
+      );
+    });
+
+    it('saves historyEnabled on change like every other field', async () => {
+      const stub = makeStub({ ...DEFAULT_SETTINGS, historyEnabled: false });
+      await bindOptionsForm(document, window, stub);
+      const toggle = document.getElementById(FIELD_IDS.historyEnabled) as HTMLInputElement;
+      toggle.checked = true;
+      fire(toggle, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).toHaveBeenCalledWith({ historyEnabled: true });
+    });
+
+    it('fires onHistoryDisabled when toggle transitions true → false (no companion checked)', async () => {
+      const stub = makeStub({ ...DEFAULT_SETTINGS, historyEnabled: true });
+      const onHistoryDisabled = vi.fn();
+      await bindOptionsForm(document, window, stub, onHistoryDisabled);
+      const toggle = document.getElementById(FIELD_IDS.historyEnabled) as HTMLInputElement;
+      toggle.checked = false;
+      fire(toggle, 'change');
+      await Promise.resolve();
+      expect(onHistoryDisabled).toHaveBeenCalledTimes(1);
+      // Companion checkbox left unchecked — hook receives `false`.
+      expect(onHistoryDisabled).toHaveBeenCalledWith(false);
+    });
+
+    it('passes alsoClearEntries=true when the companion checkbox is checked', async () => {
+      const stub = makeStub({ ...DEFAULT_SETTINGS, historyEnabled: true });
+      const onHistoryDisabled = vi.fn();
+      await bindOptionsForm(document, window, stub, onHistoryDisabled);
+      // User ticks the "Also clear existing entries" companion FIRST,
+      // then disables history. Hook should fire with true.
+      (document.getElementById('historyClearOnDisable') as HTMLInputElement).checked = true;
+      const toggle = document.getElementById(FIELD_IDS.historyEnabled) as HTMLInputElement;
+      toggle.checked = false;
+      fire(toggle, 'change');
+      await Promise.resolve();
+      expect(onHistoryDisabled).toHaveBeenCalledWith(true);
+    });
+
+    it('does NOT fire onHistoryDisabled on false → true transition (only on disable)', async () => {
+      const stub = makeStub({ ...DEFAULT_SETTINGS, historyEnabled: false });
+      const onHistoryDisabled = vi.fn();
+      await bindOptionsForm(document, window, stub, onHistoryDisabled);
+      const toggle = document.getElementById(FIELD_IDS.historyEnabled) as HTMLInputElement;
+      toggle.checked = true;
+      fire(toggle, 'change');
+      await Promise.resolve();
+      expect(onHistoryDisabled).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire onHistoryDisabled twice when the user toggles off, on, off', async () => {
+      // Each off transition must be observed independently; a stale
+      // "lastHistoryEnabled" cache would either miss the second off
+      // (false positive — hook silent on disable) or fire twice in a
+      // row (false negative — hook fires on re-disable AND on the
+      // initial subscribe re-render). Pin both.
+      const stub = makeStub({ ...DEFAULT_SETTINGS, historyEnabled: true });
+      const onHistoryDisabled = vi.fn();
+      await bindOptionsForm(document, window, stub, onHistoryDisabled);
+      const toggle = document.getElementById(FIELD_IDS.historyEnabled) as HTMLInputElement;
+      toggle.checked = false;
+      fire(toggle, 'change');
+      await Promise.resolve();
+      expect(onHistoryDisabled).toHaveBeenCalledTimes(1);
+
+      toggle.checked = true;
+      fire(toggle, 'change');
+      await Promise.resolve();
+      // Still only the original disable.
+      expect(onHistoryDisabled).toHaveBeenCalledTimes(1);
+
+      toggle.checked = false;
+      fire(toggle, 'change');
+      await Promise.resolve();
+      expect(onHistoryDisabled).toHaveBeenCalledTimes(2);
+    });
+
+    it('does NOT fire onHistoryDisabled when omitted from bindOptionsForm', async () => {
+      // No hook supplied → the controller must not throw when the user
+      // toggles off. Defaults still apply (no wipe).
+      const stub = makeStub({ ...DEFAULT_SETTINGS, historyEnabled: true });
+      await bindOptionsForm(document, window, stub /* no hook */);
+      const toggle = document.getElementById(FIELD_IDS.historyEnabled) as HTMLInputElement;
+      toggle.checked = false;
+      expect(() => fire(toggle, 'change')).not.toThrow();
     });
   });
 

--- a/src/chrome/options/__tests__/index-html.test.ts
+++ b/src/chrome/options/__tests__/index-html.test.ts
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { bindOptionsForm, FIELD_IDS, type SettingsApi } from '../controller';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
-import type { SettingsV4 } from '../../../core/settings/schema';
+import type { SettingsV5 } from '../../../core/settings/schema';
 import manifest from '../../manifest';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -50,6 +50,7 @@ describe('options index.html structure', () => {
       ['speed', 'Speed'],
       ['appearance', 'Appearance'],
       ['pacing', 'Pacing'],
+      ['privacy', 'Privacy'],
       ['shortcuts', 'Shortcuts'],
     ])('renders the %s section with legend "%s"', (key, legendText) => {
       const section = doc.querySelector<HTMLFieldSetElement>(`fieldset[data-section="${key}"]`);
@@ -58,7 +59,7 @@ describe('options index.html structure', () => {
       expect(legend?.textContent?.trim()).toBe(legendText);
     });
 
-    it('renders the four sections required by issue #30 (order unconstrained)', () => {
+    it('renders the five sections (issue #30 + #49 privacy section)', () => {
       // No production code reads section order; the per-section it.each above
       // already proves presence + placement. Set-equality avoids overspecifying.
       const sections = new Set(
@@ -66,7 +67,7 @@ describe('options index.html structure', () => {
           el.getAttribute('data-section'),
         ),
       );
-      expect(sections).toEqual(new Set(['speed', 'appearance', 'pacing', 'shortcuts']));
+      expect(sections).toEqual(new Set(['speed', 'appearance', 'pacing', 'privacy', 'shortcuts']));
     });
   });
 
@@ -114,6 +115,7 @@ describe('options index.html structure', () => {
       punctuationPacing: 'Slow down at punctuation',
       contextLine: 'Show line of context around current word',
       startFromWordOne: 'Always start from word one',
+      historyEnabled: 'Remember recently read articles',
     };
 
     it.each(Object.entries(FIELD_IDS))(
@@ -211,7 +213,7 @@ describe('options index.html structure', () => {
    * assertion below go red.
    */
   describe('controller binds against real index.html', () => {
-    function makeStubApi(initial: SettingsV4 = DEFAULT_SETTINGS): SettingsApi & {
+    function makeStubApi(initial: SettingsV5 = DEFAULT_SETTINGS): SettingsApi & {
       loadMock: ReturnType<typeof vi.fn>;
       saveMock: ReturnType<typeof vi.fn>;
       flushMock: ReturnType<typeof vi.fn>;

--- a/src/chrome/options/controller.ts
+++ b/src/chrome/options/controller.ts
@@ -1,4 +1,4 @@
-import type { SettingsV4 } from '../../core/settings/schema';
+import type { SettingsV5 } from '../../core/settings/schema';
 import { DEFAULT_SETTINGS } from '../../core/settings/defaults';
 import {
   FONT_SIZE_MAX,
@@ -10,11 +10,22 @@ import {
 import { resolveFontId } from '../../core/overlay/font-ids';
 
 export interface SettingsApi {
-  load(): Promise<SettingsV4>;
-  save(partial: Partial<Omit<SettingsV4, 'version' | 'lastUsedWpm'>>): Promise<void>;
+  load(): Promise<SettingsV5>;
+  save(partial: Partial<Omit<SettingsV5, 'version' | 'lastUsedWpm'>>): Promise<void>;
   flush(): Promise<void>;
-  subscribe(listener: (s: SettingsV4) => void): () => void;
+  subscribe(listener: (s: SettingsV5) => void): () => void;
 }
+
+/**
+ * Optional side-effect hook (#49). Fires when the user TRANSITIONS the
+ * `historyEnabled` toggle from true → false. The hook receives the
+ * value of the companion "Also clear existing entries" checkbox so the
+ * caller can decide whether to call `store.clearAll()`. Defined here
+ * (not as a method on SettingsApi) so the chrome boundary stays clean:
+ * SettingsApi is pure settings; this is a UX side-effect with no place
+ * in the settings model.
+ */
+export type OnHistoryDisabled = (alsoClearEntries: boolean) => void;
 
 /**
  * IDs the options page HTML form is required to expose. Centralised so the
@@ -30,7 +41,20 @@ export const FIELD_IDS = {
   alignment: 'alignment',
   contextLine: 'contextLine',
   startFromWordOne: 'startFromWordOne',
+  historyEnabled: 'historyEnabled',
 } as const;
+
+/**
+ * Companion checkbox to `historyEnabled` (#49): when the user disables
+ * history, optionally wipe the existing entries from the position store
+ * at the same time. Default unchecked — turning the surface off is the
+ * common case; nuking stored data is the destructive sub-action.
+ *
+ * This ID is read by `index.ts` (the chrome glue), NOT by the controller
+ * — the controller's data model is `SettingsV5` only. The wipe call goes
+ * to the position store directly.
+ */
+export const HISTORY_CLEAR_ON_DISABLE_ID = 'historyClearOnDisable';
 
 const SAVED_INDICATOR_ID = 'saved';
 const SAVE_ERROR_ID = 'save-error';
@@ -39,8 +63,8 @@ const SAVED_INDICATOR_MS = 1500;
 const SAVE_ERROR_MS = 4000;
 
 type EditableField = keyof typeof FIELD_IDS;
-type EditableValue<K extends EditableField> = SettingsV4[K];
-type EditablePatch = Partial<Omit<SettingsV4, 'version' | 'lastUsedWpm'>>;
+type EditableValue<K extends EditableField> = SettingsV5[K];
+type EditablePatch = Partial<Omit<SettingsV5, 'version' | 'lastUsedWpm'>>;
 
 const THEME_VALUES = ['system', 'light', 'dark', 'sepia', 'paper', 'cream', 'nord'] as const;
 const ALIGNMENT_VALUES = ['orp', 'center'] as const;
@@ -51,7 +75,7 @@ function getInput(doc: Document, id: string): HTMLInputElement | HTMLSelectEleme
   return null;
 }
 
-function populate(doc: Document, s: SettingsV4): void {
+function populate(doc: Document, s: SettingsV5): void {
   const wpm = getInput(doc, FIELD_IDS.wpm);
   if (wpm) wpm.value = String(s.wpm);
 
@@ -80,6 +104,9 @@ function populate(doc: Document, s: SettingsV4): void {
 
   const startOne = getInput(doc, FIELD_IDS.startFromWordOne);
   if (startOne instanceof HTMLInputElement) startOne.checked = s.startFromWordOne;
+
+  const historyEnabled = getInput(doc, FIELD_IDS.historyEnabled);
+  if (historyEnabled instanceof HTMLInputElement) historyEnabled.checked = s.historyEnabled;
 }
 
 function flashIndicator(doc: Document, win: Window, id: string, ms: number): void {
@@ -97,7 +124,7 @@ function showLoadErrorBanner(doc: Document): void {
 
 /**
  * Per-field reader. `K` ties the element-read result to the exact
- * `SettingsV4[K]` slot so `theme`-shaped readers can't accidentally return
+ * `SettingsV5[K]` slot so `theme`-shaped readers can't accidentally return
  * a number. Each reader returns `null` to reject invalid input — the binder
  * suppresses save on null, leaving the stored value untouched.
  */
@@ -133,13 +160,13 @@ function readFont(el: HTMLInputElement | HTMLSelectElement): string | null {
   return v;
 }
 
-function readTheme(el: HTMLInputElement | HTMLSelectElement): SettingsV4['theme'] | null {
-  const v = el.value as SettingsV4['theme'];
+function readTheme(el: HTMLInputElement | HTMLSelectElement): SettingsV5['theme'] | null {
+  const v = el.value as SettingsV5['theme'];
   return (THEME_VALUES as readonly string[]).includes(v) ? v : null;
 }
 
-function readAlignment(el: HTMLInputElement | HTMLSelectElement): SettingsV4['alignment'] | null {
-  const v = el.value as SettingsV4['alignment'];
+function readAlignment(el: HTMLInputElement | HTMLSelectElement): SettingsV5['alignment'] | null {
+  const v = el.value as SettingsV5['alignment'];
   return (ALIGNMENT_VALUES as readonly string[]).includes(v) ? v : null;
 }
 
@@ -156,6 +183,7 @@ const FIELD_READERS: { [K in EditableField]: Reader<K> } = {
   alignment: readAlignment,
   contextLine: readCheckbox,
   startFromWordOne: readCheckbox,
+  historyEnabled: readCheckbox,
 };
 
 function bindField<K extends EditableField>(
@@ -205,9 +233,10 @@ export async function bindOptionsForm(
   doc: Document,
   win: Window,
   api: SettingsApi,
+  onHistoryDisabled?: OnHistoryDisabled,
 ): Promise<() => void> {
   let degraded = false;
-  let initial: SettingsV4;
+  let initial: SettingsV5;
   try {
     initial = await api.load();
   } catch (err) {
@@ -238,7 +267,31 @@ export async function bindOptionsForm(
     listeners.push(bindField(doc, win, field, el, api, isSavingAllowed));
   }
 
-  const unsubscribe = api.subscribe((s) => populate(doc, s));
+  // #49 — fire the OnHistoryDisabled hook on a true→false transition of
+  // the historyEnabled toggle. The hook reads the companion checkbox
+  // (HISTORY_CLEAR_ON_DISABLE_ID) to decide whether to wipe entries too.
+  // Tracked locally because settings subscribe re-fires on save and
+  // would double-invoke the hook otherwise.
+  let lastHistoryEnabled = initial.historyEnabled;
+  const historyEl = getInput(doc, FIELD_IDS.historyEnabled);
+  if (historyEl instanceof HTMLInputElement && onHistoryDisabled) {
+    const historyHandler: EventListener = () => {
+      const next = historyEl.checked;
+      if (lastHistoryEnabled === true && next === false) {
+        const clearBox = doc.getElementById(HISTORY_CLEAR_ON_DISABLE_ID);
+        const alsoClear = clearBox instanceof HTMLInputElement && clearBox.checked;
+        onHistoryDisabled(alsoClear);
+      }
+      lastHistoryEnabled = next;
+    };
+    historyEl.addEventListener('change', historyHandler);
+    listeners.push({ el: historyEl, type: 'change', handler: historyHandler });
+  }
+
+  const unsubscribe = api.subscribe((s) => {
+    populate(doc, s);
+    lastHistoryEnabled = s.historyEnabled;
+  });
 
   // Flush pending writes when the page is hidden so a close-before-debounce
   // does not drop the last change. `visibilitychange` covers tab-switch and

--- a/src/chrome/options/index.html
+++ b/src/chrome/options/index.html
@@ -290,6 +290,26 @@
         </div>
       </fieldset>
 
+      <!-- Privacy — #49 history opt-in. -->
+      <fieldset class="section" data-section="privacy">
+        <legend>Privacy</legend>
+        <div class="field inline">
+          <input type="checkbox" id="historyEnabled" />
+          <label for="historyEnabled">Remember recently read articles</label>
+        </div>
+        <p class="hint" id="historyEnabled-hint">
+          Off by default. When on, the popup shows the last 50 articles you
+          opened SpeedReader on. Data is stored locally and never synced or
+          sent anywhere.
+        </p>
+        <div class="field inline">
+          <input type="checkbox" id="historyClearOnDisable" />
+          <label for="historyClearOnDisable">
+            Also clear existing entries when turning this off
+          </label>
+        </div>
+      </fieldset>
+
       <!-- Shortcuts — read-only reference. The toggle binding is set in the
            manifest and can be re-bound by the user at chrome://extensions/shortcuts. -->
       <fieldset class="section" data-section="shortcuts">

--- a/src/chrome/options/index.ts
+++ b/src/chrome/options/index.ts
@@ -6,12 +6,30 @@
  */
 import { bindOptionsForm } from './controller';
 import { loadSettings, saveSettings, flushSettings, subscribeSettings } from '../settings/storage';
+import { createChromePositionStore } from '../storage/chrome-position-store';
 
 document.addEventListener('DOMContentLoaded', () => {
-  void bindOptionsForm(document, window, {
-    load: loadSettings,
-    save: saveSettings,
-    flush: flushSettings,
-    subscribe: subscribeSettings,
-  });
+  // #49 — singleton position store for the optional "Also clear existing
+  // entries" companion action on the historyEnabled toggle. Constructed
+  // at module scope so its internal write-queue serialises any clearAll
+  // call with itself; the popup constructs its own store, but they both
+  // hit `chrome.storage.local` and the per-instance queue is sufficient
+  // for the single user-initiated wipe here.
+  const positionStore = createChromePositionStore();
+  void bindOptionsForm(
+    document,
+    window,
+    {
+      load: loadSettings,
+      save: saveSettings,
+      flush: flushSettings,
+      subscribe: subscribeSettings,
+    },
+    (alsoClearEntries: boolean) => {
+      if (!alsoClearEntries) return;
+      positionStore.clearAll().catch((err: unknown) => {
+        console.error('[speedreader] options: clearAll on history-disable failed', err);
+      });
+    },
+  );
 });

--- a/src/chrome/popup/__tests__/history-integration.test.ts
+++ b/src/chrome/popup/__tests__/history-integration.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Integration tests for the popup `#history-container` wiring (issue #49).
+ *
+ * Asserts the chrome-glue wires the pure `renderHistorySection` to:
+ *   - `loadSettings()` for the historyEnabled flag
+ *   - `ReadingPositionStore.list()` for entries
+ *   - `chrome.tabs.create({ url })` for resume
+ *   - `store.clear(url)` for delete (and the section re-renders without it)
+ *   - `store.clearAll()` for clear-all (and the section shows the empty state)
+ *   - `chrome.runtime.openOptionsPage()` for the Enable link
+ *
+ * Anti-tautology stance:
+ *   - "tabs.create was called with the right URL" (state assertion),
+ *     not "tabs.create was called once".
+ *   - After delete, assert the row is GONE from the DOM, not just that
+ *     `store.clear` was called.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { bootstrapPopup } from '../index';
+import type { ReadingPositionStore } from '../../../core/storage/reading-position';
+
+interface StoreStub extends ReadingPositionStore {
+  __snapshot(): Array<{
+    url: string;
+    position: { wordIndex: number; totalWords: number; lastReadAt: number };
+  }>;
+}
+
+function makeStoreStub(initial: Array<{ url: string; lastReadAt: number }>): StoreStub {
+  // Mutable backing list — list() reads it, clear/clearAll mutate it.
+  let entries = initial.map((e) => ({
+    url: e.url,
+    position: { wordIndex: 0, totalWords: 100, lastReadAt: e.lastReadAt },
+  }));
+  return {
+    read: vi.fn(async () => undefined),
+    write: vi.fn(async () => undefined),
+    touch: vi.fn(async () => undefined),
+    clear: vi.fn(async (url: string) => {
+      entries = entries.filter((e) => e.url !== url);
+    }),
+    list: vi.fn(async () => entries.map((e) => ({ url: e.url, position: { ...e.position } }))),
+    clearAll: vi.fn(async () => {
+      entries = [];
+    }),
+    __snapshot: () => entries,
+  };
+}
+
+function installPopupDom(): void {
+  // Mirrors src/chrome/popup/index.html structure — must include
+  // #history-container so the mount targets it.
+  document.body.innerHTML = `
+    <h1>SpeedReader</h1>
+    <div class="actions">
+      <button type="button" id="read-article" aria-label="Read article">Read article</button>
+      <button type="button" id="read-selection" aria-label="Read selection" aria-disabled="true" disabled>Read selection</button>
+    </div>
+    <div class="status" id="status" role="status" aria-live="polite"></div>
+    <div id="history-container"></div>
+  `;
+}
+
+interface ChromeStubOpts {
+  hasSelection?: boolean;
+}
+
+function makeChromeStub(opts: ChromeStubOpts = {}): typeof chrome & {
+  tabsCreate: ReturnType<typeof vi.fn>;
+  openOptionsPage: ReturnType<typeof vi.fn>;
+} {
+  const tabsCreate = vi.fn(() => Promise.resolve(undefined));
+  const openOptionsPage = vi.fn(() => Promise.resolve(undefined));
+  const stub = {
+    tabs: {
+      query: vi.fn(() => Promise.resolve([{ id: 42 }])),
+      create: tabsCreate,
+    },
+    scripting: {
+      executeScript: vi.fn(() => Promise.resolve([{ result: opts.hasSelection ?? false }])),
+    },
+    runtime: {
+      id: 'test-ext',
+      sendMessage: vi.fn(() => Promise.resolve({ ok: true })),
+      openOptionsPage,
+    },
+  } as unknown as typeof chrome & {
+    tabsCreate: ReturnType<typeof vi.fn>;
+    openOptionsPage: ReturnType<typeof vi.fn>;
+  };
+  stub.tabsCreate = tabsCreate;
+  stub.openOptionsPage = openOptionsPage;
+  return stub;
+}
+
+const NOW = 1_700_000_000_000;
+
+beforeEach(() => {
+  installPopupDom();
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('bootstrapPopup — history section disabled', () => {
+  it('renders the "off" message when historyEnabled is false', async () => {
+    const api = makeChromeStub();
+    const store = makeStoreStub([]);
+    await bootstrapPopup({
+      api,
+      doc: document,
+      loadSettings: async () => ({ historyEnabled: false }),
+      store,
+      now: () => NOW,
+    });
+
+    const container = document.getElementById('history-container') as HTMLElement;
+    expect(container.textContent ?? '').toMatch(/Reading history is off/i);
+    // No store.list() call when disabled — privacy floor.
+    expect(store.list).not.toHaveBeenCalled();
+  });
+
+  it('Enable link click invokes chrome.runtime.openOptionsPage', async () => {
+    const api = makeChromeStub();
+    await bootstrapPopup({
+      api,
+      doc: document,
+      loadSettings: async () => ({ historyEnabled: false }),
+      store: makeStoreStub([]),
+      now: () => NOW,
+    });
+    const enableBtn = document
+      .getElementById('history-container')
+      ?.querySelector('button') as HTMLButtonElement;
+    enableBtn.click();
+    expect(api.openOptionsPage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('bootstrapPopup — history section enabled', () => {
+  it('renders entries from store.list when enabled', async () => {
+    const api = makeChromeStub();
+    const store = makeStoreStub([
+      { url: 'https://example.com/a', lastReadAt: NOW - 30 * 60_000 },
+      { url: 'https://example.com/b', lastReadAt: NOW - 2 * 86_400_000 },
+    ]);
+    await bootstrapPopup({
+      api,
+      doc: document,
+      loadSettings: async () => ({ historyEnabled: true }),
+      store,
+      now: () => NOW,
+    });
+
+    const container = document.getElementById('history-container') as HTMLElement;
+    const items = container.querySelectorAll('[role="listitem"]');
+    expect(items.length).toBe(2);
+    expect(container.textContent).toContain('example.com / a');
+    expect(container.textContent).toContain('30m ago');
+  });
+
+  it('clicking an entry calls chrome.tabs.create with that URL', async () => {
+    const api = makeChromeStub();
+    const store = makeStoreStub([
+      { url: 'https://example.com/article-x', lastReadAt: NOW - 60_000 },
+    ]);
+    await bootstrapPopup({
+      api,
+      doc: document,
+      loadSettings: async () => ({ historyEnabled: true }),
+      store,
+      now: () => NOW,
+    });
+
+    const resumeBtn = document.querySelector<HTMLButtonElement>('button[data-action="resume"]');
+    if (!resumeBtn) throw new Error('test: resume button missing');
+    resumeBtn.click();
+    expect(api.tabsCreate).toHaveBeenCalledWith({ url: 'https://example.com/article-x' });
+  });
+
+  it('clicking delete removes the row from the DOM after re-render', async () => {
+    const api = makeChromeStub();
+    const store = makeStoreStub([
+      { url: 'https://example.com/a', lastReadAt: NOW - 60_000 },
+      { url: 'https://example.com/b', lastReadAt: NOW - 120_000 },
+    ]);
+    await bootstrapPopup({
+      api,
+      doc: document,
+      loadSettings: async () => ({ historyEnabled: true }),
+      store,
+      now: () => NOW,
+    });
+    expect(document.querySelectorAll('[role="listitem"]').length).toBe(2);
+
+    const firstDelete = document.querySelector<HTMLButtonElement>(
+      '[role="listitem"] button[data-action="delete"]',
+    );
+    if (!firstDelete) throw new Error('test: delete button missing');
+    firstDelete.click();
+    // Wait for the async store.clear() + remount.
+    await vi.waitFor(() => {
+      expect(document.querySelectorAll('[role="listitem"]').length).toBe(1);
+    });
+    expect(store.clear).toHaveBeenCalledWith('https://example.com/a');
+    // The REMAINING row is b, not a — observed state change, not call shape.
+    expect(document.body.textContent).toContain('example.com / b');
+    expect(document.body.textContent).not.toContain('example.com / a');
+  });
+
+  it('clicking Clear all (with confirm=true) wipes the list and shows the empty state', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const api = makeChromeStub();
+    const store = makeStoreStub([{ url: 'https://example.com/a', lastReadAt: NOW - 60_000 }]);
+    await bootstrapPopup({
+      api,
+      doc: document,
+      loadSettings: async () => ({ historyEnabled: true }),
+      store,
+      now: () => NOW,
+    });
+
+    const clearBtn = document.querySelector<HTMLButtonElement>('button[data-action="clear-all"]');
+    if (!clearBtn) throw new Error('test: clear-all button missing');
+    clearBtn.click();
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toMatch(/No articles yet/);
+    });
+    expect(store.clearAll).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('[role="list"]')).toBeNull();
+  });
+});
+
+describe('bootstrapPopup — history section graceful degradation', () => {
+  it('settings load failure renders the disabled state, does NOT block primary buttons', async () => {
+    const api = makeChromeStub();
+    const store = makeStoreStub([]);
+    await bootstrapPopup({
+      api,
+      doc: document,
+      loadSettings: () => Promise.reject(new Error('storage unavailable')),
+      store,
+      now: () => NOW,
+    });
+    // History section renders the disabled state on settings failure.
+    const container = document.getElementById('history-container') as HTMLElement;
+    expect(container.textContent ?? '').toMatch(/Reading history is off/i);
+    // Primary article button is still wired (not disabled — there IS
+    // an active tab in the stub).
+    const articleBtn = document.getElementById('read-article') as HTMLButtonElement;
+    expect(articleBtn.disabled).toBe(false);
+  });
+});

--- a/src/chrome/popup/__tests__/history-integration.test.ts
+++ b/src/chrome/popup/__tests__/history-integration.test.ts
@@ -252,4 +252,73 @@ describe('bootstrapPopup — history section graceful degradation', () => {
     const articleBtn = document.getElementById('read-article') as HTMLButtonElement;
     expect(articleBtn.disabled).toBe(false);
   });
+
+  // TG2 — store.list() rejection path: regression turning the try/catch
+  // around store.list() into a re-throw would crash popup boot, blocking
+  // the article button. Pin the graceful-degradation contract: empty-state
+  // renders, primary button stays wired, console.error fired exactly once.
+  it('store.list() rejection renders the empty-state, does NOT block primary buttons', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const api = makeChromeStub();
+    const failingStore = makeStoreStub([]);
+    failingStore.list = vi.fn(async () => {
+      throw new Error('storage failed');
+    });
+
+    await bootstrapPopup({
+      api,
+      doc: document,
+      loadSettings: async () => ({ historyEnabled: true }),
+      store: failingStore,
+      now: () => NOW,
+    });
+
+    const container = document.getElementById('history-container') as HTMLElement;
+    // Enabled + list() failed → renders the enabled empty-state copy,
+    // not the disabled "off" message. The list() error path falls back
+    // to entries:[] while keeping enabled:true.
+    expect(container.textContent ?? '').toMatch(/No articles yet/i);
+    // No list element when entries are empty (anti-tautology: pin
+    // "list absent" not "list has 0 items").
+    expect(container.querySelector('[role="list"]')).toBeNull();
+    // Primary article button stays wired.
+    const articleBtn = document.getElementById('read-article') as HTMLButtonElement;
+    expect(articleBtn.disabled).toBe(false);
+    // console.error fired exactly once for the list() failure path.
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(failingStore.list).toHaveBeenCalledTimes(1);
+  });
+});
+
+// TG1 (integration leg) — pin that the rendering layer TRUSTS the
+// ordering returned by `store.list()` rather than re-sorting in the
+// popup. Feeding oldest-first must render oldest-first in the DOM —
+// proves a future popup-side `entries.sort(...)` would surface here.
+describe('bootstrapPopup — history section trusts store.list() ordering', () => {
+  it('renders entries in the order store.list() returns them (no client-side re-sort)', async () => {
+    const api = makeChromeStub();
+    // Store returns OLDEST-first deliberately. The contract (#48) is
+    // newest-first, but the popup layer should not silently paper over
+    // a regression in the store's ordering — if it did, oldest-first
+    // would be rendered without anyone noticing.
+    const store = makeStoreStub([
+      { url: 'https://example.com/oldest', lastReadAt: NOW - 10 * 86_400_000 },
+      { url: 'https://example.com/middle', lastReadAt: NOW - 5 * 86_400_000 },
+      { url: 'https://example.com/newest', lastReadAt: NOW - 60_000 },
+    ]);
+    await bootstrapPopup({
+      api,
+      doc: document,
+      loadSettings: async () => ({ historyEnabled: true }),
+      store,
+      now: () => NOW,
+    });
+
+    const items = document.querySelectorAll<HTMLElement>('[role="listitem"]');
+    expect(items.length).toBe(3);
+    // Walking input order proves the renderer did NOT re-sort.
+    expect(items[0].textContent).toContain('oldest');
+    expect(items[1].textContent).toContain('middle');
+    expect(items[2].textContent).toContain('newest');
+  });
 });

--- a/src/chrome/popup/index.css
+++ b/src/chrome/popup/index.css
@@ -81,3 +81,154 @@ h1 {
 .status[data-state='error'] {
   color: #c5221f;
 }
+
+/* #49 — Recently read section. */
+.history {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.history__heading {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.history__off,
+.history__empty {
+  font-size: 0.8125rem;
+  color: #666;
+  margin: 0;
+}
+
+.history__enable-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #1a73e8;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: underline;
+}
+
+.history__enable-link:focus-visible {
+  outline: 2px solid #1a73e8;
+  outline-offset: 2px;
+}
+
+.history__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.history__item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  position: relative;
+}
+
+.history__resume {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 8px 10px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8125rem;
+  color: inherit;
+  text-align: left;
+  /* Prevent very long derived titles from overflowing the popup width. */
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.history__resume:hover {
+  background-color: #f1f6fd;
+}
+
+.history__resume:focus-visible {
+  outline: 2px solid #1a73e8;
+  outline-offset: -2px;
+}
+
+.history__time {
+  font-size: 0.6875rem;
+  color: #888;
+}
+
+.history__delete {
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 1.125rem;
+  line-height: 1;
+  color: #888;
+  /* Surface on hover/focus of the row OR direct hover/focus on the button. */
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.history__item:hover .history__delete,
+.history__item:focus-within .history__delete,
+.history__delete:focus-visible {
+  opacity: 1;
+}
+
+.history__delete:hover {
+  background-color: #fde9e8;
+  color: #c5221f;
+}
+
+.history__delete:focus-visible {
+  outline: 2px solid #1a73e8;
+  outline-offset: -2px;
+}
+
+.history__clear-all {
+  margin-top: 8px;
+  padding: 6px 10px;
+  background: transparent;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.75rem;
+  color: #666;
+}
+
+.history__clear-all:hover {
+  background-color: #f5f5f5;
+  color: #c5221f;
+  border-color: #c5221f;
+}
+
+.history__clear-all:focus-visible {
+  outline: 2px solid #1a73e8;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .history__delete {
+    transition: none;
+  }
+}

--- a/src/chrome/popup/index.html
+++ b/src/chrome/popup/index.html
@@ -34,6 +34,10 @@
       role="status"
       aria-live="polite"
     ></div>
+    <!-- #49 — "Recently read" surface. Container is populated by
+         bootstrapPopup at DOMContentLoaded; renders nothing until then
+         (no flash-of-empty-list). -->
+    <div id="history-container"></div>
     <script type="module" src="./index.ts"></script>
   </body>
 </html>

--- a/src/chrome/popup/index.ts
+++ b/src/chrome/popup/index.ts
@@ -22,10 +22,20 @@ import {
   tabHasSelection,
   type PopupScope,
 } from './activate';
+import { renderHistorySection, type HistorySectionEntry } from '../../core/popup/history-section';
+import type { ReadingPositionStore } from '../../core/storage/reading-position';
+import { createChromePositionStore } from '../storage/chrome-position-store';
+import { loadSettings } from '../settings/storage';
 
 interface PopupBootstrapDeps {
   readonly api: typeof chrome;
   readonly doc: Document;
+  /** Injectable for tests; defaults to `loadSettings`. */
+  readonly loadSettings?: () => Promise<{ historyEnabled: boolean }>;
+  /** Injectable for tests; defaults to `createChromePositionStore()`. */
+  readonly store?: ReadingPositionStore;
+  /** Injectable for tests; defaults to `Date.now`. */
+  readonly now?: () => number;
 }
 
 /**
@@ -37,6 +47,14 @@ export async function bootstrapPopup(deps: PopupBootstrapDeps): Promise<void> {
   const articleBtn = doc.getElementById('read-article') as HTMLButtonElement | null;
   const selectionBtn = doc.getElementById('read-selection') as HTMLButtonElement | null;
   const statusEl = doc.getElementById('status');
+
+  // #49 — mount the "Recently read" section. Independent of the
+  // activate-reader flow below; failure here must NOT block the
+  // primary buttons from wiring up. Errors are surfaced to console
+  // and the section is left empty (graceful degradation).
+  await mountHistorySection(deps).catch((err: unknown) => {
+    console.error('[speedreader] popup: history section mount failed', err);
+  });
 
   if (!articleBtn || !selectionBtn || !statusEl) {
     // Defensive — the popup HTML controls these IDs. A missing element
@@ -157,6 +175,89 @@ function formatActivationError(resp: ActivationResponse | undefined): string {
     return `Activation failed (${inner}).`;
   }
   return `Activation failed (${outer}).`;
+}
+
+/**
+ * #49 — read settings + position store, render the "Recently read"
+ * section into `#history-container`. Wires callbacks to platform APIs:
+ *   - resume   → `chrome.tabs.create({ url })` (new tab; CS auto-resumes
+ *     on next mount via #48 position store)
+ *   - delete   → `store.clear(url)` then re-mount the section
+ *   - clearAll → `store.clearAll()` then re-mount
+ *   - enable   → `chrome.runtime.openOptionsPage()`
+ *
+ * No live re-render on external store changes — popup re-renders on
+ * next open, which is acceptable for the popup's short lifecycle.
+ */
+async function mountHistorySection(deps: PopupBootstrapDeps): Promise<void> {
+  const { api, doc } = deps;
+  const container = doc.getElementById('history-container');
+  if (!container) return; // HTML drift; non-fatal — primary buttons still work.
+
+  const loadFn = deps.loadSettings ?? loadSettings;
+  const store = deps.store ?? createChromePositionStore();
+  const now = deps.now ?? (() => Date.now());
+
+  const remount = async (): Promise<void> => {
+    let enabled = false;
+    let entries: HistorySectionEntry[] = [];
+    try {
+      const settings = await loadFn();
+      enabled = settings.historyEnabled === true;
+    } catch (err) {
+      console.error('[speedreader] popup: settings load failed in history section', err);
+      // Render the disabled "off" state on settings load failure so
+      // the user has a path back via the Enable link rather than a
+      // mystery-empty section. `enabled` keeps its initial `false`.
+    }
+
+    if (enabled) {
+      try {
+        const list = await store.list();
+        entries = list.map((e) => ({ url: e.url, timestamp: e.position.lastReadAt }));
+      } catch (err) {
+        console.error('[speedreader] popup: history list() failed', err);
+        entries = [];
+      }
+    }
+
+    const section = renderHistorySection({
+      entries,
+      enabled,
+      now: now(),
+      onResume: (url) => {
+        void api.tabs.create({ url });
+      },
+      onDelete: (url) => {
+        void store
+          .clear(url)
+          .then(() => remount())
+          .catch((err: unknown) => {
+            console.error('[speedreader] popup: history clear failed', err);
+          });
+      },
+      onClearAll: () => {
+        void store
+          .clearAll()
+          .then(() => remount())
+          .catch((err: unknown) => {
+            console.error('[speedreader] popup: history clearAll failed', err);
+          });
+      },
+      onEnableInSettings: () => {
+        // openOptionsPage is the canonical MV3 way to surface the
+        // options page programmatically. It honors the user's
+        // `chrome://extensions/?options=` preference (separate page
+        // vs. embedded) without us having to know which.
+        if (api.runtime.openOptionsPage) {
+          void api.runtime.openOptionsPage();
+        }
+      },
+    });
+    container.replaceChildren(section);
+  };
+
+  await remount();
 }
 
 // DOM bootstrap. Skipped in test contexts that import the module

--- a/src/chrome/settings/__tests__/storage.test.ts
+++ b/src/chrome/settings/__tests__/storage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import sinonChrome from 'sinon-chrome';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
-import type { SettingsV4 } from '../../../core/settings/schema';
+import type { SettingsV5 } from '../../../core/settings/schema';
 import { DEBOUNCE_MS } from '../storage';
 
 const KEY = 'speedreader.settings';
@@ -81,7 +81,7 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('loadSettings returns valid stored payload as-is', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS, wpm: 380 } satisfies SettingsV4;
+    storedRaw = { ...DEFAULT_SETTINGS, wpm: 380 } satisfies SettingsV5;
     const { loadSettings } = await import('../storage');
     const settings = await loadSettings();
     expect(settings.wpm).toBe(380);
@@ -96,7 +96,7 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('saveSettings coalesces 10 calls within 300ms into one write', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV4;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV5;
     const { saveSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
@@ -113,14 +113,14 @@ describe('chrome settings storage adapter', () => {
     // Exactly one set call (the trailing-edge write); set may also fire from
     // an internal load() canonicalisation if storedRaw mismatched, so assert
     // the *final* persisted wpm rather than count alone.
-    const finalStored = storedRaw as SettingsV4;
+    const finalStored = storedRaw as SettingsV5;
     expect(finalStored.wpm).toBe(340);
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
   });
 
   // #68 — debounce window resolution contract.
   it('saveSettings: 3 calls in one window share resolution, all resolve on one set', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV4;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV5;
     const { saveSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
@@ -145,12 +145,12 @@ describe('chrome settings storage adapter', () => {
     // All three resolved together, and exactly one set fired.
     expect(resolved).toEqual([true, true, true]);
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
-    expect((storedRaw as SettingsV4).wpm).toBe(280);
+    expect((storedRaw as SettingsV5).wpm).toBe(280);
   });
 
   // #68 — late call landing during in-flight flush queues for next window.
   it('saveSettings: call landing during in-flight flush queues for next window (distinct resolutions)', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV4;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV5;
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
     // Replace `get` with a controllable Promise so we can park the in-flight
@@ -207,12 +207,12 @@ describe('chrome settings storage adapter', () => {
 
     // Two distinct sets — late call did not coalesce into the in-flight write.
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(2);
-    expect((storedRaw as SettingsV4).wpm).toBe(380);
+    expect((storedRaw as SettingsV5).wpm).toBe(380);
   });
 
   // #68 — flushSettings semantics.
   it('flushSettings resolves immediately when no pending save', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV4;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV5;
     const { flushSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
@@ -221,7 +221,7 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('flushSettings cancels debounce timer and forces an immediate flush', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV4;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV5;
     const { saveSettings, flushSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
@@ -250,7 +250,7 @@ describe('chrome settings storage adapter', () => {
     expect(flushPromiseResolved).toBe(true);
     expect(savePromiseResolved).toBe(true);
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
-    expect((storedRaw as SettingsV4).wpm).toBe(410);
+    expect((storedRaw as SettingsV5).wpm).toBe(410);
 
     // Confirm there is no zombie timer left behind — advancing past 300ms
     // must not produce a second set.
@@ -259,7 +259,7 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('flushSettings rejects when the forced flush fails', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV4;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV5;
     const { saveSettings, flushSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
     const setErr = new Error('quota exceeded');
@@ -280,13 +280,13 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('saveSettings preserves the version field', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV4;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV5;
     const { saveSettings } = await import('../storage');
     const p = saveSettings({ theme: 'dark' });
     await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
     await p;
-    const stored = storedRaw as SettingsV4;
-    expect(stored.version).toBe(4);
+    const stored = storedRaw as SettingsV5;
+    expect(stored.version).toBe(5);
     expect(stored.theme).toBe('dark');
   });
 
@@ -295,7 +295,7 @@ describe('chrome settings storage adapter', () => {
     const listener = vi.fn();
     const unsubscribe = subscribeSettings(listener);
 
-    const next: SettingsV4 = { ...DEFAULT_SETTINGS, wpm: 420 };
+    const next: SettingsV5 = { ...DEFAULT_SETTINGS, wpm: 420 };
     emitChange(next, 'sync');
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith(next);

--- a/src/chrome/settings/storage.ts
+++ b/src/chrome/settings/storage.ts
@@ -1,10 +1,10 @@
-import type { SettingsV4 } from '../../core/settings/schema';
+import type { SettingsV5 } from '../../core/settings/schema';
 import { migrate } from '../../core/settings/migrations';
 
 const KEY = 'speedreader.settings';
 export const DEBOUNCE_MS = 300;
 
-export type SaveSettingsInput = Omit<Partial<SettingsV4>, 'version'>;
+export type SaveSettingsInput = Omit<Partial<SettingsV5>, 'version'>;
 
 /**
  * Read settings from `chrome.storage.sync`, migrating + validating the raw
@@ -12,7 +12,7 @@ export type SaveSettingsInput = Omit<Partial<SettingsV4>, 'version'>;
  * or repair of a partial payload), the canonical form is written back so the
  * next read is a fast pass-through.
  */
-export async function loadSettings(): Promise<SettingsV4> {
+export async function loadSettings(): Promise<SettingsV5> {
   const result = await chrome.storage.sync.get(KEY);
   const raw = result[KEY];
   const settings = migrate(raw);
@@ -50,7 +50,7 @@ async function flushPendingSave(): Promise<void> {
   pendingRejectors = [];
   try {
     const current = await loadSettings();
-    const next: SettingsV4 = { ...current, ...partial, version: current.version };
+    const next: SettingsV5 = { ...current, ...partial, version: current.version };
     await chrome.storage.sync.set({ [KEY]: next });
     resolvers.forEach((r) => r());
   } catch (err) {
@@ -119,7 +119,7 @@ export function flushSettings(): Promise<void> {
  * the options page, or a different signed-in device via Chrome sync. Returns
  * an unsubscribe function.
  */
-export function subscribeSettings(listener: (s: SettingsV4) => void): () => void {
+export function subscribeSettings(listener: (s: SettingsV5) => void): () => void {
   const handler = (
     changes: Record<string, chrome.storage.StorageChange>,
     area: chrome.storage.AreaName,

--- a/src/chrome/welcome/__tests__/controller.test.ts
+++ b/src/chrome/welcome/__tests__/controller.test.ts
@@ -20,7 +20,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { bindWelcome, WELCOME_IDS, type SettingsApi } from '../controller';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
 import { SAMPLE_PASSAGE } from '../sample';
-import type { SettingsV4 } from '../../../core/settings/schema';
+import type { SettingsV5 } from '../../../core/settings/schema';
 
 const HTML = `
   <header>
@@ -46,16 +46,16 @@ interface Stub extends SettingsApi {
   loadMock: ReturnType<typeof vi.fn>;
   saveMock: ReturnType<typeof vi.fn>;
   flushMock: ReturnType<typeof vi.fn>;
-  resolveLoad(s: SettingsV4): void;
+  resolveLoad(s: SettingsV5): void;
   rejectLoad(err: unknown): void;
 }
 
-function makeStub(options: { initial?: SettingsV4; deferLoad?: boolean } = {}): Stub {
+function makeStub(options: { initial?: SettingsV5; deferLoad?: boolean } = {}): Stub {
   const initial = options.initial ?? DEFAULT_SETTINGS;
-  let resolveLoad: (s: SettingsV4) => void = () => undefined;
+  let resolveLoad: (s: SettingsV5) => void = () => undefined;
   let rejectLoad: (e: unknown) => void = () => undefined;
   const loadPromise = options.deferLoad
-    ? new Promise<SettingsV4>((res, rej) => {
+    ? new Promise<SettingsV5>((res, rej) => {
         resolveLoad = res;
         rejectLoad = rej;
       })

--- a/src/chrome/welcome/controller.ts
+++ b/src/chrome/welcome/controller.ts
@@ -11,14 +11,14 @@
  * See docs/superpowers/specs/2026-05-30-onboarding-surface.md.
  */
 
-import type { SettingsV4 } from '../../core/settings/schema';
+import type { SettingsV5 } from '../../core/settings/schema';
 import { DEFAULT_SETTINGS } from '../../core/settings/defaults';
 import { createRsvpEngine, type RsvpEngine } from '../../core/rsvp-engine';
 import { SAMPLE_PASSAGE } from './sample';
 
 export interface SettingsApi {
-  load(): Promise<SettingsV4>;
-  save(partial: Partial<Omit<SettingsV4, 'version' | 'lastUsedWpm'>>): Promise<void>;
+  load(): Promise<SettingsV5>;
+  save(partial: Partial<Omit<SettingsV5, 'version' | 'lastUsedWpm'>>): Promise<void>;
   flush(): Promise<void>;
 }
 
@@ -121,7 +121,7 @@ export async function bindWelcome(
   const $label = label as HTMLElement;
   const $saveFinishBtn = saveFinishBtn as HTMLButtonElement;
 
-  // Initialize slider + label to V4 default; the in-flight `loadSettings`
+  // Initialize slider + label to current default; the in-flight `loadSettings`
   // call below may reseat once it resolves. Spec §"Settings Round-Trip"
   // forbids blocking the render on load.
   const setSliderValue = (value: number): void => {

--- a/src/core/messaging/validate.ts
+++ b/src/core/messaging/validate.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { SettingsSchemaV4 } from '../settings/schema';
+import { SettingsSchemaV5 } from '../settings/schema';
 
 /**
  * Per-activation override payload — applied by the CS as one-shot deltas
@@ -12,10 +12,10 @@ import { SettingsSchemaV4 } from '../settings/schema';
  *    `wpm` must be a number, toggles must be booleans. Out-of-bound values
  *    PASS the shape gate — they're caught downstream.
  *  - **Bounds gate** (`pickValidOverrides`) drops fields that fail their
- *    real per-field schema (`SettingsSchemaV4.shape.wpm` for wpm: int,
+ *    real per-field schema (`SettingsSchemaV5.shape.wpm` for wpm: int,
  *    [100,600], multipleOf(10); strict-boolean for toggles).
  *
- * Why split: the bounds gate reuses `SettingsSchemaV4.shape.wpm` so the
+ * Why split: the bounds gate reuses `SettingsSchemaV5.shape.wpm` so the
  * `wpm` constraint stays the single source of truth (no duplication).
  * The shape gate intentionally relaxes wpm to `z.number()` so a hostile
  * 999999 payload reaches the bounds gate to be dropped per-field rather
@@ -23,7 +23,7 @@ import { SettingsSchemaV4 } from '../settings/schema';
  * activation alive with snapshot defaults for the other fields.
  *
  * Field-name alignment: `contextLine` / `startFromWordOne` here match
- * the `SettingsV4` field names exactly so the CS-side
+ * the `SettingsV5` field names exactly so the CS-side
  * `{...snapshot, ...validatedOverrides}` shallow-merge composes
  * cleanly without a wire→settings translation table. The hi-fi mock's
  * "Show context line" submenu label is a display string, not the wire
@@ -65,7 +65,7 @@ export function validateOverrides(raw: unknown): Overrides | null {
 export function pickValidOverrides(raw: Overrides): Overrides {
   const out: Overrides = {};
   if (raw.wpm !== undefined) {
-    const r = SettingsSchemaV4.shape.wpm.safeParse(raw.wpm);
+    const r = SettingsSchemaV5.shape.wpm.safeParse(raw.wpm);
     if (r.success) out.wpm = r.data;
   }
   if (raw.contextLine !== undefined && typeof raw.contextLine === 'boolean') {

--- a/src/core/overlay/types.ts
+++ b/src/core/overlay/types.ts
@@ -3,13 +3,13 @@ import type { ThemeId } from '../theme';
 import type { FontId } from './font-ids';
 
 /**
- * Settings slice the overlay binds to. The wider SettingsV4 is not imported
+ * Settings slice the overlay binds to. The wider SettingsV5 is not imported
  * here so `core/overlay` stays portable (no transitive dependency on the
  * Chrome storage shape).
  *
  * `theme` extends `ThemeId` with `'system'` — the concrete-theme enum
  * covers the six design-pack values; `'system'` resolves at mount time via
- * `prefers-color-scheme` matching `SettingsV4.theme` (which includes
+ * `prefers-color-scheme` matching `SettingsV5.theme` (which includes
  * `'system'` as the auto-detect sentinel). Keeping the sentinel here avoids
  * callers having to pre-resolve before constructing the overlay.
  */

--- a/src/core/popup/__tests__/derive-title.test.ts
+++ b/src/core/popup/__tests__/derive-title.test.ts
@@ -93,12 +93,20 @@ describe('deriveTitleFromUrl — defensive', () => {
     expect(deriveTitleFromUrl('https://EXAMPLE.com/Page')).toBe('example.com / Page');
   });
 
-  it('handles file:// and other non-http schemes gracefully', () => {
-    // The reading-position store rejects these, but a defensive caller
-    // might still pass one in. Return the hostname (or raw input) rather
-    // than crashing.
-    const result = deriveTitleFromUrl('file:///etc/hosts');
-    expect(typeof result).toBe('string');
-    expect(result.length).toBeGreaterThan(0);
+  it('handles file:// scheme by emitting the empty-host + last-segment shape', () => {
+    // The reading-position store rejects file:// URLs (#48 canonicalization),
+    // so this is a defensive path — a hand-crafted entry or a future
+    // permitted-scheme change shouldn't crash the popup row.
+    //
+    // Contract pinned VERBATIM (anti-tautology): `new URL('file:///etc/hosts')`
+    // exposes `hostname === ''` and `pathname === '/etc/hosts'`. The
+    // current implementation runs the empty hostname through stripWww
+    // (no-op) and concatenates with " / " + last segment, yielding
+    // " / hosts". The leading space is a cosmetic artifact of an empty
+    // host — acceptable because non-http schemes are not part of the
+    // happy path, but pinning the exact string here surfaces any silent
+    // contract drift (e.g., a future change to return the raw input,
+    // hide the row, or throw).
+    expect(deriveTitleFromUrl('file:///etc/hosts')).toBe(' / hosts');
   });
 });

--- a/src/core/popup/__tests__/derive-title.test.ts
+++ b/src/core/popup/__tests__/derive-title.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for `deriveTitleFromUrl` (issue #49 — popup "Recently read"
+ * display labels).
+ *
+ * The reading-position store (#48) does NOT persist article titles —
+ * persisting them would require a schema bump (deferred to #196 spec).
+ * Until then, the popup derives a display label from the URL: hostname
+ * (no www.) plus the last meaningful path segment.
+ *
+ * Anti-tautology stance: assertions pin the OUTPUT STRING, not "URL
+ * was parsed". A canonical-URL output of `example.com / about` for
+ * `https://www.example.com/about` is the contract; a future change
+ * that drops the path entirely would surface here.
+ */
+import { describe, it, expect } from 'vitest';
+import { deriveTitleFromUrl } from '../derive-title';
+
+describe('deriveTitleFromUrl — bare hostname', () => {
+  it('returns hostname for root URL', () => {
+    expect(deriveTitleFromUrl('https://example.com/')).toBe('example.com');
+  });
+
+  it('returns hostname for hostname without trailing slash', () => {
+    expect(deriveTitleFromUrl('https://example.com')).toBe('example.com');
+  });
+
+  it('strips leading www. prefix', () => {
+    expect(deriveTitleFromUrl('https://www.example.com/')).toBe('example.com');
+  });
+
+  it('does NOT strip non-www subdomains (en.wikipedia.org stays intact)', () => {
+    expect(deriveTitleFromUrl('https://en.wikipedia.org/')).toBe('en.wikipedia.org');
+  });
+});
+
+describe('deriveTitleFromUrl — hostname + path', () => {
+  it('returns hostname / last-segment for single-segment path', () => {
+    expect(deriveTitleFromUrl('https://example.com/about')).toBe('example.com / about');
+  });
+
+  it('returns hostname / last-segment for deep path', () => {
+    expect(deriveTitleFromUrl('https://www.example.com/blog/2026/article-title')).toBe(
+      'example.com / article-title',
+    );
+  });
+
+  it('decodes percent-encoded path segments (URL-safe → human readable)', () => {
+    expect(deriveTitleFromUrl('https://example.com/articles/hello%20world')).toBe(
+      'example.com / hello world',
+    );
+  });
+
+  it('handles trailing slash by using the last non-empty segment', () => {
+    expect(deriveTitleFromUrl('https://example.com/blog/article/')).toBe('example.com / article');
+  });
+
+  it('truncates very long path segments to keep popup labels readable', () => {
+    const longSegment = 'a'.repeat(120);
+    const result = deriveTitleFromUrl(`https://example.com/${longSegment}`);
+    // Truncated form: hostname / first-N-chars + ellipsis. Pin the
+    // length cap so a future arbitrary widening surfaces here.
+    expect(result.length).toBeLessThanOrEqual(64);
+    expect(result).toMatch(/example\.com \/ a+…$/);
+  });
+});
+
+describe('deriveTitleFromUrl — query / fragment stripping', () => {
+  it('strips query string (utm tags etc.) from the label', () => {
+    expect(deriveTitleFromUrl('https://example.com/article?utm_source=feed&ref=twitter')).toBe(
+      'example.com / article',
+    );
+  });
+
+  it('strips fragment from the label', () => {
+    expect(deriveTitleFromUrl('https://example.com/article#section-3')).toBe(
+      'example.com / article',
+    );
+  });
+
+  it('strips both query and fragment', () => {
+    expect(deriveTitleFromUrl('https://example.com/a/b?x=1#top')).toBe('example.com / b');
+  });
+});
+
+describe('deriveTitleFromUrl — defensive', () => {
+  it('returns the raw input string when URL fails to parse', () => {
+    // Non-URL strings shouldn't crash the popup; surface what the
+    // store happens to hold rather than disappearing the row.
+    expect(deriveTitleFromUrl('not a url')).toBe('not a url');
+  });
+
+  it('lowercases the host (parity with canonicalizeUrl)', () => {
+    expect(deriveTitleFromUrl('https://EXAMPLE.com/Page')).toBe('example.com / Page');
+  });
+
+  it('handles file:// and other non-http schemes gracefully', () => {
+    // The reading-position store rejects these, but a defensive caller
+    // might still pass one in. Return the hostname (or raw input) rather
+    // than crashing.
+    const result = deriveTitleFromUrl('file:///etc/hosts');
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/src/core/popup/__tests__/format-relative-time.test.ts
+++ b/src/core/popup/__tests__/format-relative-time.test.ts
@@ -102,6 +102,42 @@ describe('formatRelativeTime — prior years (absolute MMM D, YYYY)', () => {
     const result = formatRelativeTime(NOW - twoYears, NOW);
     expect(result).toMatch(/, 202[12]$/);
   });
+
+  // TG4 — year-boundary contract: a SHORT delta (10 days) that crosses
+  // a calendar-year boundary still triggers the year-suffix branch
+  // because the branch keys on `date.getUTCFullYear() !== nowDate.getUTCFullYear()`,
+  // not on the absolute delta. Pin this so a future refactor that
+  // re-keys on `delta >= 365d` (and silently drops the year for a
+  // 10-day cross-year delta) surfaces here as a contract change.
+  it('emits year suffix for cross-year deltas even when delta is well under 365 days', () => {
+    // now = 2026-01-05T00:00:00Z, timestamp = 2025-12-26T00:00:00Z
+    // (10-day delta, but crossing the Jan 1 boundary).
+    const nowEarlyJan = Date.UTC(2026, 0, 5, 0, 0, 0);
+    const tenDaysAcrossBoundary = Date.UTC(2025, 11, 26, 0, 0, 0);
+    expect(formatRelativeTime(tenDaysAcrossBoundary, nowEarlyJan)).toBe('Dec 26, 2025');
+  });
+});
+
+// NIT-1 — date formatting must use UTC getters so output is stable
+// regardless of the runner's TZ. A test using local-TZ getters and a
+// timestamp near a UTC-midnight equivalent would render Nov 4 in UTC
+// but Nov 3 in PDT — flaky depending on whose machine runs it.
+//
+// Verification protocol: this test was authored against `TZ=America/Los_Angeles`
+// (`TZ=America/Los_Angeles npx vitest run src/core/popup/__tests__/format-relative-time.test.ts`)
+// and confirmed green; reverting to `getMonth/getDate/getFullYear`
+// under that TZ environment turns it red.
+describe('formatRelativeTime — TZ stability (regression guard)', () => {
+  it('emits the SAME absolute-date label regardless of host TZ getters (UTC contract)', () => {
+    // Pick a timestamp that sits on a different calendar day in UTC vs.
+    // a UTC-8 (PST) zone. Date.UTC(2023, 10, 4, 2, 0, 0) = 2023-11-04T02:00:00Z
+    // = 2023-11-03 18:00 PST. UTC label must be "Nov 4"; a local-TZ
+    // implementation on a PST host would emit "Nov 3".
+    const ts = Date.UTC(2023, 10, 4, 2, 0, 0);
+    // `now` chosen to be ≥ 7 days later so we land in the absolute-date branch.
+    const nowTs = Date.UTC(2023, 10, 14, 0, 0, 0);
+    expect(formatRelativeTime(ts, nowTs)).toBe('Nov 4');
+  });
 });
 
 describe('formatRelativeTime — edge cases', () => {

--- a/src/core/popup/__tests__/format-relative-time.test.ts
+++ b/src/core/popup/__tests__/format-relative-time.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for `formatRelativeTime` (issue #49 — popup "Recently read" timestamps).
+ *
+ * Anti-tautology stance:
+ *   - Assertions pin the OUTPUT STRING for each input timestamp delta —
+ *     not "Intl.RelativeTimeFormat was called with N units". The formatter
+ *     is intentionally hand-rolled (no Intl dependency) for stable output
+ *     across locales; testing Intl call shape would be testing the
+ *     framework, not the function's contract.
+ *   - Boundary tests sit on each transition (exact 60s, 60m, 24h, 7d,
+ *     365d) so a regression that shifts a threshold by ±1 ms surfaces.
+ */
+import { describe, it, expect } from 'vitest';
+import { formatRelativeTime } from '../format-relative-time';
+
+const NOW = 1_700_000_000_000; // 2023-11-14T22:13:20Z
+
+describe('formatRelativeTime — recent past', () => {
+  it('returns "Just now" for delta = 0', () => {
+    expect(formatRelativeTime(NOW, NOW)).toBe('Just now');
+  });
+
+  it('returns "Just now" for delta < 60s (30s ago)', () => {
+    expect(formatRelativeTime(NOW - 30_000, NOW)).toBe('Just now');
+  });
+
+  it('returns "Just now" for delta = 59s (still under the 1-minute boundary)', () => {
+    expect(formatRelativeTime(NOW - 59_000, NOW)).toBe('Just now');
+  });
+
+  it('returns "1m ago" at the 60s boundary (1 minute)', () => {
+    expect(formatRelativeTime(NOW - 60_000, NOW)).toBe('1m ago');
+  });
+
+  it('returns "Xm ago" for minute deltas (2m, 30m, 59m)', () => {
+    expect(formatRelativeTime(NOW - 2 * 60_000, NOW)).toBe('2m ago');
+    expect(formatRelativeTime(NOW - 30 * 60_000, NOW)).toBe('30m ago');
+    expect(formatRelativeTime(NOW - 59 * 60_000, NOW)).toBe('59m ago');
+  });
+});
+
+describe('formatRelativeTime — hours', () => {
+  it('returns "1h ago" at the 60-minute boundary', () => {
+    expect(formatRelativeTime(NOW - 60 * 60_000, NOW)).toBe('1h ago');
+  });
+
+  it('returns "Xh ago" for hour deltas (2h, 12h, 23h)', () => {
+    expect(formatRelativeTime(NOW - 2 * 3_600_000, NOW)).toBe('2h ago');
+    expect(formatRelativeTime(NOW - 12 * 3_600_000, NOW)).toBe('12h ago');
+    expect(formatRelativeTime(NOW - 23 * 3_600_000, NOW)).toBe('23h ago');
+  });
+});
+
+describe('formatRelativeTime — days', () => {
+  it('returns "Yesterday" at the 24-hour boundary', () => {
+    expect(formatRelativeTime(NOW - 24 * 3_600_000, NOW)).toBe('Yesterday');
+  });
+
+  it('returns "Yesterday" for any delta in [24h, 48h)', () => {
+    expect(formatRelativeTime(NOW - 36 * 3_600_000, NOW)).toBe('Yesterday');
+    expect(formatRelativeTime(NOW - (48 * 3_600_000 - 1), NOW)).toBe('Yesterday');
+  });
+
+  it('returns "X days ago" for delta in [2 days, 7 days)', () => {
+    expect(formatRelativeTime(NOW - 2 * 86_400_000, NOW)).toBe('2 days ago');
+    expect(formatRelativeTime(NOW - 6 * 86_400_000, NOW)).toBe('6 days ago');
+    expect(formatRelativeTime(NOW - (7 * 86_400_000 - 1), NOW)).toBe('6 days ago');
+  });
+});
+
+describe('formatRelativeTime — within current year (absolute MMM D)', () => {
+  it('returns absolute short-month + day for delta >= 7 days within same year', () => {
+    // NOW = 2023-11-14T22:13:20Z. 10 days earlier = 2023-11-04T22:13:20Z.
+    const result = formatRelativeTime(NOW - 10 * 86_400_000, NOW);
+    expect(result).toMatch(/^[A-Z][a-z]{2} \d{1,2}$/);
+    expect(result).toBe('Nov 4');
+  });
+
+  it('returns absolute MMM D at exactly 7 days ago', () => {
+    // 2023-11-07.
+    expect(formatRelativeTime(NOW - 7 * 86_400_000, NOW)).toBe('Nov 7');
+  });
+
+  it('does not include a year suffix when same-year (180 days ago, still same year)', () => {
+    // 180 days before 2023-11-14 = 2023-05-18 (still 2023).
+    const result = formatRelativeTime(NOW - 180 * 86_400_000, NOW);
+    expect(result).toBe('May 18');
+    expect(result).not.toMatch(/2023/);
+  });
+});
+
+describe('formatRelativeTime — prior years (absolute MMM D, YYYY)', () => {
+  it('includes a year suffix when crossing year boundary (366 days ago)', () => {
+    // 2022-11-13.
+    const result = formatRelativeTime(NOW - 366 * 86_400_000, NOW);
+    expect(result).toBe('Nov 13, 2022');
+  });
+
+  it('includes year when the same calendar date appears in a prior year', () => {
+    // ~2 years ago, May 2022.
+    const twoYears = 2 * 365 * 86_400_000;
+    const result = formatRelativeTime(NOW - twoYears, NOW);
+    expect(result).toMatch(/, 202[12]$/);
+  });
+});
+
+describe('formatRelativeTime — edge cases', () => {
+  it('returns "Just now" for future timestamps (clock drift / sync skew)', () => {
+    expect(formatRelativeTime(NOW + 5_000, NOW)).toBe('Just now');
+    expect(formatRelativeTime(NOW + 86_400_000, NOW)).toBe('Just now');
+  });
+
+  it('returns "Just now" for NaN timestamp', () => {
+    expect(formatRelativeTime(NaN, NOW)).toBe('Just now');
+  });
+
+  it('returns "Just now" for Infinity timestamp', () => {
+    expect(formatRelativeTime(Infinity, NOW)).toBe('Just now');
+    expect(formatRelativeTime(-Infinity, NOW)).toBe('Just now');
+  });
+
+  it('returns "Just now" when `now` is NaN (defensive — broken clock)', () => {
+    expect(formatRelativeTime(NOW, NaN)).toBe('Just now');
+  });
+});

--- a/src/core/popup/__tests__/history-section.test.ts
+++ b/src/core/popup/__tests__/history-section.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for `renderHistorySection` (issue #49 — popup "Recently read"
+ * surface).
+ *
+ * The section is a pure rendering function: input is the data slice
+ * (entries, enabled flag) plus callbacks; output is a DOM subtree.
+ * No chrome.* — the popup glue in src/chrome/popup/index.ts wires the
+ * callbacks to chrome.tabs.create / store.clear / store.clearAll.
+ *
+ * Anti-tautology stance:
+ *   - Accessible queries (role="list", role="listitem", role="button"
+ *     with accessible name) rather than raw CSS selectors. A class
+ *     rename should not false-pass.
+ *   - Callbacks assert OBSERVED state change (URL passed to onResume
+ *     matches the entry clicked), not "callback was called once".
+ *   - Empty-state assertion checks the empty-state element is PRESENT
+ *     and the list element is ABSENT — not "list has 0 items" (which
+ *     a broken render-empty path could satisfy).
+ *   - Confirm-before-clear-all asserts onClearAll fires only when the
+ *     stub returns true; a false return must NOT invoke the callback.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHistorySection, type HistorySectionEntry } from '../history-section';
+
+const NOW = 1_700_000_000_000;
+
+function mount(node: HTMLElement): HTMLElement {
+  document.body.appendChild(node);
+  return node;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('renderHistorySection — disabled state', () => {
+  it('renders the "off" message and a link to enable, no list', () => {
+    const section = mount(
+      renderHistorySection({
+        entries: [],
+        enabled: false,
+        now: NOW,
+        onResume: vi.fn(),
+        onDelete: vi.fn(),
+        onClearAll: vi.fn(),
+        onEnableInSettings: vi.fn(),
+      }),
+    );
+
+    expect(section.textContent ?? '').toMatch(/Reading history is off/i);
+    // Enable link must be a button (accessible name "Enable in settings").
+    const enableBtn = section.querySelector('button');
+    expect(enableBtn).not.toBeNull();
+    expect(enableBtn?.textContent).toMatch(/enable/i);
+    // No list element when disabled.
+    expect(section.querySelector('[role="list"]')).toBeNull();
+  });
+
+  it('Enable link click invokes onEnableInSettings', () => {
+    const onEnable = vi.fn();
+    const section = mount(
+      renderHistorySection({
+        entries: [],
+        enabled: false,
+        now: NOW,
+        onResume: vi.fn(),
+        onDelete: vi.fn(),
+        onClearAll: vi.fn(),
+        onEnableInSettings: onEnable,
+      }),
+    );
+    const btn = section.querySelector('button') as HTMLButtonElement;
+    btn.click();
+    expect(onEnable).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('renderHistorySection — enabled but empty', () => {
+  it('renders the empty-state message AND no list element', () => {
+    const section = mount(
+      renderHistorySection({
+        entries: [],
+        enabled: true,
+        now: NOW,
+        onResume: vi.fn(),
+        onDelete: vi.fn(),
+        onClearAll: vi.fn(),
+        onEnableInSettings: vi.fn(),
+      }),
+    );
+    expect(section.textContent ?? '').toMatch(/No articles yet/i);
+    // Critical anti-tautology: list element ABSENT, not "list has 0
+    // items" — a broken render path could yield an empty <ul> and we'd
+    // never catch it. Forces the implementation to a single render path.
+    expect(section.querySelector('[role="list"]')).toBeNull();
+    // No clear-all button when there's nothing to clear.
+    expect(section.querySelector('button')).toBeNull();
+  });
+});
+
+describe('renderHistorySection — enabled with entries', () => {
+  const entries: HistorySectionEntry[] = [
+    {
+      url: 'https://example.com/a',
+      timestamp: NOW - 30 * 60_000, // 30m ago
+    },
+    {
+      url: 'https://www.foo.com/blog/post',
+      timestamp: NOW - 2 * 86_400_000, // 2 days ago
+    },
+  ];
+
+  it('renders a list with one listitem per entry', () => {
+    const section = mount(
+      renderHistorySection({
+        entries,
+        enabled: true,
+        now: NOW,
+        onResume: vi.fn(),
+        onDelete: vi.fn(),
+        onClearAll: vi.fn(),
+        onEnableInSettings: vi.fn(),
+      }),
+    );
+    const list = section.querySelector('[role="list"]');
+    expect(list).not.toBeNull();
+    const items = section.querySelectorAll('[role="listitem"]');
+    expect(items.length).toBe(2);
+  });
+
+  it('each item renders derived title and relative timestamp', () => {
+    const section = mount(
+      renderHistorySection({
+        entries,
+        enabled: true,
+        now: NOW,
+        onResume: vi.fn(),
+        onDelete: vi.fn(),
+        onClearAll: vi.fn(),
+        onEnableInSettings: vi.fn(),
+      }),
+    );
+    const text = section.textContent ?? '';
+    // Derived titles (deriveTitleFromUrl): "example.com / a", "foo.com / post".
+    expect(text).toContain('example.com / a');
+    expect(text).toContain('foo.com / post');
+    // Relative timestamps.
+    expect(text).toContain('30m ago');
+    expect(text).toContain('2 days ago');
+  });
+
+  it('clicking an entry invokes onResume with that entry URL (not just "called once")', () => {
+    const onResume = vi.fn();
+    const section = mount(
+      renderHistorySection({
+        entries,
+        enabled: true,
+        now: NOW,
+        onResume,
+        onDelete: vi.fn(),
+        onClearAll: vi.fn(),
+        onEnableInSettings: vi.fn(),
+      }),
+    );
+    // Each listitem exposes a primary action button with the title as
+    // accessible name. Clicking the SECOND entry must invoke onResume
+    // with the SECOND entry's URL, not the first — pins observed state
+    // change, not call shape.
+    const items = section.querySelectorAll<HTMLElement>('[role="listitem"]');
+    const secondResume = items[1].querySelector<HTMLButtonElement>('button[data-action="resume"]');
+    if (!secondResume) throw new Error('test: resume button missing');
+    secondResume.click();
+    expect(onResume).toHaveBeenCalledTimes(1);
+    expect(onResume).toHaveBeenCalledWith('https://www.foo.com/blog/post');
+  });
+
+  it('clicking the delete button invokes onDelete with the entry URL', () => {
+    const onDelete = vi.fn();
+    const section = mount(
+      renderHistorySection({
+        entries,
+        enabled: true,
+        now: NOW,
+        onResume: vi.fn(),
+        onDelete,
+        onClearAll: vi.fn(),
+        onEnableInSettings: vi.fn(),
+      }),
+    );
+    const items = section.querySelectorAll<HTMLElement>('[role="listitem"]');
+    const firstDelete = items[0].querySelector<HTMLButtonElement>('button[data-action="delete"]');
+    if (!firstDelete) throw new Error('test: delete button missing');
+    expect(firstDelete.getAttribute('aria-label')).toMatch(/remove|delete/i);
+    firstDelete.click();
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledWith('https://example.com/a');
+  });
+
+  it('renders a "Clear all" button that invokes onClearAll AFTER confirm returns true', () => {
+    const onClearAll = vi.fn();
+    const confirmStub = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const section = mount(
+      renderHistorySection({
+        entries,
+        enabled: true,
+        now: NOW,
+        onResume: vi.fn(),
+        onDelete: vi.fn(),
+        onClearAll,
+        onEnableInSettings: vi.fn(),
+      }),
+    );
+    const clearBtn = section.querySelector<HTMLButtonElement>('button[data-action="clear-all"]');
+    if (!clearBtn) throw new Error('test: clear-all button missing');
+    clearBtn.click();
+    expect(confirmStub).toHaveBeenCalledTimes(1);
+    expect(onClearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('Clear all does NOT fire when confirm returns false (cancelled)', () => {
+    const onClearAll = vi.fn();
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const section = mount(
+      renderHistorySection({
+        entries,
+        enabled: true,
+        now: NOW,
+        onResume: vi.fn(),
+        onDelete: vi.fn(),
+        onClearAll,
+        onEnableInSettings: vi.fn(),
+      }),
+    );
+    const clearBtn = section.querySelector<HTMLButtonElement>('button[data-action="clear-all"]');
+    if (!clearBtn) throw new Error('test: clear-all button missing');
+    clearBtn.click();
+    expect(onClearAll).not.toHaveBeenCalled();
+  });
+});
+
+describe('renderHistorySection — entry cap', () => {
+  it('renders at most MAX_DISPLAY_ENTRIES (50) even when given more', () => {
+    const entries: HistorySectionEntry[] = Array.from({ length: 75 }, (_, i) => ({
+      url: `https://example.com/article-${i}`,
+      timestamp: NOW - i * 60_000,
+    }));
+    const section = mount(
+      renderHistorySection({
+        entries,
+        enabled: true,
+        now: NOW,
+        onResume: vi.fn(),
+        onDelete: vi.fn(),
+        onClearAll: vi.fn(),
+        onEnableInSettings: vi.fn(),
+      }),
+    );
+    const items = section.querySelectorAll('[role="listitem"]');
+    // Pin the cap value so a future widening to 100/200 surfaces here.
+    expect(items.length).toBe(50);
+    // The FIRST entry (most recent) must be present; the 51st must not.
+    expect(section.textContent).toContain('article-0');
+    expect(section.textContent).not.toContain('article-50');
+  });
+});

--- a/src/core/popup/__tests__/history-section.test.ts
+++ b/src/core/popup/__tests__/history-section.test.ts
@@ -266,5 +266,14 @@ describe('renderHistorySection — entry cap', () => {
     // The FIRST entry (most recent) must be present; the 51st must not.
     expect(section.textContent).toContain('article-0');
     expect(section.textContent).not.toContain('article-50');
+    // Pin DOM ORDER == INPUT ORDER for the first 50 entries. The previous
+    // assertion only proved "article-0 present, article-50 absent" — a
+    // future `entries.slice(-MAX_DISPLAY_ENTRIES)` mutation would still
+    // pass (article-0 would be in slot 0 of the trimmed tail and article-50
+    // would be excluded). Walking the items asserts the render trusts
+    // input order, not "first present, last absent".
+    for (let i = 0; i < 50; i += 1) {
+      expect(items[i].textContent).toContain(`article-${i}`);
+    }
   });
 });

--- a/src/core/popup/derive-title.ts
+++ b/src/core/popup/derive-title.ts
@@ -1,0 +1,73 @@
+/**
+ * URL → display-label derivation for the popup "Recently read" surface
+ * (issue #49).
+ *
+ * The reading-position store (#48) records only `{wordIndex, totalWords,
+ * lastReadAt}` per URL — it does NOT persist article titles. Persisting
+ * the title would require a schema bump and a content-script side
+ * pickup; both are deferred to #196 (combined S3 + title PR after that
+ * spec lands). Until then, the popup derives a best-effort label from
+ * the URL.
+ *
+ * Output shape:
+ *   - Bare hostname for root paths           → "example.com"
+ *   - Hostname + last segment for deeper URLs → "example.com / article-title"
+ *   - `www.` prefix stripped (parity with canonicalizeUrl)
+ *   - Query string + fragment dropped (mirrors canonicalizeUrl)
+ *   - Path segments percent-decoded for readability
+ *   - Long final segments truncated to keep popup labels compact
+ *   - Non-URL input returned verbatim so a corrupted store entry still
+ *     renders SOMETHING in the row (vs. disappearing silently)
+ *
+ * Pure — no `chrome.*`, no DOM.
+ */
+
+/**
+ * Total cap on label length to keep popup rows visually consistent at
+ * the 280 px popup floor (CSS-side wraps long labels, but the truncation
+ * here avoids the visual jitter of a 200-char segment forcing a wrap).
+ */
+const MAX_LABEL_LENGTH = 64;
+
+/**
+ * Cap on the path-segment portion alone. With a typical hostname of
+ * ~16 chars + " / " separator (3 chars), this leaves ~45 chars for the
+ * path segment before truncation — fits comfortably on one popup line.
+ */
+const MAX_SEGMENT_LENGTH = 44;
+
+export function deriveTitleFromUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+
+  const host = stripWww(parsed.hostname.toLowerCase());
+
+  // Pull the last non-empty segment (handles trailing slash by skipping
+  // the empty tail). Percent-decode so "hello%20world" → "hello world".
+  const segments = parsed.pathname.split('/').filter((s) => s.length > 0);
+  if (segments.length === 0) return host;
+
+  let last: string;
+  try {
+    last = decodeURIComponent(segments[segments.length - 1]);
+  } catch {
+    last = segments[segments.length - 1];
+  }
+
+  const truncatedSegment = truncate(last, MAX_SEGMENT_LENGTH);
+  const label = `${host} / ${truncatedSegment}`;
+  return truncate(label, MAX_LABEL_LENGTH);
+}
+
+function stripWww(host: string): string {
+  return host.startsWith('www.') ? host.slice(4) : host;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max - 1)}…`;
+}

--- a/src/core/popup/format-relative-time.ts
+++ b/src/core/popup/format-relative-time.ts
@@ -63,12 +63,20 @@ export function formatRelativeTime(timestamp: number, now: number): string {
   // ≥ 7 days — switch to absolute date. Year suffix only when the
   // timestamp's year differs from `now`'s year (keeps the common
   // "earlier this year" case terse).
+  //
+  // UTC getters (vs. local-TZ getters) so output is stable across
+  // contributor / CI timezones. Local-TZ formatting made tests near
+  // UTC-midnight equivalents (e.g., a fixed epoch that sits on Nov 4
+  // UTC but Nov 3 in PDT) brittle. The popup label is informational —
+  // a one-day-off UTC label is a smaller harm than locale-flaky tests
+  // and a Slack-style mismatch between two users seeing the same
+  // history entry.
   const date = new Date(timestamp);
   const nowDate = new Date(now);
-  const month = MONTHS_SHORT[date.getMonth()];
-  const day = date.getDate();
-  if (date.getFullYear() === nowDate.getFullYear()) {
+  const month = MONTHS_SHORT[date.getUTCMonth()];
+  const day = date.getUTCDate();
+  if (date.getUTCFullYear() === nowDate.getUTCFullYear()) {
     return `${month} ${day}`;
   }
-  return `${month} ${day}, ${date.getFullYear()}`;
+  return `${month} ${day}, ${date.getUTCFullYear()}`;
 }

--- a/src/core/popup/format-relative-time.ts
+++ b/src/core/popup/format-relative-time.ts
@@ -1,0 +1,74 @@
+/**
+ * Relative-time formatter for the popup "Recently read" surface (issue #49).
+ *
+ * Hand-rolled rather than `Intl.RelativeTimeFormat`-backed for two reasons:
+ *   1. Locale-stable test output — Intl varies by user locale, making
+ *      assertions brittle without locale pinning at the test boundary.
+ *   2. The output set is tiny (Just now / Xm / Xh / Yesterday / X days /
+ *      "MMM D" / "MMM D, YYYY"). Intl is overweight for the surface.
+ *
+ * Edge cases — all collapse to "Just now":
+ *   - Future timestamps (clock drift between writer and reader)
+ *   - NaN / Infinity / -Infinity timestamps
+ *   - NaN `now` (broken clock — defensive)
+ *
+ * The Safari upstream's "Recently read" surface does not exist (Safari
+ * has no equivalent feature today), so there is no parity constraint
+ * on the exact string set — see project memory note
+ * `project_safari_no_context_menu.md` for the comparable precedent.
+ *
+ * Pure — no `chrome.*`, no DOM. Lives under `src/core/` per the boundary
+ * contract in `src/core/README.md`.
+ */
+
+const SECOND_MS = 1_000;
+const MINUTE_MS = 60 * SECOND_MS;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+
+const MONTHS_SHORT = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+export function formatRelativeTime(timestamp: number, now: number): string {
+  // Defensive guards — any non-finite input collapses to "Just now" rather
+  // than emitting "NaNm ago" or crashing on arithmetic.
+  if (!Number.isFinite(timestamp) || !Number.isFinite(now)) return 'Just now';
+
+  const delta = now - timestamp;
+
+  // Future timestamps (negative delta) → "Just now". Clock drift between
+  // the writer (content-script tab) and the reader (popup) shouldn't
+  // produce a confusing "in 3 minutes" string.
+  if (delta < 0) return 'Just now';
+
+  if (delta < MINUTE_MS) return 'Just now';
+  if (delta < HOUR_MS) return `${Math.floor(delta / MINUTE_MS)}m ago`;
+  if (delta < DAY_MS) return `${Math.floor(delta / HOUR_MS)}h ago`;
+  if (delta < 2 * DAY_MS) return 'Yesterday';
+  if (delta < WEEK_MS) return `${Math.floor(delta / DAY_MS)} days ago`;
+
+  // ≥ 7 days — switch to absolute date. Year suffix only when the
+  // timestamp's year differs from `now`'s year (keeps the common
+  // "earlier this year" case terse).
+  const date = new Date(timestamp);
+  const nowDate = new Date(now);
+  const month = MONTHS_SHORT[date.getMonth()];
+  const day = date.getDate();
+  if (date.getFullYear() === nowDate.getFullYear()) {
+    return `${month} ${day}`;
+  }
+  return `${month} ${day}, ${date.getFullYear()}`;
+}

--- a/src/core/popup/history-section.ts
+++ b/src/core/popup/history-section.ts
@@ -1,0 +1,175 @@
+/**
+ * Pure rendering for the popup "Recently read" surface (issue #49).
+ *
+ * Adapter pattern: this module takes data + callbacks and returns a DOM
+ * subtree. It does NOT touch `chrome.*`, the settings store, or the
+ * reading-position store. The chrome glue in
+ * `src/chrome/popup/index.ts` wires the callbacks:
+ *   - onResume → `chrome.tabs.create({ url })`
+ *   - onDelete → `ReadingPositionStore.clear(url)`
+ *   - onClearAll → `ReadingPositionStore.clearAll()`
+ *   - onEnableInSettings → `chrome.runtime.openOptionsPage()`
+ *
+ * Visibility model:
+ *   - `enabled: false` → render an "off" message with an Enable link
+ *     (NO list element rendered)
+ *   - `enabled: true, entries: []` → render an empty-state message
+ *     (NO list element rendered — pin via the empty-state test)
+ *   - `enabled: true, entries: [...]` → render the list, capped at
+ *     `MAX_DISPLAY_ENTRIES`
+ *
+ * Cap rationale (50): the underlying LRU is 100 entries (#48), but a
+ * popup viewport tops out around 600 px on a comfortable display. 50
+ * rows fits without scrolling churn and keeps the popup snappy.
+ * "Show all" pagination beyond 50 is explicitly deferred (out of scope
+ * for #49 per the brief).
+ *
+ * Pure — no `chrome.*`, no DOM imports from chrome modules. Uses the
+ * global `document` and `window` so the section can be rendered into
+ * any host page (popup, options page, future surfaces).
+ */
+
+import { deriveTitleFromUrl } from './derive-title';
+import { formatRelativeTime } from './format-relative-time';
+
+export const MAX_DISPLAY_ENTRIES = 50;
+
+export interface HistorySectionEntry {
+  /** Canonical URL from `ReadingPositionStore.list()`. */
+  readonly url: string;
+  /** `ReadingPosition.lastReadAt` in ms epoch. */
+  readonly timestamp: number;
+}
+
+export interface HistorySectionProps {
+  readonly entries: readonly HistorySectionEntry[];
+  readonly enabled: boolean;
+  readonly now: number;
+  readonly onResume: (url: string) => void;
+  readonly onDelete: (url: string) => void;
+  readonly onClearAll: () => void;
+  readonly onEnableInSettings: () => void;
+}
+
+export function renderHistorySection(props: HistorySectionProps): HTMLElement {
+  const section = document.createElement('section');
+  section.className = 'history';
+  section.setAttribute('aria-labelledby', 'history-heading');
+
+  const heading = document.createElement('h2');
+  heading.id = 'history-heading';
+  heading.className = 'history__heading';
+  heading.textContent = 'Recently read';
+  section.appendChild(heading);
+
+  if (!props.enabled) {
+    section.appendChild(renderDisabledState(props.onEnableInSettings));
+    return section;
+  }
+
+  if (props.entries.length === 0) {
+    section.appendChild(renderEmptyState());
+    return section;
+  }
+
+  const visible = props.entries.slice(0, MAX_DISPLAY_ENTRIES);
+  section.appendChild(renderList(visible, props));
+  section.appendChild(renderClearAllButton(props.onClearAll));
+  return section;
+}
+
+function renderDisabledState(onEnable: () => void): HTMLElement {
+  const wrapper = document.createElement('p');
+  wrapper.className = 'history__off';
+  // Use a button rather than an anchor — anchors with no real href
+  // either need href="#" (page-jump side effect) or JS-only handlers,
+  // and a button is the accessibility-correct primitive for a
+  // "navigate inside the extension" action.
+  wrapper.append('Reading history is off. ');
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'history__enable-link';
+  btn.textContent = 'Enable in settings';
+  btn.addEventListener('click', () => onEnable());
+  wrapper.appendChild(btn);
+  return wrapper;
+}
+
+function renderEmptyState(): HTMLElement {
+  const p = document.createElement('p');
+  p.className = 'history__empty';
+  p.textContent = 'No articles yet. Open SpeedReader on an article to start tracking.';
+  return p;
+}
+
+function renderList(
+  entries: readonly HistorySectionEntry[],
+  props: HistorySectionProps,
+): HTMLElement {
+  const ul = document.createElement('ul');
+  ul.className = 'history__list';
+  // jsdom + axe both honor the role override; an <ul> already has
+  // role=list, but the explicit attribute makes the test query stable
+  // against a future tag swap (e.g., <ol>).
+  ul.setAttribute('role', 'list');
+
+  for (const entry of entries) {
+    ul.appendChild(renderItem(entry, props));
+  }
+  return ul;
+}
+
+function renderItem(entry: HistorySectionEntry, props: HistorySectionProps): HTMLElement {
+  const li = document.createElement('li');
+  li.className = 'history__item';
+  li.setAttribute('role', 'listitem');
+
+  const title = deriveTitleFromUrl(entry.url);
+  const time = formatRelativeTime(entry.timestamp, props.now);
+
+  const resumeBtn = document.createElement('button');
+  resumeBtn.type = 'button';
+  resumeBtn.className = 'history__resume';
+  resumeBtn.dataset.action = 'resume';
+  // Accessible name comes from the text content; we wrap the time in a
+  // span so it's visually distinguishable but still part of the name.
+  resumeBtn.appendChild(document.createTextNode(title));
+  const timeEl = document.createElement('span');
+  timeEl.className = 'history__time';
+  timeEl.textContent = time;
+  resumeBtn.appendChild(timeEl);
+  resumeBtn.addEventListener('click', () => props.onResume(entry.url));
+
+  const deleteBtn = document.createElement('button');
+  deleteBtn.type = 'button';
+  deleteBtn.className = 'history__delete';
+  deleteBtn.dataset.action = 'delete';
+  deleteBtn.setAttribute('aria-label', `Remove ${title} from reading history`);
+  // U+00D7 multiplication sign — visually a × close glyph, kept out of
+  // the accessible name (aria-label above provides the meaningful text).
+  deleteBtn.textContent = '×';
+  deleteBtn.addEventListener('click', () => props.onDelete(entry.url));
+
+  li.appendChild(resumeBtn);
+  li.appendChild(deleteBtn);
+  return li;
+}
+
+function renderClearAllButton(onClearAll: () => void): HTMLElement {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'history__clear-all';
+  btn.dataset.action = 'clear-all';
+  btn.textContent = 'Clear all';
+  btn.addEventListener('click', () => {
+    // Confirm dialog keeps the affordance reversible — clearing 50
+    // entries on a misclick is a real annoyance, and the popup has
+    // no undo. window.confirm() is the smallest reversible primitive
+    // available in the popup context; a fancier in-popup confirm
+    // dialog could replace this later without breaking callers.
+    if (window.confirm('Clear all reading history?')) {
+      onClearAll();
+    }
+  });
+  return btn;
+}

--- a/src/core/settings/__tests__/migrations.test.ts
+++ b/src/core/settings/__tests__/migrations.test.ts
@@ -429,6 +429,30 @@ describe('migrate — V4 -> V5 historyEnabled field (#49)', () => {
     expect(result.historyEnabled).toBe(false);
   });
 
+  // TG5 — privacy-floor INTENT (not implementation): a hand-edited V4
+  // blob carrying ANY truthy or invalid `historyEnabled` value MUST end
+  // up at `historyEnabled === false` after migration. The previous
+  // single-case assertion (`historyEnabled: true`) passed by accident of
+  // spread order — the migrator's `{ ...raw, historyEnabled: false }`
+  // happens to put the literal AFTER the spread, so `false` wins. A
+  // defensible refactor flipping to `{ historyEnabled: false, ...raw }`
+  // ("defaults first, then user overrides") would silently allow
+  // `historyEnabled: true` through. These cases pin the contract
+  // independently of spread order: even if the migrator stamp loses,
+  // the V5 safeParse rejects invalid types and the defaults fallback
+  // (historyEnabled: false) restores the privacy floor.
+  it.each([
+    ['boolean true', true],
+    ['number 1', 1],
+    ['truthy string', 'TRUTHY_BUT_INVALID'],
+    ['number 0 (falsy but non-boolean)', 0],
+    ['object {}', {}],
+  ])('V4 -> V5 forces historyEnabled to false regardless of hand-edited %s', (_label, value) => {
+    const hand = { ...V4_BASE, historyEnabled: value };
+    const result = migrate(hand);
+    expect(result.historyEnabled).toBe(false);
+  });
+
   it('V5-already-present payload with historyEnabled: true round-trips unchanged', () => {
     const v5 = { ...DEFAULT_SETTINGS, historyEnabled: true };
     const result = migrate(v5);

--- a/src/core/settings/__tests__/migrations.test.ts
+++ b/src/core/settings/__tests__/migrations.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { migrate } from '../migrations';
 import { DEFAULT_SETTINGS } from '../defaults';
-import { SettingsSchemaV4 } from '../schema';
+import { SettingsSchemaV5 } from '../schema';
 
 describe('migrate', () => {
   it('returns a fresh defaults clone for undefined input (first install)', () => {
@@ -37,14 +37,14 @@ describe('migrate', () => {
     const written = JSON.parse(JSON.stringify(modified)); // simulate storage round-trip
     const read = migrate(written);
     expect(read).toEqual(modified);
-    expect(SettingsSchemaV4.safeParse(read).success).toBe(true);
+    expect(SettingsSchemaV5.safeParse(read).success).toBe(true);
   });
 
   it('migrates a synthetic v0 payload up through the full chain to current version', () => {
     // v0 lacks an explicit version field; defaults fill in the rest.
     const v0 = { wpm: 300, theme: 'dark', font: 'Georgia', fontSize: 22 };
     const result = migrate(v0);
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.wpm).toBe(300);
     expect(result.theme).toBe('dark');
     // Fields absent in v0 come from defaults.
@@ -55,7 +55,7 @@ describe('migrate', () => {
   it('fills in missing fields from defaults when partial v2 is stored', () => {
     const partial = { version: 2, wpm: 350 };
     const result = migrate(partial);
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.wpm).toBe(350);
     expect(result.theme).toBe(DEFAULT_SETTINGS.theme);
     expect(result.fontSize).toBe(DEFAULT_SETTINGS.fontSize);
@@ -82,7 +82,7 @@ describe('migrate', () => {
     const result = migrate(v3MissingField);
     expect(result.punctuationPacing).toBe(DEFAULT_SETTINGS.punctuationPacing);
     // And the rest of the user's values survive the repair.
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.wpm).toBe(300);
     expect(result.theme).toBe('dark');
   });
@@ -105,7 +105,7 @@ describe('migrate — V1 -> V2 alignment field (forward-compatible)', () => {
       punctuationPacing: true,
     };
     const result = migrate(v1);
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.alignment).toBe('orp');
     expect(result.wpm).toBe(300);
     expect(result.theme).toBe('dark');
@@ -118,7 +118,7 @@ describe('migrate — V1 -> V2 alignment field (forward-compatible)', () => {
   it('V0 payload (no version) -> chained 0->1->2->3 with alignment: orp', () => {
     const v0 = { wpm: 280, theme: 'light' as const };
     const result = migrate(v0);
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.alignment).toBe('orp');
     expect(result.wpm).toBe(280);
     expect(result.theme).toBe('light');
@@ -136,7 +136,7 @@ describe('migrate — V1 -> V2 alignment field (forward-compatible)', () => {
       alignment: 'center' as const,
     };
     const result = migrate(v2);
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.alignment).toBe('center');
     expect(result.wpm).toBe(300);
     expect(result.theme).toBe('dark');
@@ -176,7 +176,7 @@ describe('migrate — V2 -> V3 theme enum widening (#101)', () => {
     'V2 payload with legacy theme "%s" -> V3 preserves theme, stamps version: 3',
     (theme) => {
       const result = migrate({ ...V2_BASE, theme });
-      expect(result.version).toBe(4);
+      expect(result.version).toBe(5);
       expect(result.theme).toBe(theme);
       expect(result.wpm).toBe(300);
       expect(result.alignment).toBe('orp');
@@ -190,14 +190,14 @@ describe('migrate — V2 -> V3 theme enum widening (#101)', () => {
       const result = migrate(v3);
       expect(result).toEqual(v3);
       expect(result.theme).toBe(newTheme);
-      expect(result.version).toBe(4);
+      expect(result.version).toBe(5);
     },
   );
 
   it('V0 payload with legacy theme: light chains through to V3', () => {
     const v0 = { wpm: 320, theme: 'light' as const };
     const result = migrate(v0);
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.theme).toBe('light');
     expect(result.alignment).toBe('orp'); // stamped at 1->2
   });
@@ -210,7 +210,7 @@ describe('migrate — V2 -> V3 theme enum widening (#101)', () => {
     // here as an intentional change, not silent data loss.
     const v2Corrupt = { ...V2_BASE, theme: 'sepia' as const };
     const result = migrate(v2Corrupt);
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.theme).toBe('sepia');
   });
 });
@@ -224,7 +224,7 @@ describe('migrate — version-boundary policies', () => {
     // a future "reject future versions" change surfaces here.
     const future = { version: 99, wpm: 400, theme: 'dark' as const, alignment: 'orp' as const };
     const result = migrate(future);
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.wpm).toBe(400);
     expect(result.theme).toBe('dark');
     expect(result.alignment).toBe('orp');
@@ -261,7 +261,7 @@ describe('migrate — version-boundary policies', () => {
   it('partial V3 payload (missing alignment) -> defaults fill alignment: orp', () => {
     const partialV3 = { version: 3, wpm: 300, theme: 'nord' };
     const result = migrate(partialV3);
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.theme).toBe('nord');
     expect(result.alignment).toBe('orp');
   });
@@ -287,7 +287,7 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
 
   it('V3 payload (no contextLine/startFromWordOne/lastUsedWpm) -> V4 defaults the new fields; lastUsedWpm mirrors input wpm', () => {
     const result = migrate(V3_BASE);
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.contextLine).toBe(false);
     expect(result.startFromWordOne).toBe(false);
     expect(result.lastUsedWpm).toBe(V3_BASE.wpm);
@@ -300,7 +300,7 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
   it('V0 payload chains 0 -> 1 -> 2 -> 3 -> 4 with new V4 fields defaulted', () => {
     const v0 = { wpm: 320, theme: 'light' as const };
     const result = migrate(v0);
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.contextLine).toBe(false);
     expect(result.startFromWordOne).toBe(false);
     expect(result.lastUsedWpm).toBe(320); // mirrors wpm at 3->4 step
@@ -309,16 +309,16 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
     expect(result.theme).toBe('light');
   });
 
-  it('V4 payload with contextLine: true round-trips unchanged', () => {
-    const v4 = {
+  it('V5 payload with contextLine: true round-trips unchanged', () => {
+    const v5 = {
       ...DEFAULT_SETTINGS,
       contextLine: true,
       startFromWordOne: true,
       lastUsedWpm: 420,
       wpm: 420,
     };
-    const result = migrate(v4);
-    expect(result).toEqual(v4);
+    const result = migrate(v5);
+    expect(result).toEqual(v5);
     expect(result.contextLine).toBe(true);
     expect(result.startFromWordOne).toBe(true);
     expect(result.lastUsedWpm).toBe(420);
@@ -326,7 +326,7 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
 
   it('V3 payload with custom wpm: 380 -> V4 with lastUsedWpm: 380 (mirrors input wpm)', () => {
     const result = migrate({ ...V3_BASE, wpm: 380 });
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.wpm).toBe(380);
     expect(result.lastUsedWpm).toBe(380);
   });
@@ -343,7 +343,7 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
       punctuationPacing: true,
       alignment: 'orp',
     });
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.contextLine).toBe(false);
     expect(result.startFromWordOne).toBe(false);
     expect(result.lastUsedWpm).toBe(250);
@@ -364,12 +364,13 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
   });
 
   it('clamps an out-of-range numeric source to a valid lastUsedWpm without re-nuking via that field', () => {
-    // Pass a V4 blob where wpm is valid but lastUsedWpm is bogus. The
-    // V3->V4 migrator does not run (already V4), so the clamp does not
-    // apply — the safeParse falls back to defaults. Pins the boundary so
-    // future "auto-repair" changes surface here as intentional.
-    const v4Bogus = { ...DEFAULT_SETTINGS, lastUsedWpm: 99999 };
-    expect(migrate(v4Bogus)).toEqual(DEFAULT_SETTINGS);
+    // Pass a current-version blob where wpm is valid but lastUsedWpm is
+    // bogus. The V3->V4 migrator does not run (already past V4), so the
+    // clamp does not apply — the safeParse falls back to defaults. Pins
+    // the boundary so future "auto-repair" changes surface here as
+    // intentional.
+    const currentBogus = { ...DEFAULT_SETTINGS, lastUsedWpm: 99999 };
+    expect(migrate(currentBogus)).toEqual(DEFAULT_SETTINGS);
   });
 
   it('rounds raw.wpm to nearest multipleOf(10) when seeding lastUsedWpm', () => {
@@ -384,5 +385,69 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
     // → entire payload nukes to defaults. That's correct behavior; this
     // test pins it so a future relaxation surfaces here.
     expect(result).toEqual(DEFAULT_SETTINGS);
+  });
+});
+
+// V4 -> V5 history opt-in toggle — issue #49.
+// V5 adds `historyEnabled: boolean` defaulted to `false` (privacy floor —
+// reading patterns are sensitive). The migrator never enables history
+// retroactively for existing users.
+describe('migrate — V4 -> V5 historyEnabled field (#49)', () => {
+  const V4_BASE = {
+    version: 4 as const,
+    wpm: 250,
+    theme: 'dark' as const,
+    font: 'system-ui',
+    fontSize: 20,
+    openDyslexic: false,
+    punctuationPacing: true,
+    alignment: 'orp' as const,
+    contextLine: false,
+    startFromWordOne: false,
+    lastUsedWpm: 250,
+  };
+
+  it('V4 payload (no historyEnabled) -> V5 with historyEnabled: false (opt-in default)', () => {
+    const result = migrate(V4_BASE);
+    expect(result.version).toBe(5);
+    expect(result.historyEnabled).toBe(false);
+    // Other V4 fields preserved.
+    expect(result.wpm).toBe(250);
+    expect(result.theme).toBe('dark');
+    expect(result.contextLine).toBe(false);
+    expect(result.lastUsedWpm).toBe(250);
+  });
+
+  it('V4 payload with historyEnabled: true is NOT possible — but a hand-edited blob is accepted at the V5 schema gate', () => {
+    // V4 schema strips historyEnabled (unknown key) on shape gates, but the
+    // raw migration step `4 -> 5` only does `...raw, historyEnabled: false`
+    // — meaning a user that hand-edits a V4 blob to add `historyEnabled:
+    // true` STILL ends up at historyEnabled: false after migration. Pins
+    // the migrator's stamp (we never auto-enable history during migration).
+    const hand = { ...V4_BASE, historyEnabled: true };
+    const result = migrate(hand);
+    expect(result.historyEnabled).toBe(false);
+  });
+
+  it('V5-already-present payload with historyEnabled: true round-trips unchanged', () => {
+    const v5 = { ...DEFAULT_SETTINGS, historyEnabled: true };
+    const result = migrate(v5);
+    expect(result).toEqual(v5);
+    expect(result.historyEnabled).toBe(true);
+  });
+
+  it('V0 payload chains all the way to V5 with historyEnabled: false', () => {
+    const v0 = { wpm: 300, theme: 'light' as const };
+    const result = migrate(v0);
+    expect(result.version).toBe(5);
+    expect(result.historyEnabled).toBe(false);
+  });
+
+  it('partial V5 payload missing historyEnabled — defaults fill it as false (forward-compat repair)', () => {
+    const partial: Record<string, unknown> = { ...DEFAULT_SETTINGS };
+    delete partial.historyEnabled;
+    const result = migrate(partial);
+    expect(result.version).toBe(5);
+    expect(result.historyEnabled).toBe(false);
   });
 });

--- a/src/core/settings/__tests__/schema.test.ts
+++ b/src/core/settings/__tests__/schema.test.ts
@@ -1,18 +1,24 @@
 import { describe, it, expect } from 'vitest';
-import { SettingsSchemaV4, SettingsSchemaV3, SettingsSchemaV2, VALID_ALIGNMENTS } from '../schema';
+import {
+  SettingsSchemaV5,
+  SettingsSchemaV4,
+  SettingsSchemaV3,
+  SettingsSchemaV2,
+  VALID_ALIGNMENTS,
+} from '../schema';
 
 const VALID_THEMES_V4 = ['system', 'light', 'dark', 'sepia', 'paper', 'cream', 'nord'] as const;
 import { DEFAULT_SETTINGS } from '../defaults';
 
-describe('SettingsSchemaV4 (current)', () => {
+describe('SettingsSchemaV5 (current)', () => {
   it('accepts the canonical defaults', () => {
-    const parsed = SettingsSchemaV4.safeParse(DEFAULT_SETTINGS);
+    const parsed = SettingsSchemaV5.safeParse(DEFAULT_SETTINGS);
     expect(parsed.success).toBe(true);
   });
 
   it('accepts a known-good payload', () => {
-    const parsed = SettingsSchemaV4.safeParse({
-      version: 4,
+    const parsed = SettingsSchemaV5.safeParse({
+      version: 5,
       wpm: 400,
       theme: 'dark',
       font: 'Georgia',
@@ -23,62 +29,64 @@ describe('SettingsSchemaV4 (current)', () => {
       contextLine: true,
       startFromWordOne: false,
       lastUsedWpm: 400,
+      historyEnabled: false,
     });
     expect(parsed.success).toBe(true);
   });
 
   it('rejects wpm outside [100, 600]', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, wpm: 50 }).success).toBe(false);
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, wpm: 9999 }).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, wpm: 50 }).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, wpm: 9999 }).success).toBe(false);
   });
 
   it('rejects wpm not multiples of 10', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, wpm: 255 }).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, wpm: 255 }).success).toBe(false);
   });
 
   it('rejects fontSize outside [12, 48]', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, fontSize: 8 }).success).toBe(false);
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, fontSize: 64 }).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, fontSize: 8 }).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, fontSize: 64 }).success).toBe(false);
   });
 
   it('rejects an unknown theme', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, theme: 'rainbow' }).success).toBe(
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, theme: 'rainbow' }).success).toBe(
       false,
     );
   });
 
   it('rejects a wrong version literal', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, version: 1 }).success).toBe(false);
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, version: 2 }).success).toBe(false);
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, version: 3 }).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, version: 1 }).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, version: 2 }).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, version: 3 }).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, version: 4 }).success).toBe(false);
   });
 });
 
 // V4 new fields (#72) — pin the three context-menu integration fields.
-describe('SettingsSchemaV4 — context-menu fields (#72)', () => {
+describe('SettingsSchemaV5 — context-menu fields (#72)', () => {
   it('rejects contextLine: non-boolean', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, contextLine: 'yes' }).success).toBe(
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, contextLine: 'yes' }).success).toBe(
       false,
     );
   });
 
   it('rejects startFromWordOne: non-boolean', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, startFromWordOne: 1 }).success).toBe(
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, startFromWordOne: 1 }).success).toBe(
       false,
     );
   });
 
   it('rejects lastUsedWpm outside [100, 600]', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 50 }).success).toBe(
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 50 }).success).toBe(
       false,
     );
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 9999 }).success).toBe(
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 9999 }).success).toBe(
       false,
     );
   });
 
   it('rejects lastUsedWpm not multiple of 10', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 255 }).success).toBe(
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 255 }).success).toBe(
       false,
     );
   });
@@ -86,24 +94,87 @@ describe('SettingsSchemaV4 — context-menu fields (#72)', () => {
   it('rejects missing contextLine', () => {
     const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
     delete partial.contextLine;
-    expect(SettingsSchemaV4.safeParse(partial).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse(partial).success).toBe(false);
   });
 });
 
 // V4 retains V3's 7-value theme enum (ADR #0002). Pin acceptance of
 // each design-pack theme so a regression collapsing back to V2's
 // 3-value set surfaces immediately.
-describe('SettingsSchemaV4 — theme enum (inherited from V3 widening, issue #101)', () => {
+describe('SettingsSchemaV5 — theme enum (inherited from V3 widening, issue #101)', () => {
   it.each(VALID_THEMES_V4)('ACCEPTS theme "%s"', (theme) => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, theme }).success).toBe(true);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, theme }).success).toBe(true);
   });
 
   it.each(['sepia', 'paper', 'cream', 'nord'] as const)(
     'design-pack theme "%s" is parseable',
     (theme) => {
-      expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, theme }).success).toBe(true);
+      expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, theme }).success).toBe(true);
     },
   );
+});
+
+// V5 new field (#49) — pin the historyEnabled boolean.
+describe('SettingsSchemaV5 — historyEnabled field (#49)', () => {
+  it('rejects historyEnabled: non-boolean', () => {
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: 'yes' }).success).toBe(
+      false,
+    );
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: 1 }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects missing historyEnabled', () => {
+    const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
+    delete partial.historyEnabled;
+    expect(SettingsSchemaV5.safeParse(partial).success).toBe(false);
+  });
+
+  it('ACCEPTS historyEnabled: true', () => {
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: true }).success).toBe(
+      true,
+    );
+  });
+
+  it('ACCEPTS historyEnabled: false (default)', () => {
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: false }).success).toBe(
+      true,
+    );
+  });
+});
+
+// Legacy V4 schema preserved for the V4 -> V5 migrator (#49 retention policy).
+describe('SettingsSchemaV4 (legacy, migration consumer)', () => {
+  const V4_CANONICAL = {
+    version: 4 as const,
+    wpm: 250,
+    theme: 'system' as const,
+    font: 'system-ui',
+    fontSize: 20,
+    openDyslexic: false,
+    punctuationPacing: true,
+    alignment: 'orp' as const,
+    contextLine: false,
+    startFromWordOne: false,
+    lastUsedWpm: 250,
+  };
+
+  it('accepts a V4 payload with version literal 4', () => {
+    expect(SettingsSchemaV4.safeParse(V4_CANONICAL).success).toBe(true);
+  });
+
+  it('rejects version: 5 (V4 schema is version-literal 4)', () => {
+    expect(SettingsSchemaV4.safeParse({ ...V4_CANONICAL, version: 5 }).success).toBe(false);
+  });
+
+  it('strips unknown V5 field historyEnabled (V4 schema has no historyEnabled)', () => {
+    // Zod strips unknown keys; success stays true. Documents the boundary
+    // so a future strict() change on V4 surfaces here.
+    expect(SettingsSchemaV4.safeParse({ ...V4_CANONICAL, historyEnabled: true }).success).toBe(
+      true,
+    );
+  });
 });
 
 // Legacy V3 schema preserved for migration consumers (#72 retention policy).
@@ -172,41 +243,41 @@ describe('SettingsSchemaV2 (legacy, migration consumer)', () => {
 // input. Chrome rejects-on-parse via Zod instead. Both strategies protect
 // downstream code from invalid values; these tests assert the rejection
 // behavior at the same boundaries Safari clamps to.
-describe('SettingsSchemaV4 — boundary cases (Safari parity)', () => {
+describe('SettingsSchemaV5 — boundary cases (Safari parity)', () => {
   it('accepts fontSize at lower boundary 12 (parity: clampFontSize accepts FONT_SIZE_MIN)', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, fontSize: 12 }).success).toBe(true);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, fontSize: 12 }).success).toBe(true);
   });
 
   it('accepts fontSize at upper boundary 48 (parity: clampFontSize accepts FONT_SIZE_MAX)', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, fontSize: 48 }).success).toBe(true);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, fontSize: 48 }).success).toBe(true);
   });
 
   it('accepts wpm at lower boundary 100', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, wpm: 100 }).success).toBe(true);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, wpm: 100 }).success).toBe(true);
   });
 
   it('accepts wpm at upper boundary 600', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, wpm: 600 }).success).toBe(true);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, wpm: 600 }).success).toBe(true);
   });
 
   it('rejects fontSize NaN (parity: clampFontSize returns FONT_SIZE_DEFAULT)', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, fontSize: NaN }).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, fontSize: NaN }).success).toBe(false);
   });
 
   it('rejects fontSize string (parity: clampFontSize returns FONT_SIZE_DEFAULT)', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, fontSize: 'big' }).success).toBe(
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, fontSize: 'big' }).success).toBe(
       false,
     );
   });
 
   it('rejects wpm NaN', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, wpm: NaN }).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, wpm: NaN }).success).toBe(false);
   });
 
   it('rejects missing wpm key', () => {
     const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
     delete partial.wpm;
-    expect(SettingsSchemaV4.safeParse(partial).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse(partial).success).toBe(false);
   });
 });
 
@@ -223,11 +294,11 @@ describe('SettingsSchemaV4 — boundary cases (Safari parity)', () => {
 //     note `project_safari_no_context_menu.md`.
 describe('DEFAULT_SETTINGS covers every schema field (Safari parity)', () => {
   it('DEFAULT_SETTINGS round-trips through the schema', () => {
-    expect(SettingsSchemaV4.safeParse(DEFAULT_SETTINGS).success).toBe(true);
+    expect(SettingsSchemaV5.safeParse(DEFAULT_SETTINGS).success).toBe(true);
   });
 
   it('DEFAULT_SETTINGS has a value for every schema key', () => {
-    const shapeKeys = Object.keys(SettingsSchemaV4.shape);
+    const shapeKeys = Object.keys(SettingsSchemaV5.shape);
     for (const key of shapeKeys) {
       expect(DEFAULT_SETTINGS).toHaveProperty(key);
     }
@@ -238,37 +309,37 @@ describe('DEFAULT_SETTINGS covers every schema field (Safari parity)', () => {
 // spec docs/superpowers/specs/2026-05-23-alignment-field-v2.md).
 // Target: 7 cases (2 accept + 5 reject). Type-mismatch cases (42, true)
 // are paired into a single parameterized it.each per spec author note.
-describe('SettingsSchemaV4 — alignment field (Safari parity)', () => {
+describe('SettingsSchemaV5 — alignment field (Safari parity)', () => {
   it("ACCEPTS alignment: 'orp'", () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, alignment: 'orp' }).success).toBe(
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, alignment: 'orp' }).success).toBe(
       true,
     );
   });
 
   it("ACCEPTS alignment: 'center'", () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, alignment: 'center' }).success).toBe(
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, alignment: 'center' }).success).toBe(
       true,
     );
   });
 
   it("REJECTS alignment: 'left' (string outside enum)", () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, alignment: 'left' }).success).toBe(
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, alignment: 'left' }).success).toBe(
       false,
     );
   });
 
   it("REJECTS alignment: '' (empty string)", () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, alignment: '' }).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, alignment: '' }).success).toBe(false);
   });
 
   it('REJECTS alignment: undefined (missing required key)', () => {
     const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
     delete partial.alignment;
-    expect(SettingsSchemaV4.safeParse(partial).success).toBe(false);
+    expect(SettingsSchemaV5.safeParse(partial).success).toBe(false);
   });
 
   it('REJECTS alignment: null', () => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, alignment: null }).success).toBe(
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, alignment: null }).success).toBe(
       false,
     );
   });
@@ -277,7 +348,7 @@ describe('SettingsSchemaV4 — alignment field (Safari parity)', () => {
     { label: 'number 42', value: 42 },
     { label: 'boolean true', value: true },
   ])('REJECTS alignment: $label (type mismatch)', ({ value }) => {
-    expect(SettingsSchemaV4.safeParse({ ...DEFAULT_SETTINGS, alignment: value }).success).toBe(
+    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, alignment: value }).success).toBe(
       false,
     );
   });
@@ -286,9 +357,9 @@ describe('SettingsSchemaV4 — alignment field (Safari parity)', () => {
 // Defaults / VALID_ALIGNMENTS export — pins the Safari mirror at the
 // constant layer so accidental enum widening surfaces immediately.
 describe('alignment defaults and VALID_ALIGNMENTS export', () => {
-  it("DEFAULT_SETTINGS.alignment === 'orp' AND version === 4 (current)", () => {
+  it("DEFAULT_SETTINGS.alignment === 'orp' AND version === 5 (current)", () => {
     expect(DEFAULT_SETTINGS.alignment).toBe('orp');
-    expect(DEFAULT_SETTINGS.version).toBe(4);
+    expect(DEFAULT_SETTINGS.version).toBe(5);
   });
 
   it("VALID_ALIGNMENTS has length 2 and equals ['orp', 'center']", () => {

--- a/src/core/settings/bounds.ts
+++ b/src/core/settings/bounds.ts
@@ -1,5 +1,5 @@
 /**
- * Canonical numeric bounds for SettingsV4 fields.
+ * Canonical numeric bounds for SettingsV5 fields.
  *
  * Single source of truth — `schema.ts` derives its Zod constraints from these
  * constants, and consumers that need to clamp/validate outside Zod (the

--- a/src/core/settings/defaults.ts
+++ b/src/core/settings/defaults.ts
@@ -1,7 +1,7 @@
-import type { SettingsV4 } from './schema';
+import type { SettingsV5 } from './schema';
 
-export const DEFAULT_SETTINGS: SettingsV4 = {
-  version: 4,
+export const DEFAULT_SETTINGS: SettingsV5 = {
+  version: 5,
   wpm: 250,
   theme: 'system',
   font: 'system-ui',
@@ -12,4 +12,7 @@ export const DEFAULT_SETTINGS: SettingsV4 = {
   contextLine: false,
   startFromWordOne: false,
   lastUsedWpm: 250,
+  // #49 — opt-in by default. Reading patterns are sensitive; users that
+  // want the popup "Recently read" surface must enable it explicitly.
+  historyEnabled: false,
 };

--- a/src/core/settings/index.ts
+++ b/src/core/settings/index.ts
@@ -1,9 +1,11 @@
 export {
+  SettingsSchemaV5,
   SettingsSchemaV4,
   SettingsSchemaV3,
   SettingsSchemaV2,
   CURRENT_VERSION,
   VALID_ALIGNMENTS,
+  type SettingsV5,
   type SettingsV4,
   type SettingsV3,
   type SettingsV2,

--- a/src/core/settings/migrations.ts
+++ b/src/core/settings/migrations.ts
@@ -1,12 +1,12 @@
-import { SettingsSchemaV4, CURRENT_VERSION, type SettingsV4 } from './schema';
+import { SettingsSchemaV5, CURRENT_VERSION, type SettingsV5 } from './schema';
 import { DEFAULT_SETTINGS } from './defaults';
 
 type Migrator = (raw: Record<string, unknown>) => Record<string, unknown>;
 
 /**
  * Sequential migrators keyed by source version. Forward-only chain:
- * `0 -> 1 -> 2 -> 3 -> 4 -> ...`. To add a 4->5 migration in the future,
- * drop in `4: m4to5` and bump `CURRENT_VERSION` in `schema.ts`.
+ * `0 -> 1 -> 2 -> 3 -> 4 -> 5 -> ...`. To add a 5->6 migration in the future,
+ * drop in `5: m5to6` and bump `CURRENT_VERSION` in `schema.ts`.
  *
  * Spread order is load-bearing: `...raw` first, then literals. New
  * payloads get the literal `alignment: 'orp'` stamp; V4-already-present
@@ -30,6 +30,9 @@ type Migrator = (raw: Record<string, unknown>) => Record<string, unknown>;
  * `safeParse` to nuke the entire payload to defaults. The whole-payload
  * fallback still fires if `raw.wpm` itself fails V4 validation — this
  * clamp only protects the derived `lastUsedWpm` field.
+ *
+ * 4 -> 5 (#49) adds `historyEnabled: false`. Existing users opt in
+ * via the options page; the migrator never enables history retroactively.
  */
 function clampLastUsedWpm(raw: unknown): number {
   if (typeof raw !== 'number' || !Number.isFinite(raw)) return 250;
@@ -48,6 +51,7 @@ const MIGRATIONS: Record<number, Migrator> = {
     lastUsedWpm: clampLastUsedWpm(raw.wpm),
     version: 4,
   }),
+  4: (raw) => ({ ...raw, historyEnabled: false, version: 5 }),
 };
 
 /**
@@ -71,7 +75,7 @@ const MIGRATIONS: Record<number, Migrator> = {
  * `'migrates v3 blob with missing field by filling defaults (explicit repair
  * behavior)'` in `__tests__/migrations.test.ts`.
  */
-export function migrate(rawValue: unknown): SettingsV4 {
+export function migrate(rawValue: unknown): SettingsV5 {
   if (rawValue == null || typeof rawValue !== 'object' || Array.isArray(rawValue)) {
     return { ...DEFAULT_SETTINGS };
   }
@@ -87,7 +91,7 @@ export function migrate(rawValue: unknown): SettingsV4 {
   }
 
   const merged = { ...DEFAULT_SETTINGS, ...value, version: CURRENT_VERSION };
-  const parsed = SettingsSchemaV4.safeParse(merged);
+  const parsed = SettingsSchemaV5.safeParse(merged);
   if (!parsed.success) {
     console.warn(
       '[speedreader] settings failed validation, falling back to defaults',

--- a/src/core/settings/schema.ts
+++ b/src/core/settings/schema.ts
@@ -2,7 +2,18 @@ import { z } from 'zod';
 import { FONT_SIZE_MAX, FONT_SIZE_MIN, WPM_MAX, WPM_MIN, WPM_STEP } from './bounds';
 
 /**
- * V4 adds three fields for the context-menu integration (#72):
+ * V5 adds `historyEnabled` (issue #49) — opt-in toggle gating the popup
+ * "Recently read" surface. Default is `false` (privacy floor — reading
+ * patterns are sensitive). The 4 -> 5 migrator stamps `historyEnabled:
+ * false` for every existing payload; users that want history must
+ * opt in via the options page.
+ *
+ * Disabling the toggle does NOT clear existing reading-position records
+ * (the options-page UX surfaces a separate "Also clear existing entries"
+ * checkbox for that — see `src/chrome/options/`). The flag only gates
+ * the popup's display of `ReadingPositionStore.list()`.
+ *
+ * V4 added three fields for the context-menu integration (#72):
  * `contextLine` (toggle the line-of-context decoration around the current
  * RSVP word), `startFromWordOne` (always begin playback at token 0 rather
  * than restoring the saved cursor), and `lastUsedWpm` (persistent
@@ -12,8 +23,6 @@ import { FONT_SIZE_MAX, FONT_SIZE_MIN, WPM_MAX, WPM_MIN, WPM_STEP } from './boun
  * false`, and `lastUsedWpm` to the payload's current `wpm` (so first
  * post-migration submenu open shows the user's actual reading speed, not
  * a hardcoded 250). See `src/core/settings/migrations.ts`.
- *
- * No other shape changes from V3.
  */
 /**
  * Shared WPM constraint — used by both `wpm` and `lastUsedWpm` so the
@@ -23,6 +32,29 @@ import { FONT_SIZE_MAX, FONT_SIZE_MIN, WPM_MAX, WPM_MIN, WPM_STEP } from './boun
  */
 const WPM_SCHEMA = z.number().int().min(WPM_MIN).max(WPM_MAX).multipleOf(WPM_STEP);
 
+export const SettingsSchemaV5 = z.object({
+  version: z.literal(5),
+  wpm: WPM_SCHEMA,
+  theme: z.enum(['system', 'light', 'dark', 'sepia', 'paper', 'cream', 'nord']),
+  font: z.string(),
+  fontSize: z.number().int().min(FONT_SIZE_MIN).max(FONT_SIZE_MAX),
+  openDyslexic: z.boolean(),
+  punctuationPacing: z.boolean(),
+  alignment: z.enum(['orp', 'center']),
+  contextLine: z.boolean(),
+  startFromWordOne: z.boolean(),
+  lastUsedWpm: WPM_SCHEMA,
+  historyEnabled: z.boolean(),
+});
+
+export type SettingsV5 = z.infer<typeof SettingsSchemaV5>;
+
+export const CURRENT_VERSION = 5 as const;
+
+/**
+ * V4 preserved for the V4 -> V5 migrator (#49) per the schema retention
+ * policy adopted at V2 (issue #101 AC: "keep prior schema exported").
+ */
 export const SettingsSchemaV4 = z.object({
   version: z.literal(4),
   wpm: WPM_SCHEMA,
@@ -39,14 +71,12 @@ export const SettingsSchemaV4 = z.object({
 
 export type SettingsV4 = z.infer<typeof SettingsSchemaV4>;
 
-export const CURRENT_VERSION = 4 as const;
-
 /**
  * Cardinality-pinned constant mirroring Safari's `VALID_ALIGNMENTS`.
  * Used by tests today; consumed by the future Options-page UI radio
  * group (#30 follow-up) and overlay rendering wiring (pairs with #19).
  * Widening the enum is a future ADR — keep this in lockstep with the
- * `alignment` field in `SettingsSchemaV4` above.
+ * `alignment` field in `SettingsSchemaV5` above.
  */
 export const VALID_ALIGNMENTS = ['orp', 'center'] as const;
 


### PR DESCRIPTION
## Summary

- Adds a **Recently read** section to the popup: list of the last 50 articles the user has used SpeedReader on, with derived title, relative timestamp, click-to-resume, delete-on-hover, and clear-all.
- **Opt-in by default** — new `historyEnabled` settings field (default `false`). Privacy floor: reading patterns are sensitive. Disabled-state banner links to options.
- **Consumes #48's `ReadingPositionStore.list()`** — no parallel store, no schema bump on the position record. Click-to-resume opens the URL in a new tab; next mount auto-resumes via #48.
- **Options page Privacy fieldset** — enable toggle + companion "Also clear existing entries when disabling" checkbox. On true → false with companion checked, calls `store.clearAll()`.

Closes #49 — second of M2 batch A (after #48 store layer landed in PR #195).

## Locked design decisions (per dispatch brief)

| Axis | Decision |
|---|---|
| Backing store | Reuse `#48` `ReadingPositionStore.list()`; no parallel store |
| Title source | Derived from URL hostname + last path segment (no schema bump for real titles — defer to combined #196 spec) |
| Default state | Opt-in (`historyEnabled: false`) |
| Display cap | 50 entries (subset of 100-entry LRU from #48); constant exported |
| UI shape | List with derived title + relative time + delete-on-hover + clear-all; click = resume in new tab |
| Privacy semantics | Disable-doesn't-auto-clear (companion checkbox required); cross-context enumeration still applies (deferred to #196) |

## Decisions beyond the locked six (surfaced for review)

1. **Settings schema V4 → V5 bump.** Brief said avoid schema bumps; that referred to the persisted reading-position record. Settings bumps are routine (V3→V4 did the same for #72). Added `4: (raw) => ({ ...raw, historyEnabled: false, version: 5 })` migrator; V4 schema retained as frozen export per project policy.
2. **`onHistoryDisabled` optional 4th arg to `bindOptionsForm`.** Controller's data model stays pure; the "wipe on disable" side effect is a UX hook. Optional callback keeps controller tests isolated and the chrome boundary clean (only `chrome/options/index.ts` imports `createChromePositionStore`).
3. **Mount fails open.** `mountHistorySection` is wrapped in `.catch()` — history-path errors can never block the article/selection buttons. Falls back to disabled "off" state on settings-load failure.
4. **`window.confirm` for Clear-all.** Smallest reversible primitive. Tests stub both return values to pin the gating. Can be replaced with in-popup dialog later.
5. **Privacy section placement.** Sits between Pacing and Shortcuts in options page; existing `index-html.test.ts` set-equality assertion has no order constraint.

## Mutation evidence (assertion discrimination)

| Production line mutated | Mutation | Test that caught it |
|---|---|---|
| `format-relative-time.ts` `< MINUTE_MS` | → `<= MINUTE_MS` | `returns "1m ago" at the 60s boundary` |
| `derive-title.ts` www-strip | dropped `host.startsWith('www.') ? host.slice(4) : host` | `strips leading www. prefix` + `returns hostname / last-segment for deep path` (2 red) |
| `history-section.ts` cap | `slice(0, MAX_DISPLAY_ENTRIES)` → `slice(0)` | `renders at most MAX_DISPLAY_ENTRIES (50) even when given more` |
| `chrome/popup/index.ts` gate | `=== true` → `!== true` | 6 of 7 integration tests red |
| `chrome/options/controller.ts` transition | `true && next === false` → `false && next === true` | 4 history-toggle tests red |

All mutations reverted; 1111/1111 still green after re-run.

## Files changed

**New (7):** `src/core/popup/{format-relative-time,derive-title,history-section}.ts` + tests, `src/chrome/popup/__tests__/history-integration.test.ts`.

**Modified (settings V4→V5 rename — surgical):** `src/core/settings/{schema,defaults,migrations,index,bounds}.ts`, `src/core/messaging/validate.ts`, `src/core/overlay/types.ts`, `src/chrome/settings/storage.ts`, `src/chrome/background/context-menu/factory.ts`, `src/chrome/welcome/controller.ts`, plus all `__tests__` files referencing the type names (V4 frozen-schema test block + V4→V5 migration tests added).

**Modified (#49 chrome glue):** `src/chrome/popup/{index.ts,index.html,index.css}`, `src/chrome/options/{index.ts,index.html,controller.ts}`.

## Test plan

- [x] `npm run lint` — clean (`--max-warnings=0`)
- [x] `npm run format:check` — all formatted
- [x] `npm test` — 1111 passed / 1111 (+61 vs base)
- [x] `npm run build` — clean
- [ ] Manual smoke: load unpacked `dist/`, popup shows "Reading history is off" banner with link to options
- [ ] Manual: enable in options, read an article, reopen popup → entry appears with derived title + "Just now"
- [ ] Manual: click entry → new tab opens at URL, overlay auto-resumes via #48
- [ ] Manual: hover entry → delete button appears; click → entry removed
- [ ] Manual: clear-all → confirm dialog → all entries cleared
- [ ] Manual: disable history toggle in options → confirms toggle off; check companion checkbox → toggle off + entries cleared

## Deferred follow-ups

- Persistent real-title storage (requires position-record schema bump; defer to combined #196 SW migration + title PR)
- "Show all" pagination beyond 50 entries
- Search / filter / group-by-domain
- Export/import of history
- Cross-device sync
- Per-domain "never remember" denylist
- Live `storage.onChanged` subscription so popup re-renders on external store updates without re-open

## Related

- PR #195 (issue #48) — store layer that this consumes
- Issue #196 — S3 SW-owned message API spec (will rework `chrome.tabs.create` resume path)
- Issue #197 — `clearAll()` orphan-sweep maintenance
- Issue #198 — 13-NIT polish bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
