### PR TITLE
feat(rsvp): chunk-stream emission for 2–3 word display (#51)

### DIFF
--- a/src/chrome/background/context-menu/__tests__/factory.test.ts
+++ b/src/chrome/background/context-menu/__tests__/factory.test.ts
@@ -6,13 +6,13 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { SettingsV5 } from '../../../../core/settings';
+import type { SettingsV6 } from '../../../../core/settings';
 import { DEFAULT_SETTINGS } from '../../../../core/settings/defaults';
 import { buildMenuItems, type CtxMenuItemId } from '../factory';
 
 const HTTP = ['http://*/*', 'https://*/*'];
 
-function withSettings(partial: Partial<SettingsV5>): SettingsV5 {
+function withSettings(partial: Partial<SettingsV6>): SettingsV6 {
   return { ...DEFAULT_SETTINGS, ...partial };
 }
 

--- a/src/chrome/background/context-menu/__tests__/install.test.ts
+++ b/src/chrome/background/context-menu/__tests__/install.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
-import type { SettingsV5 } from '../../../../core/settings';
+import type { SettingsV6 } from '../../../../core/settings';
 import { DEFAULT_SETTINGS } from '../../../../core/settings/defaults';
 
 vi.mock('../../../settings/storage', () => ({
@@ -101,7 +101,7 @@ describe('ensureContextMenu', () => {
     stub.contextMenus.create.mockClear();
     stub.contextMenus.update.mockClear();
 
-    const nextSettings: SettingsV5 = { ...DEFAULT_SETTINGS, lastUsedWpm: 420 };
+    const nextSettings: SettingsV6 = { ...DEFAULT_SETTINGS, lastUsedWpm: 420 };
     loadSettings.mockResolvedValueOnce(nextSettings);
     await ensureContextMenu();
 
@@ -122,7 +122,7 @@ describe('ensureContextMenu', () => {
     stub.contextMenus.create.mockClear();
     stub.contextMenus.update.mockClear();
 
-    const nextSettings: SettingsV5 = { ...DEFAULT_SETTINGS, contextLine: true };
+    const nextSettings: SettingsV6 = { ...DEFAULT_SETTINGS, contextLine: true };
     loadSettings.mockResolvedValueOnce(nextSettings);
     await ensureContextMenu();
 
@@ -155,7 +155,7 @@ describe('ensureContextMenu', () => {
     let loadResolved = false;
     loadSettings.mockImplementationOnce(
       () =>
-        new Promise<SettingsV5>((resolve) => {
+        new Promise<SettingsV6>((resolve) => {
           setTimeout(() => {
             loadResolved = true;
             resolve(DEFAULT_SETTINGS);

--- a/src/chrome/background/context-menu/factory.ts
+++ b/src/chrome/background/context-menu/factory.ts
@@ -4,7 +4,7 @@
  * No `chrome.*` calls — `install.ts` owns the adapter side. Keeping this
  * file pure means every shape decision (titles, checkbox state, separator
  * placement) is exercised by `factory.test.ts` against a plain
- * `SettingsV5` input without any chrome-stub scaffolding.
+ * `SettingsV6` input without any chrome-stub scaffolding.
  *
  * See:
  * - `docs/superpowers/specs/2026-05-25-context-menu-integration.md`
@@ -13,7 +13,7 @@
  *   §"File Layout" — the factory / adapter / listener split.
  */
 
-import type { SettingsV5 } from '../../../core/settings';
+import type { SettingsV6 } from '../../../core/settings';
 
 /**
  * Stable, versioned menu-item IDs. The `v1` suffix lets a future shape
@@ -63,7 +63,7 @@ const HTTP_PATTERNS = ['http://*/*', 'https://*/*'] as const;
  * `chrome.*` references. Items are emitted in the order they should
  * appear in the submenu; the adapter preserves order on `create`.
  */
-export function buildMenuItems(settings: SettingsV5): CtxItemSpec[] {
+export function buildMenuItems(settings: SettingsV6): CtxItemSpec[] {
   const PARENT_ID: CtxMenuItemId = 'speedreader.ctx.parent.v1';
 
   const parent: CtxItemSpec = {

--- a/src/chrome/content/__tests__/chunk-size-wire.test.ts
+++ b/src/chrome/content/__tests__/chunk-size-wire.test.ts
@@ -1,0 +1,198 @@
+/**
+ * chunk-size-wire.test.ts — issue #51 (test-gap HIGH #3)
+ *
+ * End-to-end wire from `chrome.storage.sync.get` → loadSettings →
+ * createOverlay (`initialSettings.chunkSize` slot) → subscribeSettings
+ * push → `engine.setChunkSize(next)`. The unit tests in
+ * `core/rsvp-engine/__tests__/chunk-mode.test.ts` pin the engine's
+ * local behaviour; this file pins the chrome-glue boundary so a
+ * regression that drops `chunkSize: settings.chunkSize` from the CS
+ * payload or the subscribe wiring lands as a test failure rather
+ * than a silent default at the boundary.
+ *
+ * Mutation guards:
+ *   - Hardcoding `chunkSize: 1` at the initial-mount site must fail
+ *     the first test (which loads chunkSize=3 and asserts chunk
+ *     events are emitted by the underlying engine).
+ *   - Dropping `chunkSize: s.chunkSize` from the subscribe wiring
+ *     must fail the second test (settings push to chunkSize=2
+ *     should switch the live event stream from word to chunk).
+ */
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
+import type { SettingsV6 } from '../../../core/settings/schema';
+import { OVERLAY_CLASS } from '../../../core/overlay/constants';
+
+const SETTINGS_KEY = 'speedreader.settings';
+const EXT_ID = 'test-ext';
+
+type Listener = (
+  msg: unknown,
+  sender: { id?: string },
+  sendResponse: (r: unknown) => void,
+) => unknown;
+
+type StorageChangedListener = (
+  changes: Record<string, { newValue?: unknown; oldValue?: unknown }>,
+  area: string,
+) => void;
+
+interface ChromeMock {
+  runtime: {
+    id: string;
+    onMessage: { addListener: (l: Listener) => void };
+    getURL: ReturnType<typeof vi.fn>;
+  };
+  storage: {
+    sync: {
+      get: ReturnType<typeof vi.fn>;
+      set: ReturnType<typeof vi.fn>;
+    };
+    onChanged: {
+      addListener: ReturnType<typeof vi.fn>;
+      removeListener: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+function installChromeMock(stored: SettingsV6): {
+  mock: ChromeMock;
+  getListener: () => Listener;
+  emitStorageChange: (next: SettingsV6) => void;
+} {
+  let capturedListener: Listener | undefined;
+  const storageListeners: StorageChangedListener[] = [];
+  const mock: ChromeMock = {
+    runtime: {
+      id: EXT_ID,
+      onMessage: {
+        addListener: (l: Listener) => {
+          capturedListener = l;
+        },
+      },
+      getURL: vi.fn((path: string) => `chrome-extension://${EXT_ID}/${path}`),
+    },
+    storage: {
+      sync: {
+        get: vi.fn().mockResolvedValue({ [SETTINGS_KEY]: stored }),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      onChanged: {
+        addListener: vi.fn((l: StorageChangedListener) => {
+          storageListeners.push(l);
+        }),
+        removeListener: vi.fn(),
+      },
+    },
+  };
+  (globalThis as unknown as { chrome: ChromeMock }).chrome = mock;
+  return {
+    mock,
+    getListener: () => {
+      if (!capturedListener) throw new Error('content script never registered listener');
+      return capturedListener;
+    },
+    emitStorageChange: (next: SettingsV6) => {
+      for (const l of storageListeners) {
+        l({ [SETTINGS_KEY]: { newValue: next, oldValue: stored } }, 'sync');
+      }
+    },
+  };
+}
+
+function getShadow(): ShadowRoot {
+  const host = document.body.querySelector('[data-speedreader-overlay]');
+  if (!(host instanceof HTMLElement) || !host.shadowRoot) {
+    throw new Error('overlay host missing or no shadow root');
+  }
+  return host.shadowRoot;
+}
+
+function getWordRegion(): HTMLElement {
+  const el = getShadow().querySelector<HTMLElement>(`.${OVERLAY_CLASS.WORD_REGION}`);
+  if (!el) throw new Error('overlay shadow: missing word region');
+  return el;
+}
+
+async function mountOverlay(getListener: () => Listener): Promise<void> {
+  // Long enough that chunkSize=2 and 3 both produce a multi-word first chunk.
+  document.body.innerHTML = '<article>The quick brown fox jumps over the lazy dog.</article>';
+  await import('../index');
+  const listener = getListener();
+  const respond = vi.fn();
+  listener({ type: 'activate-reader' }, { id: EXT_ID }, respond);
+  expect(respond).toHaveBeenCalledWith({ ok: true });
+  // Drain the microtask queue (loadSettings is async) without
+  // advancing fake timers — engine emits its first event synchronously
+  // inside the mount's start(), so once the overlay handle exists the
+  // first tick is already rendered. Using runAllTimersAsync would
+  // exhaust the entire RSVP timer loop and leave the word region on
+  // the LAST emitted event, not the first.
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('content script — chunkSize wire boundary (#51)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (globalThis as unknown as { chrome?: unknown }).chrome;
+    document.body.innerHTML = '';
+    document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+    vi.resetModules();
+  });
+
+  test('initialSettings.chunkSize reflects stored value — engine emits 3-word chunks on first tick', async () => {
+    // The overlay forwards initialSettings.chunkSize into the engine
+    // factory. With chunkSize=3 and a clean stream, the first emission
+    // should be a chunk of 3 words ("The quick brown") rendered into
+    // the word region. A regression that hardcodes chunkSize:1 (or
+    // drops the field) would cause word-mode emission — the word
+    // region would show only "The".
+    const { getListener } = installChromeMock({
+      ...DEFAULT_SETTINGS,
+      chunkSize: 3,
+    });
+    await mountOverlay(getListener);
+    expect(getWordRegion().textContent).toBe('The quick brown');
+  });
+
+  test('subscribeSettings push delivers chunkSize change — live update flips display to 2-word chunks', async () => {
+    // Start at chunkSize=1 (word mode) — first emission is the single
+    // word "The". Then push chunkSize=2; the overlay's subscribe
+    // handler calls engine.setChunkSize(2) which rebuilds chunks and
+    // (in paused state) emits a replacement chunk for the current
+    // position. The engine here is PLAYING, so setChunkSize ticks
+    // immediately at the new mode — next visible text should be a
+    // chunk like "quick brown" or "The quick" depending on where the
+    // position landed. Either way it must NOT be a single word.
+    const { getListener, emitStorageChange } = installChromeMock({
+      ...DEFAULT_SETTINGS,
+      chunkSize: 1,
+    });
+    await mountOverlay(getListener);
+    expect(getWordRegion().textContent).toBe('The');
+
+    emitStorageChange({ ...DEFAULT_SETTINGS, chunkSize: 2 });
+    // Drain microtasks (storage onChanged → loadSettings → subscriber)
+    // without advancing timers — the live setChunkSize call is
+    // synchronous from the subscriber's perspective, and on PLAYING
+    // state it ticks immediately (emitting a chunk event synchronously
+    // via the engine subscriber). Advancing timers would let the
+    // engine run to completion and leave the region on the last word.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Word region should now contain a multi-word chunk (text
+    // includes a space). Asserting "contains a space" is robust to
+    // exactly which chunk the engine lands on after the live switch.
+    const text = getWordRegion().textContent ?? '';
+    expect(text.includes(' ')).toBe(true);
+    expect(text.split(' ').length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/chrome/content/__tests__/font-wire.test.ts
+++ b/src/chrome/content/__tests__/font-wire.test.ts
@@ -17,7 +17,7 @@
  */
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
-import type { SettingsV5 } from '../../../core/settings/schema';
+import type { SettingsV6 } from '../../../core/settings/schema';
 import { OVERLAY_CLASS } from '../../../core/overlay/constants';
 
 const SETTINGS_KEY = 'speedreader.settings';
@@ -52,10 +52,10 @@ interface ChromeMock {
   };
 }
 
-function installChromeMock(stored: SettingsV5): {
+function installChromeMock(stored: SettingsV6): {
   mock: ChromeMock;
   getListener: () => Listener;
-  emitStorageChange: (next: SettingsV5) => void;
+  emitStorageChange: (next: SettingsV6) => void;
 } {
   let capturedListener: Listener | undefined;
   const storageListeners: StorageChangedListener[] = [];
@@ -89,7 +89,7 @@ function installChromeMock(stored: SettingsV5): {
       if (!capturedListener) throw new Error('content script never registered listener');
       return capturedListener;
     },
-    emitStorageChange: (next: SettingsV5) => {
+    emitStorageChange: (next: SettingsV6) => {
       for (const l of storageListeners) {
         l({ [SETTINGS_KEY]: { newValue: next, oldValue: stored } }, 'sync');
       }

--- a/src/chrome/content/index.ts
+++ b/src/chrome/content/index.ts
@@ -271,6 +271,11 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
             // 'system', so the overlay's typed `font?: FontId` slot stays
             // honest at the boundary.
             font: resolveFontId(settings),
+            // #51 — chunk size pinned at mount. Live-update via
+            // subscribeSettings is intentionally NOT wired (engine
+            // reconstruction required); changes apply on next overlay
+            // mount.
+            chunkSize: settings.chunkSize,
           },
           subscribeSettings: (listener) =>
             subscribeSettings((s) =>
@@ -280,6 +285,7 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
                 fontSize: s.fontSize,
                 openDyslexic: s.openDyslexic,
                 font: resolveFontId(s),
+                chunkSize: s.chunkSize,
               }),
             ),
           // OpenDyslexic font URL (#27, #10). `core/` cannot call

--- a/src/chrome/options/__tests__/controller.test.ts
+++ b/src/chrome/options/__tests__/controller.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { bindOptionsForm, FIELD_IDS, type SettingsApi } from '../controller';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
-import type { SettingsV5 } from '../../../core/settings/schema';
+import type { SettingsV6 } from '../../../core/settings/schema';
 
 const HTML = `
   <div id="load-error-banner"></div>
@@ -32,6 +32,11 @@ const HTML = `
   <input type="checkbox" id="${FIELD_IDS.startFromWordOne}" />
   <input type="checkbox" id="${FIELD_IDS.historyEnabled}" />
   <input type="checkbox" id="historyClearOnDisable" />
+  <select id="${FIELD_IDS.chunkSize}">
+    <option value="1"></option>
+    <option value="2"></option>
+    <option value="3"></option>
+  </select>
   <div id="saved"></div>
   <div id="save-error"></div>
 `;
@@ -41,15 +46,15 @@ interface Stub extends SettingsApi {
   saveMock: ReturnType<typeof vi.fn>;
   flushMock: ReturnType<typeof vi.fn>;
   subscribeMock: ReturnType<typeof vi.fn>;
-  emit(s: SettingsV5): void;
+  emit(s: SettingsV6): void;
 }
 
-function makeStub(initial: SettingsV5 = DEFAULT_SETTINGS): Stub {
-  let listener: ((s: SettingsV5) => void) | null = null;
+function makeStub(initial: SettingsV6 = DEFAULT_SETTINGS): Stub {
+  let listener: ((s: SettingsV6) => void) | null = null;
   const loadMock = vi.fn(async () => initial);
   const saveMock = vi.fn(async () => undefined);
   const flushMock = vi.fn(async () => undefined);
-  const subscribeMock = vi.fn((cb: (s: SettingsV5) => void) => {
+  const subscribeMock = vi.fn((cb: (s: SettingsV6) => void) => {
     listener = cb;
     return () => {
       listener = null;
@@ -439,7 +444,7 @@ describe('options controller', () => {
   });
 
   // #49 — historyEnabled toggle + onHistoryDisabled side-effect hook.
-  // The controller's settings data model is pure SettingsV5; the hook
+  // The controller's settings data model is pure SettingsV6; the hook
   // is the bridge to the position-store wipe action wired in index.ts.
   describe('history toggle (#49)', () => {
     it('populates historyEnabled checkbox from loaded settings', async () => {
@@ -557,6 +562,44 @@ describe('options controller', () => {
 
       window.dispatchEvent(new Event('pagehide'));
       expect(stub.flushMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // #51 — chunk size select (1 | 2 | 3).
+  describe('chunk size (#51)', () => {
+    it('populates the chunkSize select from loaded settings', async () => {
+      const stub = makeStub({ ...DEFAULT_SETTINGS, chunkSize: 2 });
+      await bindOptionsForm(document, window, stub);
+      const select = document.getElementById(FIELD_IDS.chunkSize) as HTMLSelectElement;
+      expect(select.value).toBe('2');
+    });
+
+    it.each([1, 2, 3] as const)('saves chunkSize=%d on change', async (n) => {
+      const stub = makeStub({ ...DEFAULT_SETTINGS, chunkSize: 1 });
+      await bindOptionsForm(document, window, stub);
+      const select = document.getElementById(FIELD_IDS.chunkSize) as HTMLSelectElement;
+      select.value = String(n);
+      fire(select, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).toHaveBeenCalledWith({ chunkSize: n });
+    });
+
+    it('rejects an invalid chunkSize value at the boundary (HTML drift defense)', async () => {
+      // Simulate HTML drift adding a "4" option. The reader's literal-set
+      // gate MUST drop it so storage never sees a non-(1|2|3) value.
+      const stub = makeStub({ ...DEFAULT_SETTINGS, chunkSize: 1 });
+      await bindOptionsForm(document, window, stub);
+      const select = document.getElementById(FIELD_IDS.chunkSize) as HTMLSelectElement;
+      // Inject a rogue option and select it.
+      const rogue = document.createElement('option');
+      rogue.value = '4';
+      select.appendChild(rogue);
+      select.value = '4';
+      fire(select, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({ chunkSize: expect.anything() }),
+      );
     });
   });
 });

--- a/src/chrome/options/__tests__/index-html.test.ts
+++ b/src/chrome/options/__tests__/index-html.test.ts
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { bindOptionsForm, FIELD_IDS, type SettingsApi } from '../controller';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
-import type { SettingsV5 } from '../../../core/settings/schema';
+import type { SettingsV6 } from '../../../core/settings/schema';
 import manifest from '../../manifest';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -88,6 +88,7 @@ describe('options index.html structure', () => {
       ['fontSize', FIELD_IDS.fontSize],
       ['alignment', FIELD_IDS.alignment],
       ['contextLine', FIELD_IDS.contextLine],
+      ['chunkSize', FIELD_IDS.chunkSize],
     ])('places %s under Appearance', (_, id) => {
       const section = doc.querySelector('fieldset[data-section="appearance"]');
       expect(section?.querySelector(`#${id}`)).not.toBeNull();
@@ -116,6 +117,7 @@ describe('options index.html structure', () => {
       contextLine: 'Show line of context around current word',
       startFromWordOne: 'Always start from word one',
       historyEnabled: 'Remember recently read articles',
+      chunkSize: 'Words per display',
     };
 
     it.each(Object.entries(FIELD_IDS))(
@@ -213,7 +215,7 @@ describe('options index.html structure', () => {
    * assertion below go red.
    */
   describe('controller binds against real index.html', () => {
-    function makeStubApi(initial: SettingsV5 = DEFAULT_SETTINGS): SettingsApi & {
+    function makeStubApi(initial: SettingsV6 = DEFAULT_SETTINGS): SettingsApi & {
       loadMock: ReturnType<typeof vi.fn>;
       saveMock: ReturnType<typeof vi.fn>;
       flushMock: ReturnType<typeof vi.fn>;

--- a/src/chrome/options/controller.ts
+++ b/src/chrome/options/controller.ts
@@ -1,4 +1,4 @@
-import type { SettingsV5 } from '../../core/settings/schema';
+import type { SettingsV6 } from '../../core/settings/schema';
 import { DEFAULT_SETTINGS } from '../../core/settings/defaults';
 import {
   FONT_SIZE_MAX,
@@ -10,10 +10,10 @@ import {
 import { resolveFontId } from '../../core/overlay/font-ids';
 
 export interface SettingsApi {
-  load(): Promise<SettingsV5>;
-  save(partial: Partial<Omit<SettingsV5, 'version' | 'lastUsedWpm'>>): Promise<void>;
+  load(): Promise<SettingsV6>;
+  save(partial: Partial<Omit<SettingsV6, 'version' | 'lastUsedWpm'>>): Promise<void>;
   flush(): Promise<void>;
-  subscribe(listener: (s: SettingsV5) => void): () => void;
+  subscribe(listener: (s: SettingsV6) => void): () => void;
 }
 
 /**
@@ -42,6 +42,9 @@ export const FIELD_IDS = {
   contextLine: 'contextLine',
   startFromWordOne: 'startFromWordOne',
   historyEnabled: 'historyEnabled',
+  // #51 — chunk size select (1 | 2 | 3). Default 1 keeps today's
+  // single-word display; opting into 2 or 3 enables multi-word RSVP.
+  chunkSize: 'chunkSize',
 } as const;
 
 /**
@@ -51,7 +54,7 @@ export const FIELD_IDS = {
  * common case; nuking stored data is the destructive sub-action.
  *
  * This ID is read by `index.ts` (the chrome glue), NOT by the controller
- * — the controller's data model is `SettingsV5` only. The wipe call goes
+ * — the controller's data model is `SettingsV6` only. The wipe call goes
  * to the position store directly.
  */
 export const HISTORY_CLEAR_ON_DISABLE_ID = 'historyClearOnDisable';
@@ -63,11 +66,12 @@ const SAVED_INDICATOR_MS = 1500;
 const SAVE_ERROR_MS = 4000;
 
 type EditableField = keyof typeof FIELD_IDS;
-type EditableValue<K extends EditableField> = SettingsV5[K];
-type EditablePatch = Partial<Omit<SettingsV5, 'version' | 'lastUsedWpm'>>;
+type EditableValue<K extends EditableField> = SettingsV6[K];
+type EditablePatch = Partial<Omit<SettingsV6, 'version' | 'lastUsedWpm'>>;
 
 const THEME_VALUES = ['system', 'light', 'dark', 'sepia', 'paper', 'cream', 'nord'] as const;
 const ALIGNMENT_VALUES = ['orp', 'center'] as const;
+const CHUNK_SIZE_VALUES = [1, 2, 3] as const;
 
 function getInput(doc: Document, id: string): HTMLInputElement | HTMLSelectElement | null {
   const el = doc.getElementById(id);
@@ -75,7 +79,7 @@ function getInput(doc: Document, id: string): HTMLInputElement | HTMLSelectEleme
   return null;
 }
 
-function populate(doc: Document, s: SettingsV5): void {
+function populate(doc: Document, s: SettingsV6): void {
   const wpm = getInput(doc, FIELD_IDS.wpm);
   if (wpm) wpm.value = String(s.wpm);
 
@@ -107,6 +111,9 @@ function populate(doc: Document, s: SettingsV5): void {
 
   const historyEnabled = getInput(doc, FIELD_IDS.historyEnabled);
   if (historyEnabled instanceof HTMLInputElement) historyEnabled.checked = s.historyEnabled;
+
+  const chunkSize = getInput(doc, FIELD_IDS.chunkSize);
+  if (chunkSize) chunkSize.value = String(s.chunkSize);
 }
 
 function flashIndicator(doc: Document, win: Window, id: string, ms: number): void {
@@ -124,7 +131,7 @@ function showLoadErrorBanner(doc: Document): void {
 
 /**
  * Per-field reader. `K` ties the element-read result to the exact
- * `SettingsV5[K]` slot so `theme`-shaped readers can't accidentally return
+ * `SettingsV6[K]` slot so `theme`-shaped readers can't accidentally return
  * a number. Each reader returns `null` to reject invalid input — the binder
  * suppresses save on null, leaving the stored value untouched.
  */
@@ -160,18 +167,30 @@ function readFont(el: HTMLInputElement | HTMLSelectElement): string | null {
   return v;
 }
 
-function readTheme(el: HTMLInputElement | HTMLSelectElement): SettingsV5['theme'] | null {
-  const v = el.value as SettingsV5['theme'];
+function readTheme(el: HTMLInputElement | HTMLSelectElement): SettingsV6['theme'] | null {
+  const v = el.value as SettingsV6['theme'];
   return (THEME_VALUES as readonly string[]).includes(v) ? v : null;
 }
 
-function readAlignment(el: HTMLInputElement | HTMLSelectElement): SettingsV5['alignment'] | null {
-  const v = el.value as SettingsV5['alignment'];
+function readAlignment(el: HTMLInputElement | HTMLSelectElement): SettingsV6['alignment'] | null {
+  const v = el.value as SettingsV6['alignment'];
   return (ALIGNMENT_VALUES as readonly string[]).includes(v) ? v : null;
 }
 
 function readCheckbox(el: HTMLInputElement | HTMLSelectElement): boolean | null {
   return el instanceof HTMLInputElement ? el.checked : null;
+}
+
+function readChunkSize(el: HTMLInputElement | HTMLSelectElement): SettingsV6['chunkSize'] | null {
+  // Select values are strings even when the underlying schema is a
+  // numeric literal union; parse, then validate against the V6 literal
+  // set so HTML drift (a "4" option added to the select) does not
+  // sneak past the boundary into storage.
+  if (el.value.trim() === '') return null;
+  const n = Number(el.value);
+  if (!Number.isInteger(n)) return null;
+  if (!(CHUNK_SIZE_VALUES as readonly number[]).includes(n)) return null;
+  return n as SettingsV6['chunkSize'];
 }
 
 const FIELD_READERS: { [K in EditableField]: Reader<K> } = {
@@ -184,6 +203,7 @@ const FIELD_READERS: { [K in EditableField]: Reader<K> } = {
   contextLine: readCheckbox,
   startFromWordOne: readCheckbox,
   historyEnabled: readCheckbox,
+  chunkSize: readChunkSize,
 };
 
 function bindField<K extends EditableField>(
@@ -236,7 +256,7 @@ export async function bindOptionsForm(
   onHistoryDisabled?: OnHistoryDisabled,
 ): Promise<() => void> {
   let degraded = false;
-  let initial: SettingsV5;
+  let initial: SettingsV6;
   try {
     initial = await api.load();
   } catch (err) {

--- a/src/chrome/options/index.html
+++ b/src/chrome/options/index.html
@@ -274,6 +274,22 @@
           <input type="checkbox" id="contextLine" />
           <label for="contextLine">Show line of context around current word</label>
         </div>
+
+        <!-- #51 — chunk size select (1 | 2 | 3). Multi-word display is
+             a Safari-parity feature; the safe default is single-word. -->
+        <div class="field">
+          <label for="chunkSize">Words per display</label>
+          <select id="chunkSize" aria-describedby="chunkSize-hint">
+            <option value="1">1 word</option>
+            <option value="2">2 words</option>
+            <option value="3">3 words</option>
+          </select>
+          <span class="hint" id="chunkSize-hint">
+            Larger chunks reduce eye movement but require more focus.
+            Sentence boundaries are always respected — chunks never span
+            across the end of a sentence.
+          </span>
+        </div>
       </fieldset>
 
       <!-- Pacing -->

--- a/src/chrome/settings/__tests__/storage.test.ts
+++ b/src/chrome/settings/__tests__/storage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import sinonChrome from 'sinon-chrome';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
-import type { SettingsV5 } from '../../../core/settings/schema';
+import type { SettingsV6 } from '../../../core/settings/schema';
 import { DEBOUNCE_MS } from '../storage';
 
 const KEY = 'speedreader.settings';
@@ -81,7 +81,7 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('loadSettings returns valid stored payload as-is', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS, wpm: 380 } satisfies SettingsV5;
+    storedRaw = { ...DEFAULT_SETTINGS, wpm: 380 } satisfies SettingsV6;
     const { loadSettings } = await import('../storage');
     const settings = await loadSettings();
     expect(settings.wpm).toBe(380);
@@ -96,7 +96,7 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('saveSettings coalesces 10 calls within 300ms into one write', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV5;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV6;
     const { saveSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
@@ -113,14 +113,14 @@ describe('chrome settings storage adapter', () => {
     // Exactly one set call (the trailing-edge write); set may also fire from
     // an internal load() canonicalisation if storedRaw mismatched, so assert
     // the *final* persisted wpm rather than count alone.
-    const finalStored = storedRaw as SettingsV5;
+    const finalStored = storedRaw as SettingsV6;
     expect(finalStored.wpm).toBe(340);
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
   });
 
   // #68 — debounce window resolution contract.
   it('saveSettings: 3 calls in one window share resolution, all resolve on one set', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV5;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV6;
     const { saveSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
@@ -145,12 +145,12 @@ describe('chrome settings storage adapter', () => {
     // All three resolved together, and exactly one set fired.
     expect(resolved).toEqual([true, true, true]);
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
-    expect((storedRaw as SettingsV5).wpm).toBe(280);
+    expect((storedRaw as SettingsV6).wpm).toBe(280);
   });
 
   // #68 — late call landing during in-flight flush queues for next window.
   it('saveSettings: call landing during in-flight flush queues for next window (distinct resolutions)', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV5;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV6;
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
     // Replace `get` with a controllable Promise so we can park the in-flight
@@ -207,12 +207,12 @@ describe('chrome settings storage adapter', () => {
 
     // Two distinct sets — late call did not coalesce into the in-flight write.
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(2);
-    expect((storedRaw as SettingsV5).wpm).toBe(380);
+    expect((storedRaw as SettingsV6).wpm).toBe(380);
   });
 
   // #68 — flushSettings semantics.
   it('flushSettings resolves immediately when no pending save', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV5;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV6;
     const { flushSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
@@ -221,7 +221,7 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('flushSettings cancels debounce timer and forces an immediate flush', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV5;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV6;
     const { saveSettings, flushSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
@@ -250,7 +250,7 @@ describe('chrome settings storage adapter', () => {
     expect(flushPromiseResolved).toBe(true);
     expect(savePromiseResolved).toBe(true);
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
-    expect((storedRaw as SettingsV5).wpm).toBe(410);
+    expect((storedRaw as SettingsV6).wpm).toBe(410);
 
     // Confirm there is no zombie timer left behind — advancing past 300ms
     // must not produce a second set.
@@ -259,7 +259,7 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('flushSettings rejects when the forced flush fails', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV5;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV6;
     const { saveSettings, flushSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
     const setErr = new Error('quota exceeded');
@@ -280,13 +280,13 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('saveSettings preserves the version field', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV5;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV6;
     const { saveSettings } = await import('../storage');
     const p = saveSettings({ theme: 'dark' });
     await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
     await p;
-    const stored = storedRaw as SettingsV5;
-    expect(stored.version).toBe(5);
+    const stored = storedRaw as SettingsV6;
+    expect(stored.version).toBe(6);
     expect(stored.theme).toBe('dark');
   });
 
@@ -295,7 +295,7 @@ describe('chrome settings storage adapter', () => {
     const listener = vi.fn();
     const unsubscribe = subscribeSettings(listener);
 
-    const next: SettingsV5 = { ...DEFAULT_SETTINGS, wpm: 420 };
+    const next: SettingsV6 = { ...DEFAULT_SETTINGS, wpm: 420 };
     emitChange(next, 'sync');
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith(next);

--- a/src/chrome/settings/storage.ts
+++ b/src/chrome/settings/storage.ts
@@ -1,10 +1,10 @@
-import type { SettingsV5 } from '../../core/settings/schema';
+import type { SettingsV6 } from '../../core/settings/schema';
 import { migrate } from '../../core/settings/migrations';
 
 const KEY = 'speedreader.settings';
 export const DEBOUNCE_MS = 300;
 
-export type SaveSettingsInput = Omit<Partial<SettingsV5>, 'version'>;
+export type SaveSettingsInput = Omit<Partial<SettingsV6>, 'version'>;
 
 /**
  * Read settings from `chrome.storage.sync`, migrating + validating the raw
@@ -12,7 +12,7 @@ export type SaveSettingsInput = Omit<Partial<SettingsV5>, 'version'>;
  * or repair of a partial payload), the canonical form is written back so the
  * next read is a fast pass-through.
  */
-export async function loadSettings(): Promise<SettingsV5> {
+export async function loadSettings(): Promise<SettingsV6> {
   const result = await chrome.storage.sync.get(KEY);
   const raw = result[KEY];
   const settings = migrate(raw);
@@ -50,7 +50,7 @@ async function flushPendingSave(): Promise<void> {
   pendingRejectors = [];
   try {
     const current = await loadSettings();
-    const next: SettingsV5 = { ...current, ...partial, version: current.version };
+    const next: SettingsV6 = { ...current, ...partial, version: current.version };
     await chrome.storage.sync.set({ [KEY]: next });
     resolvers.forEach((r) => r());
   } catch (err) {
@@ -119,7 +119,7 @@ export function flushSettings(): Promise<void> {
  * the options page, or a different signed-in device via Chrome sync. Returns
  * an unsubscribe function.
  */
-export function subscribeSettings(listener: (s: SettingsV5) => void): () => void {
+export function subscribeSettings(listener: (s: SettingsV6) => void): () => void {
   const handler = (
     changes: Record<string, chrome.storage.StorageChange>,
     area: chrome.storage.AreaName,

--- a/src/chrome/welcome/__tests__/controller.test.ts
+++ b/src/chrome/welcome/__tests__/controller.test.ts
@@ -20,7 +20,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { bindWelcome, WELCOME_IDS, type SettingsApi } from '../controller';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
 import { SAMPLE_PASSAGE } from '../sample';
-import type { SettingsV5 } from '../../../core/settings/schema';
+import type { SettingsV6 } from '../../../core/settings/schema';
 
 const HTML = `
   <header>
@@ -46,16 +46,16 @@ interface Stub extends SettingsApi {
   loadMock: ReturnType<typeof vi.fn>;
   saveMock: ReturnType<typeof vi.fn>;
   flushMock: ReturnType<typeof vi.fn>;
-  resolveLoad(s: SettingsV5): void;
+  resolveLoad(s: SettingsV6): void;
   rejectLoad(err: unknown): void;
 }
 
-function makeStub(options: { initial?: SettingsV5; deferLoad?: boolean } = {}): Stub {
+function makeStub(options: { initial?: SettingsV6; deferLoad?: boolean } = {}): Stub {
   const initial = options.initial ?? DEFAULT_SETTINGS;
-  let resolveLoad: (s: SettingsV5) => void = () => undefined;
+  let resolveLoad: (s: SettingsV6) => void = () => undefined;
   let rejectLoad: (e: unknown) => void = () => undefined;
   const loadPromise = options.deferLoad
-    ? new Promise<SettingsV5>((res, rej) => {
+    ? new Promise<SettingsV6>((res, rej) => {
         resolveLoad = res;
         rejectLoad = rej;
       })

--- a/src/chrome/welcome/controller.ts
+++ b/src/chrome/welcome/controller.ts
@@ -11,14 +11,14 @@
  * See docs/superpowers/specs/2026-05-30-onboarding-surface.md.
  */
 
-import type { SettingsV5 } from '../../core/settings/schema';
+import type { SettingsV6 } from '../../core/settings/schema';
 import { DEFAULT_SETTINGS } from '../../core/settings/defaults';
 import { createRsvpEngine, type RsvpEngine } from '../../core/rsvp-engine';
 import { SAMPLE_PASSAGE } from './sample';
 
 export interface SettingsApi {
-  load(): Promise<SettingsV5>;
-  save(partial: Partial<Omit<SettingsV5, 'version' | 'lastUsedWpm'>>): Promise<void>;
+  load(): Promise<SettingsV6>;
+  save(partial: Partial<Omit<SettingsV6, 'version' | 'lastUsedWpm'>>): Promise<void>;
   flush(): Promise<void>;
 }
 

--- a/src/core/messaging/validate.ts
+++ b/src/core/messaging/validate.ts
@@ -23,7 +23,7 @@ import { SettingsSchemaV5 } from '../settings/schema';
  * activation alive with snapshot defaults for the other fields.
  *
  * Field-name alignment: `contextLine` / `startFromWordOne` here match
- * the `SettingsV5` field names exactly so the CS-side
+ * the `SettingsV6` field names exactly so the CS-side
  * `{...snapshot, ...validatedOverrides}` shallow-merge composes
  * cleanly without a wire→settings translation table. The hi-fi mock's
  * "Show context line" submenu label is a display string, not the wire

--- a/src/core/overlay/__tests__/chunk-render.test.ts
+++ b/src/core/overlay/__tests__/chunk-render.test.ts
@@ -79,22 +79,44 @@ describe('createOverlay — chunk event rendering (#51)', () => {
   });
 
   test('onWordAdvance fires on each chunk event with post-emit raw-axis progress', () => {
+    // Round-2 ITEM-3: stream contains a paragraph sentinel ('\n\n')
+    // between "quick" and "brown" so raw axis (5) and filtered-word
+    // axis (4) DIVERGE. A regression that reverts progress().index
+    // / total to filtered-word counts would report (2, 4) and
+    // (4, 4); the raw-axis assertions (2, 5) and (5, 5) catch it.
+    //
+    // markSentenceBoundaries:
+    //   The   word rawIndex=0 sentenceStart=true
+    //   quick word rawIndex=1
+    //   \n\n  paragraph (no rawIndex; sets next word sentenceStart)
+    //   brown word rawIndex=3 sentenceStart=true
+    //   fox.  word rawIndex=4 sentenceEnd=true
+    //
+    // buildChunks chunkSize=2 (filtered word axis):
+    //   chunk 0: [The, quick]   raw 0..1
+    //   chunk 1: [brown, fox.]  raw 3..4
+    //
+    // After chunk 0 emit: progress.index = chunk 0 endIndex + 1 = 2.
+    // After chunk 1 emit: nextIndex >= chunks.length → index = total = 5.
     const onWordAdvance = vi.fn();
     const overlay = createOverlay(
       defaultOpts({
         scope: 'full',
-        fullWords: ['The', 'quick', 'brown', 'fox.'],
+        fullWords: ['The', 'quick', '\n\n', 'brown', 'fox.'],
+        // Override default initialSettings to keep chunkSize=2 with
+        // the sentinel-bearing stream.
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, chunkSize: 2 },
         onWordAdvance,
       }),
     );
     overlay.mount();
-    // After first chunk: progress.index = chunk 0 endIndex + 1 = 2;
-    // total = 4 (raw words; no paragraph sentinels in this stream).
+    // After first chunk: progress.index = 2 (raw), total = 5 (raw
+    // including the paragraph sentinel slot).
     expect(onWordAdvance).toHaveBeenCalledTimes(1);
-    expect(onWordAdvance).toHaveBeenLastCalledWith(2, 4);
+    expect(onWordAdvance).toHaveBeenLastCalledWith(2, 5);
     vi.advanceTimersByTime(60000 / 300);
     expect(onWordAdvance).toHaveBeenCalledTimes(2);
-    expect(onWordAdvance).toHaveBeenLastCalledWith(4, 4);
+    expect(onWordAdvance).toHaveBeenLastCalledWith(5, 5);
     overlay.unmount();
   });
 

--- a/src/core/overlay/__tests__/chunk-render.test.ts
+++ b/src/core/overlay/__tests__/chunk-render.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Overlay chunk-event render coverage (#51 test-gap HIGH #2).
+ *
+ * The overlay engine subscribe handler has two top-level branches:
+ * `word` events and `chunk` events. The `word` branch is covered by
+ * the other overlay tests; this file pins the `chunk` branch
+ * explicitly.
+ *
+ * Mutation guards:
+ *   - Swapping `ev.text` → `ev.words[0]` (only first chunk word) must fail
+ *     — the chunk-text assertion catches it.
+ *   - Dropping the `ariaLive.textContent = ev.text` line must fail —
+ *     the aria-live assertion catches it.
+ *   - Failing to invoke `onWordAdvance` on chunk events must fail.
+ *   - Paused-state `renderPreview` failing to surface chunk context
+ *     must fail (preview hidden assertion).
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createOverlay } from '../overlay';
+import type { OverlayOptions } from '../types';
+import { createRsvpEngine } from '../../rsvp-engine';
+import { OVERLAY_CLASS } from '../constants';
+
+function getShadow(): ShadowRoot {
+  const host = document.body.querySelector('[data-speedreader-overlay]');
+  if (!(host instanceof HTMLElement) || !host.shadowRoot) {
+    throw new Error('overlay host missing or no shadow root');
+  }
+  return host.shadowRoot;
+}
+
+function getEl<T extends Element>(root: ShadowRoot, sel: string): T {
+  const el = root.querySelector<T>(sel);
+  if (!el) throw new Error(`overlay shadow: missing selector ${sel}`);
+  return el;
+}
+
+function defaultOpts(overrides: Partial<OverlayOptions> = {}): OverlayOptions {
+  return {
+    doc: document,
+    words: ['The', 'quick', 'brown', 'fox.'],
+    initialSettings: { theme: 'system', wpm: 300, fontSize: 20, chunkSize: 2 },
+    subscribeSettings: () => () => undefined,
+    engineFactory: createRsvpEngine,
+    ...overrides,
+  };
+}
+
+describe('createOverlay — chunk event rendering (#51)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+    vi.useRealTimers();
+  });
+
+  test('word region renders full chunk text (ev.text), not ev.words[0]', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const root = getShadow();
+    // Engine emits chunk 0 synchronously on start → "The quick" (chunkSize=2).
+    expect(getEl(root, `.${OVERLAY_CLASS.WORD_REGION}`).textContent).toBe('The quick');
+    // Advance one tick → "brown fox." (chunkSize=2 over 4 words).
+    vi.advanceTimersByTime(60000 / 300);
+    expect(getEl(root, `.${OVERLAY_CLASS.WORD_REGION}`).textContent).toBe('brown fox.');
+    overlay.unmount();
+  });
+
+  test('aria-live region announces the full chunk text', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const root = getShadow();
+    expect(getEl(root, '[aria-live="polite"]').textContent).toBe('The quick');
+    vi.advanceTimersByTime(60000 / 300);
+    expect(getEl(root, '[aria-live="polite"]').textContent).toBe('brown fox.');
+    overlay.unmount();
+  });
+
+  test('onWordAdvance fires on each chunk event with post-emit raw-axis progress', () => {
+    const onWordAdvance = vi.fn();
+    const overlay = createOverlay(
+      defaultOpts({
+        scope: 'full',
+        fullWords: ['The', 'quick', 'brown', 'fox.'],
+        onWordAdvance,
+      }),
+    );
+    overlay.mount();
+    // After first chunk: progress.index = chunk 0 endIndex + 1 = 2;
+    // total = 4 (raw words; no paragraph sentinels in this stream).
+    expect(onWordAdvance).toHaveBeenCalledTimes(1);
+    expect(onWordAdvance).toHaveBeenLastCalledWith(2, 4);
+    vi.advanceTimersByTime(60000 / 300);
+    expect(onWordAdvance).toHaveBeenCalledTimes(2);
+    expect(onWordAdvance).toHaveBeenLastCalledWith(4, 4);
+    overlay.unmount();
+  });
+
+  test('paused state: chunk-driven renderPreview surfaces the chunk word in context', () => {
+    // Stream long enough that the chunk lands mid-sentence so the
+    // sentence-context builder can produce before/current/after.
+    const overlay = createOverlay(
+      defaultOpts({
+        words: ['The', 'quick', 'brown', 'fox', 'jumps', 'over', 'lazy', 'dog.'],
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, chunkSize: 2 },
+      }),
+    );
+    overlay.mount();
+    const root = getShadow();
+    const preview = getEl<HTMLElement>(root, `.${OVERLAY_CLASS.CONTEXT_PREVIEW}`);
+    // Preview is hidden while playing.
+    expect(preview.hidden).toBe(true);
+
+    // Pause via space key — togglePlayPause renders the preview.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(preview.hidden).toBe(false);
+    // Preview text contains the current chunk word (rendered as the
+    // `<strong>` child).
+    const current = preview.querySelector('strong');
+    expect(current).not.toBeNull();
+    expect(current?.textContent?.length ?? 0).toBeGreaterThan(0);
+    overlay.unmount();
+  });
+});

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -439,6 +439,10 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     // in-overlay ↑/↓ shortcut and slider input update `currentWpm` + the
     // engine and (when `onWpmChange` is wired) persist via the callback.
     let currentWpm = opts.initialSettings.wpm;
+    // Local chunkSize cache so the subscribeSettings handler can
+    // short-circuit no-op emissions and only call `engine.setChunkSize`
+    // when the value actually changed (#51 architect MED #2).
+    let currentChunkSize: 1 | 2 | 3 = opts.initialSettings.chunkSize ?? 1;
 
     // Single point of truth for keeping the slider + readout in sync with
     // `currentWpm`. Called from mount-time init, the ArrowUp/Down keyboard
@@ -511,6 +515,15 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       const nextFont = resolveFontId(s);
       if (nextFont !== currentFont) {
         applyFont(nextFont);
+      }
+      // #51 architect MED #2 — live chunkSize update. Forward to the
+      // engine so a user switching chunkSize mid-session sees the new
+      // grouping immediately rather than only on next mount. Guarded
+      // on a real change so a no-op echo doesn't churn the engine.
+      const nextChunkSize: 1 | 2 | 3 = s.chunkSize ?? 1;
+      if (nextChunkSize !== currentChunkSize) {
+        currentChunkSize = nextChunkSize;
+        engine?.setChunkSize(nextChunkSize);
       }
     });
 

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -515,7 +515,13 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     });
 
     const engineWords = scopeView ? scopeView.activeWords : opts.words;
-    engine = opts.engineFactory({ words: engineWords, wpm: currentWpm });
+    // #51 — forward chunkSize when set. Engine treats undefined OR 1 as
+    // word mode (back-compat); only 2 or 3 enable chunk emission.
+    engine = opts.engineFactory({
+      words: engineWords,
+      wpm: currentWpm,
+      chunkSize: opts.initialSettings.chunkSize,
+    });
 
     const reflectEngineState = (): void => {
       const s = engine?.state ?? 'idle';
@@ -606,6 +612,19 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
         // the per-word PLAYING tick path we MUST skip the call entirely;
         // clearPreview's idempotency guard makes the no-op cheap, but
         // not calling it at all is cheaper still (perf-adversary F1).
+        if (engine?.state === 'paused') renderPreview();
+      } else if (ev.type === 'chunk') {
+        // #51 — multi-word display. ORP highlighting on the chunk is a
+        // separate concern (tracked as a follow-up issue); for now we
+        // render the chunk text verbatim into the word region. The
+        // aria-live region announces the whole chunk so screen readers
+        // hear the same unit the user sees.
+        renderWord(word, ev.text);
+        ariaLive.textContent = ev.text;
+        if (opts.onWordAdvance && engine) {
+          const p = engine.progress();
+          opts.onWordAdvance(p.index, p.total);
+        }
         if (engine?.state === 'paused') renderPreview();
       } else if (ev.type === 'done') {
         reflectEngineState();

--- a/src/core/overlay/types.ts
+++ b/src/core/overlay/types.ts
@@ -197,6 +197,19 @@ export interface OverlayOptions {
    * `scope === 'full'` — passing it for a selection-scope mount has
    * no defined meaning and may be removed by a future contract
    * cleanup.
+   *
+   * Axis note (#51 chunk mode): in chunk mode (`chunkSize >= 2`),
+   * `index` and `total` index into the engine's RAW token axis —
+   * the same axis as `WordToken.rawIndex`, which INCLUDES paragraph
+   * sentinels (`'\n\n'`) and dash tokens (`'—'` / `'–'`) — NOT the
+   * filtered-word axis used by earlier API revisions. For a stream
+   * with no structural tokens the two axes collapse to identical
+   * counts; with paragraph / dash tokens interleaved the raw axis
+   * is larger. Word mode (`chunkSize === 1` or undefined) keeps the
+   * pre-existing per-emission progress shape (still raw-axis but
+   * identical to filtered-word counts because word mode iterates
+   * the raw stream directly). Host persistence keyed on this value
+   * must use the same axis on both write and read.
    */
   onWordAdvance?: (index: number, total: number) => void;
   /**

--- a/src/core/overlay/types.ts
+++ b/src/core/overlay/types.ts
@@ -51,13 +51,12 @@ export interface OverlaySettings {
    */
   font?: FontId;
   /**
-   * Multi-word chunk display (#51). Pinned at overlay-construction
-   * time and forwarded to the engine factory. `1` (or undefined) keeps
+   * Multi-word chunk display (#51). Forwarded to the engine factory at
+   * mount time AND on every `subscribeSettings` emission — the overlay
+   * calls `engine.setChunkSize(next)` so live updates apply mid-session
+   * without re-mounting (architect MED #2). `1` (or undefined) keeps
    * today's single-word emission; `2` or `3` enables multi-word chunk
    * mode (engine emits `chunk` events with sentence-boundary respect).
-   * Live updates via `subscribeSettings` are NOT supported in M2 —
-   * changing chunkSize mid-session would require an engine
-   * reconstruction (deferred to a follow-up).
    */
   chunkSize?: 1 | 2 | 3;
 }

--- a/src/core/overlay/types.ts
+++ b/src/core/overlay/types.ts
@@ -3,13 +3,13 @@ import type { ThemeId } from '../theme';
 import type { FontId } from './font-ids';
 
 /**
- * Settings slice the overlay binds to. The wider SettingsV5 is not imported
+ * Settings slice the overlay binds to. The wider SettingsV6 is not imported
  * here so `core/overlay` stays portable (no transitive dependency on the
  * Chrome storage shape).
  *
  * `theme` extends `ThemeId` with `'system'` — the concrete-theme enum
  * covers the six design-pack values; `'system'` resolves at mount time via
- * `prefers-color-scheme` matching `SettingsV5.theme` (which includes
+ * `prefers-color-scheme` matching `SettingsV6.theme` (which includes
  * `'system'` as the auto-detect sentinel). Keeping the sentinel here avoids
  * callers having to pre-resolve before constructing the overlay.
  */
@@ -50,6 +50,16 @@ export interface OverlaySettings {
    * family stacks in `styles.ts`.
    */
   font?: FontId;
+  /**
+   * Multi-word chunk display (#51). Pinned at overlay-construction
+   * time and forwarded to the engine factory. `1` (or undefined) keeps
+   * today's single-word emission; `2` or `3` enables multi-word chunk
+   * mode (engine emits `chunk` events with sentence-boundary respect).
+   * Live updates via `subscribeSettings` are NOT supported in M2 —
+   * changing chunkSize mid-session would require an engine
+   * reconstruction (deferred to a follow-up).
+   */
+  chunkSize?: 1 | 2 | 3;
 }
 
 export type SettingsSubscriber = (s: OverlaySettings) => void;

--- a/src/core/rsvp-engine/__tests__/chunk-mode.test.ts
+++ b/src/core/rsvp-engine/__tests__/chunk-mode.test.ts
@@ -515,43 +515,78 @@ describe('createRsvpEngine — chunk mode (chunkSize >= 2)', () => {
     });
   });
 
-  // FIX-8 — seekTo snapToSentence in chunk mode. Mutation guard:
-  // removing the `if (snapToSentence && rawTarget < totalRawWords)`
-  // block (so snap never fires) must fail.
+  // FIX-8 (round-2 rewrite) — seekTo snapToSentence in chunk mode.
+  // Round-1 stream `['A','B.','C','D','E.','F','G','H.']` was NOT
+  // discriminating: every sentence-start word in that stream is also
+  // a chunk-start word, so snapped vs unsnapped seek lands in the
+  // same chunk (snap walks back to the chunk-start). To make the
+  // snap branch mutation-discriminating we need a stream where the
+  // sentence-start word lives in a PRIOR chunk than the chunk
+  // containing the target word — that requires a sentence that
+  // spans multiple chunks. Stream:
+  //
+  //   ['The', 'quick', 'brown', 'fox.', 'Jumps.']
+  //      0       1        2       3        4
+  //
+  // markSentenceBoundaries:
+  //   The   word rawIndex=0 sentenceStart=true
+  //   quick word rawIndex=1
+  //   brown word rawIndex=2
+  //   fox.  word rawIndex=3 sentenceEnd=true
+  //   Jumps. word rawIndex=4 sentenceStart=true sentenceEnd=true
+  //
+  // buildChunks chunkSize=2:
+  //   chunk 0: [The, quick]   raw 0..1
+  //   chunk 1: [brown, fox.]  raw 2..3
+  //   chunk 2: [Jumps.]       raw 4
+  //
+  // Seek raw=3 (`fox.`) unsnapped → chunk 1 ([brown, fox.],
+  //   startIndex=2). Snap walks back from fox.[3] → brown[2] →
+  //   quick[1] → The[0].sentenceStart=true → raw=0 → chunk 0
+  //   ([The, quick], startIndex=0). DIFFERENT chunks.
+  //
+  // Mutation: removing the `if (snapToSentence && rawTarget <
+  // totalRawWords)` block in `seekToChunk` means snap never fires —
+  // the snapped assertion would see startIndex=2 instead of 0 and
+  // fail. The unsnapped assertion guards against the inverse
+  // mutation (snap always fires).
   describe('seekTo({ snapToSentence: true }) — chunk mode', () => {
-    it('mid-sentence seek snaps to the chunk starting at the sentence start', () => {
-      // Stream: "A B. C D E. F G H." chunkSize=2.
-      // chunkWords (filtered, dense — no paragraphs): A B. C D E. F G H.
-      //                                  rawIdx:      0 1  2 3 4  5 6 7
-      // chunks at chunkSize=2 (respecting sentence boundaries):
-      //   chunk 0: [A, B.]    raw 0..1
-      //   chunk 1: [C, D]     raw 2..3
-      //   chunk 2: [E.]       raw 4   (single — next word starts new sentence)
-      //   chunk 3: [F, G]     raw 5..6
-      //   chunk 4: [H.]       raw 7
-      const engine = createRsvpEngine({
-        words: ['A', 'B.', 'C', 'D', 'E.', 'F', 'G', 'H.'],
-        wpm: 300,
-        chunkSize: 2,
-      });
+    const stream = ['The', 'quick', 'brown', 'fox.', 'Jumps.'];
+
+    it('snapped seek (raw=3, snap=true) lands chunk [The quick] with startIndex=0', () => {
+      const engine = createRsvpEngine({ words: stream, wpm: 300, chunkSize: 2 });
       const events: RsvpEvent[] = [];
       engine.subscribe((e) => events.push(e));
       engine.start();
       engine.pause();
-      // Sanity: chunk 0 emitted.
-      expect(events[0]).toMatchObject({ type: 'chunk', text: 'A B.' });
+      // Sanity: chunk 0 emitted on start.
+      expect(events[0]).toMatchObject({ type: 'chunk', text: 'The quick' });
 
-      // Seek mid-second-sentence to word `D` (rawIndex=3) with snap.
-      // Should snap back to sentence start at `C` (rawIndex=2), which
-      // lands in chunk 1 ([C, D]). Emitted replacement chunk text:
-      // "C D".
       engine.seekTo(3, { snapToSentence: true });
+      const last = events[events.length - 1];
+      expect(last).toMatchObject({
+        type: 'chunk',
+        startIndex: 0,
+        endIndex: 1,
+        text: 'The quick',
+      });
+    });
+
+    it('unsnapped seek (raw=3, no snap) lands chunk [brown fox.] with startIndex=2', () => {
+      const engine = createRsvpEngine({ words: stream, wpm: 300, chunkSize: 2 });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      engine.pause();
+      expect(events[0]).toMatchObject({ type: 'chunk', text: 'The quick' });
+
+      engine.seekTo(3);
       const last = events[events.length - 1];
       expect(last).toMatchObject({
         type: 'chunk',
         startIndex: 2,
         endIndex: 3,
-        text: 'C D',
+        text: 'brown fox.',
       });
     });
   });
@@ -662,6 +697,51 @@ describe('createRsvpEngine — chunk mode (chunkSize >= 2)', () => {
       engine.setChunkSize('2');
       expect(events.length).toBe(before);
       expect(engine.state).toBe('paused');
+    });
+
+    // Round-2 ITEM-5: setChunkSize on a DONE engine must NOT emit and
+    // must NOT move nextIndex backward. Captures the failure mode
+    // where a future refactor unifies the DONE / IDLE / PAUSED /
+    // PLAYING branches and accidentally re-emits or resets nextIndex.
+    //
+    // Mutation: removing the `if (state === RSVP_STATE.DONE) { ... return; }`
+    // early-return in `setChunkSize` lets the IDLE/PAUSED reset path
+    // run on a DONE engine, which would either emit a fresh event or
+    // reset nextIndex away from past-end. Either failure mode flips
+    // an assertion below.
+    it('done state: setChunkSize pins past-end and emits no events', () => {
+      // 4 words at chunkSize=2 → 2 chunks. High WPM so timers drain
+      // quickly.
+      const engine = createRsvpEngine({
+        words: ['The', 'quick', 'brown', 'fox.'],
+        wpm: 600,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      // Run all timers to drive the engine to DONE. With 2 chunks at
+      // 600 wpm (msPerWord=100), one tick fires chunk 1 and the
+      // next tick fires `done`.
+      vi.runAllTimers();
+      expect(engine.state).toBe('done');
+      expect(events[events.length - 1]).toEqual({ type: 'done' });
+      const beforeCount = events.length;
+      const beforeProgress = engine.progress();
+      expect(beforeProgress.index).toBe(beforeProgress.total);
+
+      // Live update on DONE engine.
+      engine.setChunkSize(3);
+
+      // No new events emitted.
+      expect(events.length).toBe(beforeCount);
+      // State still DONE.
+      expect(engine.state).toBe('done');
+      // progress() index still pinned to total (past-end). Note:
+      // chunkSize=3 rebuilds chunks to [[The quick brown], [fox.]]
+      // (still 2 chunks); past-end pin yields index === total.
+      const afterProgress = engine.progress();
+      expect(afterProgress.index).toBe(afterProgress.total);
     });
   });
 });

--- a/src/core/rsvp-engine/__tests__/chunk-mode.test.ts
+++ b/src/core/rsvp-engine/__tests__/chunk-mode.test.ts
@@ -326,4 +326,342 @@ describe('createRsvpEngine — chunk mode (chunkSize >= 2)', () => {
       expect(events[0]).toMatchObject({ type: 'chunk', text: 'Hello world.' });
     });
   });
+
+  describe('raw-axis indices with paragraph sentinels interleaved (#51 architect HIGH)', () => {
+    // Engine word axis includes paragraph sentinels ('\n\n') and dashes
+    // ('—' / '–'). Chunk-mode startIndex/endIndex MUST key to that raw
+    // axis (via WordToken.rawIndex) so a chunk's startIndex === N and a
+    // word-mode `word` event with index === N point at the same source
+    // token. A regression that keys to local filtered-word positions
+    // would silently corrupt #47 scrubber + #48 cross-mode position
+    // persistence.
+    it('chunk startIndex/endIndex align with raw word-mode index on the same tokens', () => {
+      // Raw tokens (paragraph sentinel between "quick" and "brown"):
+      //   ['The', 'quick', '\n\n', 'brown', 'fox.']
+      //      0      1        2       3        4
+      // markSentenceBoundaries:
+      //   word(The, start:true, rawIndex:0)
+      //   word(quick, start:false, rawIndex:1)
+      //   paragraph (resets nextWordStartsSentence=true)
+      //   word(brown, start:true, rawIndex:3)
+      //   word(fox., start:false, end:true, rawIndex:4)
+      // chunkSize=3 chunks (sentence-boundary respect):
+      //   chunk 0: [The, quick]     raw 0..1 (capped at next sentence)
+      //   chunk 1: [brown, fox.]    raw 3..4
+      // chunk 0's endIndex MUST be 1 (rawIndex of `quick`), NOT 1
+      // (local) — pre-fix would have been 1 too coincidentally, so
+      // the load-bearing assertion is chunk 1's startIndex=3, NOT 2
+      // (local chunkWords position of brown is 2). Pre-fix:
+      // startIndex would be 2; post-fix: 3 (paragraph slot accounted).
+      const rawWords = ['The', 'quick', '\n\n', 'brown', 'fox.'];
+
+      // Word-mode reference: word at raw index 3 should be `brown`.
+      const wordEngine = createRsvpEngine({ words: rawWords, wpm: 300 });
+      const wordEvents: RsvpEvent[] = [];
+      wordEngine.subscribe((e) => wordEvents.push(e));
+      wordEngine.start();
+      vi.advanceTimersByTime(60000 / 300); // index 1: quick
+      vi.advanceTimersByTime(60000 / 300); // index 2: '\n\n'
+      vi.advanceTimersByTime(60000 / 300); // index 3: brown
+      expect(wordEvents[3]).toMatchObject({ type: 'word', index: 3, word: 'brown' });
+
+      // Chunk-mode: chunk 1's startIndex MUST be 3 (rawIndex of
+      // `brown`), matching the word-mode `word` event index above.
+      // Pre-fix (local-position keying) this would be 2 instead.
+      const chunkEngine = createRsvpEngine({
+        words: rawWords,
+        wpm: 300,
+        chunkSize: 3,
+      });
+      const chunkEvents: RsvpEvent[] = [];
+      chunkEngine.subscribe((e) => chunkEvents.push(e));
+      chunkEngine.start();
+      vi.advanceTimersByTime(60000 / 300);
+
+      const chunks = chunkEvents.filter(
+        (e): e is Extract<RsvpEvent, { type: 'chunk' }> => e.type === 'chunk',
+      );
+      expect(chunks).toHaveLength(2);
+      expect(chunks[0]).toMatchObject({
+        startIndex: 0,
+        endIndex: 1,
+        text: 'The quick',
+      });
+      expect(chunks[1]).toMatchObject({
+        startIndex: 3,
+        endIndex: 4,
+        text: 'brown fox.',
+      });
+    });
+
+    it('progress() chunk-mode total matches raw token count (mode-switch monotonic for scrubber)', () => {
+      // Raw stream: 5 tokens (4 words + 1 paragraph sentinel). Both
+      // chunk-mode and word-mode `progress().total` MUST report 5 so
+      // a scrubber consumer can map position bidirectionally.
+      const rawWords = ['The', 'quick', '\n\n', 'brown', 'fox.'];
+
+      const wordEngine = createRsvpEngine({ words: rawWords, wpm: 300 });
+      expect(wordEngine.progress()).toEqual({ index: 0, total: 5, ratio: 0 });
+
+      const chunkEngine = createRsvpEngine({ words: rawWords, wpm: 300, chunkSize: 3 });
+      expect(chunkEngine.progress()).toEqual({ index: 0, total: 5, ratio: 0 });
+
+      // After first chunk tick, chunk-mode index = chunk 0's endIndex
+      // + 1 = 2 (raw axis). Word-mode after 2 ticks (consuming raw
+      // tokens 0, 1) would also report index = 2.
+      const events: RsvpEvent[] = [];
+      chunkEngine.subscribe((e) => events.push(e));
+      chunkEngine.start();
+      expect(chunkEngine.progress().index).toBe(2);
+      expect(chunkEngine.progress().total).toBe(5);
+    });
+  });
+
+  // FIX-3 — pause/resume in chunk mode. Catches a regression that
+  // accidentally swaps resume()'s totalTicks() back to words.length
+  // (which would make a paused chunk-mode engine fire `done` instead
+  // of resuming).
+  describe('pause / resume (chunk mode)', () => {
+    it('pause halts emission; resume fires next chunk exactly one msPerWord later', () => {
+      const engine = createRsvpEngine({
+        words: ['The', 'quick', 'brown', 'fox', 'jumps', 'over.'],
+        wpm: 600,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      // First chunk emits synchronously on start.
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ type: 'chunk', text: 'The quick' });
+
+      // Advance one tick (100ms at 600 wpm) → second chunk fires.
+      vi.advanceTimersByTime(100);
+      expect(events).toHaveLength(2);
+      expect(events[1]).toMatchObject({ type: 'chunk', text: 'brown fox' });
+
+      // Pause and assert no new event fires across many ticks.
+      engine.pause();
+      const beforeLen = events.length;
+      vi.advanceTimersByTime(10_000);
+      expect(events.length).toBe(beforeLen);
+      expect(engine.state).toBe('paused');
+
+      // Resume. Next chunk should fire exactly msPerWord later (100ms).
+      engine.resume();
+      // Just before the tick fires — still paused-len.
+      vi.advanceTimersByTime(99);
+      expect(events.length).toBe(beforeLen);
+      vi.advanceTimersByTime(1);
+      expect(events.length).toBe(beforeLen + 1);
+      expect(events[events.length - 1]).toMatchObject({
+        type: 'chunk',
+        text: 'jumps over.',
+      });
+    });
+  });
+
+  // FIX-6 — pre-start progress in chunk mode. Mutation guard: returning
+  // `chunks.length` for `index` instead of 0 must fail.
+  describe('progress() before start (chunk mode)', () => {
+    it('returns {index: 0, total: rawWords, ratio: 0} before start()', () => {
+      const engine = createRsvpEngine({
+        words: ['a', 'b', 'c', 'd.', 'e', 'f.'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      // Pre-start: nothing consumed yet.
+      expect(engine.progress()).toEqual({ index: 0, total: 6, ratio: 0 });
+    });
+  });
+
+  // FIX-7 — timeElapsed / timeRemaining in chunk mode. Mutation guards:
+  // multiplying by 2 (wrong cadence) OR returning chunks.length instead
+  // of (chunks.length - nextIndex) for remaining must fail.
+  describe('timeElapsed / timeRemaining (chunk mode)', () => {
+    it('timeElapsed grows by msPerWord per emitted chunk; timeRemaining shrinks symmetrically', () => {
+      // 6 words, chunkSize=2 → 3 chunks. At 600 wpm, msPerWord = 100.
+      // Cadence: chunk = 1 tick (engine comment "One tick = msPerWord per chunk").
+      const engine = createRsvpEngine({
+        words: ['The', 'quick', 'brown', 'fox', 'jumps', 'over.'],
+        wpm: 600,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+
+      // Pre-start: elapsed=0, remaining=3 chunks × 100ms = 300.
+      expect(engine.timeElapsed()).toBe(0);
+      expect(engine.timeRemaining()).toBe(300);
+
+      engine.start();
+      // After 1 chunk emission: elapsed=100, remaining=200.
+      expect(engine.timeElapsed()).toBe(100);
+      expect(engine.timeRemaining()).toBe(200);
+
+      vi.advanceTimersByTime(100);
+      expect(engine.timeElapsed()).toBe(200);
+      expect(engine.timeRemaining()).toBe(100);
+
+      vi.advanceTimersByTime(100);
+      // Third chunk emitted; remaining=0.
+      expect(engine.timeElapsed()).toBe(300);
+      expect(engine.timeRemaining()).toBe(0);
+
+      // Done after one more tick.
+      vi.advanceTimersByTime(100);
+      expect(events[events.length - 1]).toEqual({ type: 'done' });
+      expect(engine.timeRemaining()).toBe(0);
+    });
+  });
+
+  // FIX-8 — seekTo snapToSentence in chunk mode. Mutation guard:
+  // removing the `if (snapToSentence && rawTarget < totalRawWords)`
+  // block (so snap never fires) must fail.
+  describe('seekTo({ snapToSentence: true }) — chunk mode', () => {
+    it('mid-sentence seek snaps to the chunk starting at the sentence start', () => {
+      // Stream: "A B. C D E. F G H." chunkSize=2.
+      // chunkWords (filtered, dense — no paragraphs): A B. C D E. F G H.
+      //                                  rawIdx:      0 1  2 3 4  5 6 7
+      // chunks at chunkSize=2 (respecting sentence boundaries):
+      //   chunk 0: [A, B.]    raw 0..1
+      //   chunk 1: [C, D]     raw 2..3
+      //   chunk 2: [E.]       raw 4   (single — next word starts new sentence)
+      //   chunk 3: [F, G]     raw 5..6
+      //   chunk 4: [H.]       raw 7
+      const engine = createRsvpEngine({
+        words: ['A', 'B.', 'C', 'D', 'E.', 'F', 'G', 'H.'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      engine.pause();
+      // Sanity: chunk 0 emitted.
+      expect(events[0]).toMatchObject({ type: 'chunk', text: 'A B.' });
+
+      // Seek mid-second-sentence to word `D` (rawIndex=3) with snap.
+      // Should snap back to sentence start at `C` (rawIndex=2), which
+      // lands in chunk 1 ([C, D]). Emitted replacement chunk text:
+      // "C D".
+      engine.seekTo(3, { snapToSentence: true });
+      const last = events[events.length - 1];
+      expect(last).toMatchObject({
+        type: 'chunk',
+        startIndex: 2,
+        endIndex: 3,
+        text: 'C D',
+      });
+    });
+  });
+
+  // FIX-2 — live setChunkSize. Engine rebuilds chunks + maps the
+  // current raw position into the new layout per state machine semantics.
+  describe('setChunkSize (live update)', () => {
+    it('idle 1 → 2 enables chunk emission for the next start()', () => {
+      const engine = createRsvpEngine({
+        words: ['The', 'quick', 'brown', 'fox.'],
+        wpm: 300,
+        chunkSize: 1,
+      });
+      engine.setChunkSize(2);
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      // Should emit a chunk event, not a word event.
+      expect(events[0]).toMatchObject({ type: 'chunk', text: 'The quick' });
+    });
+
+    it('paused 2 → 3 rebuilds chunks and emits replacement at new chunk', () => {
+      // chunkSize=2 chunks: [The quick] [brown fox] [jumps over.]
+      // After tick #1 starts (chunk 0 emitted), pause, then setChunkSize(3).
+      // chunkSize=3 chunks: [The quick brown] [fox jumps over.]
+      // Current raw position after first chunk = 2 → chunk index 0 in
+      // new layout (because chunks[0] spans raw 0..2). Replacement
+      // emit should be chunk 0 of the new layout.
+      const engine = createRsvpEngine({
+        words: ['The', 'quick', 'brown', 'fox', 'jumps', 'over.'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      engine.pause();
+      const before = events.length;
+      engine.setChunkSize(3);
+      expect(events.length).toBeGreaterThan(before);
+      const last = events[events.length - 1];
+      expect(last).toMatchObject({
+        type: 'chunk',
+        text: 'The quick brown',
+        startIndex: 0,
+        endIndex: 2,
+      });
+    });
+
+    it('playing 2 → 1 flips engine to word emission mid-session', () => {
+      const engine = createRsvpEngine({
+        words: ['The', 'quick', 'brown', 'fox.'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      // Chunk 0 emitted ("The quick"); raw position now = 2.
+      expect(events[0]).toMatchObject({ type: 'chunk' });
+
+      engine.setChunkSize(1);
+      // Playing → tick fires immediately at the new mode. Next event
+      // should be a `word` event, not a `chunk` event.
+      const next = events[events.length - 1];
+      expect(next.type).toBe('word');
+      // Word index should resume at the raw position we held (2),
+      // i.e. the word `brown`.
+      if (next.type === 'word') {
+        expect(next.index).toBe(2);
+        expect(next.word).toBe('brown');
+      }
+    });
+
+    it('same chunkSize value is a no-op (no replacement emit on paused)', () => {
+      const engine = createRsvpEngine({
+        words: ['The', 'quick', 'brown', 'fox.'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      engine.pause();
+      const before = events.length;
+      engine.setChunkSize(2);
+      expect(events.length).toBe(before);
+    });
+
+    it('invalid input (0, 4, non-integer) is a no-op', () => {
+      const engine = createRsvpEngine({
+        words: ['The', 'quick', 'brown', 'fox.'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      engine.pause();
+      const before = events.length;
+      // @ts-expect-error — exercising runtime validation with invalid input
+      engine.setChunkSize(0);
+      // @ts-expect-error — exercising runtime validation with invalid input
+      engine.setChunkSize(4);
+      // @ts-expect-error — exercising runtime validation with invalid input
+      engine.setChunkSize(2.5);
+      // @ts-expect-error — exercising runtime validation with invalid input
+      engine.setChunkSize('2');
+      expect(events.length).toBe(before);
+      expect(engine.state).toBe('paused');
+    });
+  });
 });

--- a/src/core/rsvp-engine/__tests__/chunk-mode.test.ts
+++ b/src/core/rsvp-engine/__tests__/chunk-mode.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Engine integration tests for chunkSize >= 2 (issue #51).
+ *
+ * Covers:
+ *   - chunk event emission shape + ordering
+ *   - sentence-boundary respect across ticks
+ *   - punctuation pacing (chunk LAST-word multiplier — Q2 decision)
+ *   - seekTo snap-to-chunk-start (Q1 decision)
+ *   - seekToSentence navigation in chunk mode
+ *   - progress() reports filtered-word axis
+ *   - back-compat: chunkSize=1 still emits `word` events (Q4 decision)
+ *
+ * Self-pushback mutation hypotheses pinned per assertion in PR body.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRsvpEngine, type RsvpEvent } from '../rsvp-engine';
+
+describe('createRsvpEngine — chunk mode (chunkSize >= 2)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('chunk event emission', () => {
+    it('emits one chunk per tick, advancing through the stream', () => {
+      const engine = createRsvpEngine({
+        words: ['The', 'quick', 'brown', 'fox.'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+
+      // First chunk emits synchronously on start.
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'chunk',
+        startIndex: 0,
+        endIndex: 1,
+        text: 'The quick',
+        words: ['The', 'quick'],
+      });
+
+      // Advance one chunk's worth of time.
+      vi.advanceTimersByTime(60000 / 300);
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual({
+        type: 'chunk',
+        startIndex: 2,
+        endIndex: 3,
+        text: 'brown fox.',
+        words: ['brown', 'fox.'],
+      });
+
+      // One more tick fires done.
+      vi.advanceTimersByTime(60000 / 300);
+      expect(events).toHaveLength(3);
+      expect(events[2]).toEqual({ type: 'done' });
+    });
+
+    it('respects sentence boundaries — chunk ends early before next sentence', () => {
+      const engine = createRsvpEngine({
+        words: ['Hello', 'world.', 'Goodbye', 'world.'],
+        wpm: 300,
+        chunkSize: 3,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      vi.advanceTimersByTime(60000 / 300);
+
+      // Two chunks: ["Hello", "world."] (cut by sentence boundary at "Goodbye")
+      // and ["Goodbye", "world."] (end of stream).
+      const chunks = events.filter(
+        (e): e is Extract<RsvpEvent, { type: 'chunk' }> => e.type === 'chunk',
+      );
+      expect(chunks).toHaveLength(2);
+      expect(chunks[0].text).toBe('Hello world.');
+      expect(chunks[0].words).toEqual(['Hello', 'world.']);
+      expect(chunks[1].text).toBe('Goodbye world.');
+      expect(chunks[1].words).toEqual(['Goodbye', 'world.']);
+    });
+  });
+
+  describe('punctuation pacing (chunk last-word multiplier)', () => {
+    it('uses the chunk last-word multiplier for the next gap (sentence-end → 1.5×)', () => {
+      // First chunk = ["Hello", "world."] ends in '.'; gap before next
+      // chunk should be 1.5 × base. Use 600 wpm → 100ms base, 150ms paced.
+      const engine = createRsvpEngine({
+        words: ['Hello', 'world.', 'Goodbye', 'world.'],
+        wpm: 600,
+        chunkSize: 3,
+        punctuationPacing: true,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      // 1 chunk emitted synchronously.
+      expect(events).toHaveLength(1);
+
+      // Advance base-only (100ms). Pacing should hold the next chunk
+      // until 150ms — at 100ms, no new event.
+      vi.advanceTimersByTime(100);
+      expect(events).toHaveLength(1);
+
+      // Advance the remaining 50ms (paced multiplier × base).
+      vi.advanceTimersByTime(50);
+      expect(events).toHaveLength(2);
+    });
+
+    it('non-sentence-ending chunk uses 1.0× base', () => {
+      // First chunk = ["The", "quick"] does not end in punctuation; gap
+      // should be exactly base (no multiplier).
+      const engine = createRsvpEngine({
+        words: ['The', 'quick', 'brown', 'fox.'],
+        wpm: 600,
+        chunkSize: 2,
+        punctuationPacing: true,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      expect(events).toHaveLength(1);
+      vi.advanceTimersByTime(100); // base only
+      expect(events).toHaveLength(2);
+    });
+  });
+
+  describe('seekTo (chunk mode)', () => {
+    it('mid-chunk word-axis index snaps to the chunk containing it', () => {
+      // chunks at chunkSize=2: [The quick] [brown fox.] [jumps over.]
+      const engine = createRsvpEngine({
+        words: ['The', 'quick', 'brown', 'fox.', 'jumps', 'over.'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      engine.pause();
+      // Initial start emitted chunk 0.
+      const before = events.length;
+      // Seek to word-axis index 3 ("fox.") — should snap to chunk 1 ("brown fox.").
+      engine.seekTo(3);
+      const lastEvent = events[events.length - 1];
+      expect(events.length).toBeGreaterThan(before);
+      expect(lastEvent).toEqual({
+        type: 'chunk',
+        startIndex: 2,
+        endIndex: 3,
+        text: 'brown fox.',
+        words: ['brown', 'fox.'],
+      });
+    });
+
+    it('seek past the end transitions to done', () => {
+      const engine = createRsvpEngine({
+        words: ['a', 'b.', 'c', 'd.'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      engine.pause();
+      engine.seekTo(999);
+      expect(engine.state).toBe('done');
+      expect(events[events.length - 1]).toEqual({ type: 'done' });
+    });
+
+    it('negative seek clamps to chunk 0', () => {
+      const engine = createRsvpEngine({
+        words: ['a', 'b', 'c.', 'd', 'e.'],
+        wpm: 300,
+        chunkSize: 3,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      engine.pause();
+      engine.seekTo(-5);
+      const last = events[events.length - 1];
+      // First chunk is words 0..2 → "a b c."
+      expect(last).toMatchObject({ type: 'chunk', startIndex: 0 });
+    });
+  });
+
+  describe('seekToSentence (chunk mode)', () => {
+    it('next sentence walks past current to the sentence after the chunk just emitted', () => {
+      // 3 sentences in chunkSize=2: "A B." "C D." "E F."
+      // chunks: ["A B."] ["C D."] ["E F."]
+      // After start: chunk 0 emitted ("A B."). next-sentence skips past
+      // current sentence (B. is sentenceEnd) → targets "C" → snaps to chunk 1.
+      const engine = createRsvpEngine({
+        words: ['A', 'B.', 'C', 'D.', 'E', 'F.'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      engine.pause();
+      engine.seekToSentence('next');
+      const last = events[events.length - 1];
+      expect(last).toMatchObject({ type: 'chunk', text: 'C D.' });
+    });
+
+    it('next sentence at last sentence is a no-op (matches word mode contract)', () => {
+      // Single sentence stream: no sentenceStart exists past index 0,
+      // so next-sentence is a no-op (matches word mode: nav key cannot
+      // navigate past the last sentence). Using one sentence makes
+      // the absence-of-future-sentenceStart unambiguous.
+      const engine = createRsvpEngine({
+        words: ['no', 'periods', 'here'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      engine.pause();
+      const beforeLen = events.length;
+      engine.seekToSentence('next');
+      expect(events.length).toBe(beforeLen);
+      expect(engine.state).toBe('paused');
+    });
+
+    it('prev sentence on first sentence is a no-op for navigation (stays at start, emits replacement on paused)', () => {
+      const engine = createRsvpEngine({
+        words: ['A.', 'B.', 'C.'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      engine.pause();
+      // After start, chunk 0 emitted (just "A."). seekToSentence('prev')
+      // should walk back to sentence start at A. → chunk 0 again.
+      engine.seekToSentence('prev');
+      const last = events[events.length - 1];
+      expect(last).toMatchObject({ type: 'chunk', text: 'A.' });
+    });
+  });
+
+  describe('progress() reports filtered-word axis', () => {
+    it('reports words consumed across chunks', () => {
+      const engine = createRsvpEngine({
+        words: ['a', 'b', 'c', 'd.', 'e', 'f.'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      // After first tick, 2 of 6 words consumed (chunk 0 = "a b").
+      expect(engine.progress()).toEqual({ index: 2, total: 6, ratio: 2 / 6 });
+      vi.advanceTimersByTime(60000 / 300);
+      expect(engine.progress()).toEqual({ index: 4, total: 6, ratio: 4 / 6 });
+    });
+  });
+
+  describe('back-compat: chunkSize === 1 still emits word events (Q4)', () => {
+    it('chunkSize=1 keeps legacy word emission unchanged', () => {
+      const engine = createRsvpEngine({
+        words: ['hello', 'world.'],
+        wpm: 300,
+        chunkSize: 1,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      expect(events[0]).toEqual({ type: 'word', index: 0, word: 'hello' });
+      vi.advanceTimersByTime(60000 / 300);
+      expect(events[1]).toEqual({ type: 'word', index: 1, word: 'world.' });
+    });
+
+    it('chunkSize undefined keeps legacy word emission unchanged', () => {
+      const engine = createRsvpEngine({
+        words: ['hello', 'world.'],
+        wpm: 300,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      expect(events[0]).toEqual({ type: 'word', index: 0, word: 'hello' });
+    });
+  });
+
+  describe('empty / single-chunk cases', () => {
+    it('empty words array → done immediately on start (matches word mode)', () => {
+      const engine = createRsvpEngine({ words: [], wpm: 300, chunkSize: 2 });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      expect(events).toEqual([{ type: 'done' }]);
+    });
+
+    it('single chunk → emits then done on next tick', () => {
+      const engine = createRsvpEngine({ words: ['Hi.'], wpm: 300, chunkSize: 3 });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      expect(events[0]).toMatchObject({ type: 'chunk', text: 'Hi.' });
+      vi.advanceTimersByTime(60000 / 300);
+      expect(events[1]).toEqual({ type: 'done' });
+    });
+  });
+
+  describe('setWords rebuilds chunks', () => {
+    it('swapping words array rebuilds the chunk stream', () => {
+      const engine = createRsvpEngine({
+        words: ['a', 'b', 'c.', 'd', 'e.'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      engine.setWords(['Hello', 'world.', 'Goodbye', 'world.']);
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      expect(events[0]).toMatchObject({ type: 'chunk', text: 'Hello world.' });
+    });
+  });
+});

--- a/src/core/rsvp-engine/__tests__/chunks.test.ts
+++ b/src/core/rsvp-engine/__tests__/chunks.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Port of Safari `buildChunks` test suite — chriscantu/speed-reader's
+ * `tests/js/chunk-builder.test.js` adapted to the Chrome `MarkedToken`
+ * model.
+ *
+ * Safari's helper `words([...])` returned `{ text, index }`-shaped tokens.
+ * Chrome's word tokens carry `{ kind: 'word', text, sentenceStart,
+ * sentenceEnd }` (no `index` — derived from filtered-word position).
+ * The test helper below builds a sentence-marked stream via the canonical
+ * `tokenize` + `markSentenceBoundaries` pipeline so the boundary semantics
+ * tested here match what the engine actually sees in production.
+ *
+ * 11 cases mirror the Safari source verbatim:
+ *  - chunkSize=1 (1)  - chunkSize=2 (2)  - chunkSize=3 (1)
+ *  - sentence boundaries (3)  - edge cases (3)  - identity reference (1)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildChunks } from '../chunks';
+import { markSentenceBoundaries } from '../../tokenize/sentence-boundary';
+import { tokenize } from '../../tokenize/tokenize';
+import type { MarkedToken } from '../../tokenize/sentence-boundary';
+
+/**
+ * Build a word-only `MarkedToken[]` stream from a Safari-style word list.
+ *
+ * Joining with space and running through `tokenize` + `markSentenceBoundaries`
+ * keeps the test honest — `sentenceStart` / `sentenceEnd` flags come from
+ * the same code path the engine uses. Filters out non-word tokens
+ * (paragraph sentinels, dashes) because `buildChunks` consumes a
+ * word-only stream per its signature.
+ */
+function words(texts: string[]): Array<Extract<MarkedToken, { kind: 'word' }>> {
+  const marked = markSentenceBoundaries(tokenize(texts.join(' ')));
+  return marked.filter((t): t is Extract<MarkedToken, { kind: 'word' }> => t.kind === 'word');
+}
+
+describe('buildChunks', () => {
+  describe('chunkSize = 1', () => {
+    it('produces one chunk per word', () => {
+      const w = words(['Hello', 'world.']);
+      const chunks = buildChunks(w, 1);
+      expect(chunks.length).toBe(2);
+      expect(chunks[0].text).toBe('Hello');
+      expect(chunks[0].startIndex).toBe(0);
+      expect(chunks[0].endIndex).toBe(0);
+      expect(chunks[1].text).toBe('world.');
+      expect(chunks[1].startIndex).toBe(1);
+      expect(chunks[1].endIndex).toBe(1);
+    });
+  });
+
+  describe('chunkSize = 2', () => {
+    it('groups words into pairs', () => {
+      const w = words(['The', 'quick', 'brown', 'fox.']);
+      const chunks = buildChunks(w, 2);
+      expect(chunks.length).toBe(2);
+      expect(chunks[0].text).toBe('The quick');
+      expect(chunks[0].startIndex).toBe(0);
+      expect(chunks[0].endIndex).toBe(1);
+      expect(chunks[1].text).toBe('brown fox.');
+      expect(chunks[1].startIndex).toBe(2);
+      expect(chunks[1].endIndex).toBe(3);
+    });
+
+    it('handles odd word count with shorter final chunk', () => {
+      const w = words(['One', 'two', 'three.']);
+      const chunks = buildChunks(w, 2);
+      expect(chunks.length).toBe(2);
+      expect(chunks[0].text).toBe('One two');
+      expect(chunks[1].text).toBe('three.');
+      expect(chunks[1].words.length).toBe(1);
+    });
+  });
+
+  describe('chunkSize = 3', () => {
+    it('groups words into triples', () => {
+      const w = words(['The', 'quick', 'brown', 'fox', 'jumps', 'over.']);
+      const chunks = buildChunks(w, 3);
+      expect(chunks.length).toBe(2);
+      expect(chunks[0].text).toBe('The quick brown');
+      expect(chunks[1].text).toBe('fox jumps over.');
+    });
+  });
+
+  describe('sentence boundaries', () => {
+    it('breaks chunk at sentence boundary', () => {
+      const w = words(['Hello', 'world.', 'Goodbye', 'world.']);
+      const chunks = buildChunks(w, 3);
+      expect(chunks.length).toBe(2);
+      expect(chunks[0].text).toBe('Hello world.');
+      expect(chunks[0].words.length).toBe(2);
+      expect(chunks[1].text).toBe('Goodbye world.');
+      expect(chunks[1].words.length).toBe(2);
+    });
+
+    it('produces single-word chunk when sentence is one word', () => {
+      const w = words(['Stop.', 'Go.']);
+      const chunks = buildChunks(w, 3);
+      expect(chunks.length).toBe(2);
+      expect(chunks[0].text).toBe('Stop.');
+      expect(chunks[1].text).toBe('Go.');
+    });
+
+    it('handles sentence boundary at position 2 of a 3-word chunk', () => {
+      const w = words(['A', 'B.', 'C', 'D', 'E.']);
+      const chunks = buildChunks(w, 3);
+      expect(chunks.length).toBe(2);
+      expect(chunks[0].text).toBe('A B.');
+      expect(chunks[1].text).toBe('C D E.');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty array for empty input', () => {
+      expect(buildChunks([], 2)).toEqual([]);
+    });
+
+    it('handles single word', () => {
+      const w = words(['Hello.']);
+      const chunks = buildChunks(w, 3);
+      expect(chunks.length).toBe(1);
+      expect(chunks[0].text).toBe('Hello.');
+    });
+
+    it('chunk words array contains references to original word objects', () => {
+      const w = words(['The', 'cat.']);
+      const chunks = buildChunks(w, 2);
+      // Reference equality — the chunk's `words` array MUST point at the
+      // same MarkedToken objects, not copies (Safari source asserts the
+      // same via `assert.strictEqual`). Reference identity matters for
+      // downstream consumers that mutate or compare by reference.
+      expect(chunks[0].words[0]).toBe(w[0]);
+      expect(chunks[0].words[1]).toBe(w[1]);
+    });
+  });
+});

--- a/src/core/rsvp-engine/chunks.ts
+++ b/src/core/rsvp-engine/chunks.ts
@@ -5,10 +5,13 @@
  * a word-only token stream into display chunks of size 1, 2, or 3 while
  * respecting sentence boundaries — a chunk NEVER spans a sentence start.
  *
- * Indices in the output (`startIndex` / `endIndex`) index into the
- * filtered word stream — the position of each `kind: 'word'` token in
- * the array passed in. Consumers responsible for the engine word axis
- * receive that same array, so the indices are directly addressable.
+ * Indices in the output (`startIndex` / `endIndex`) key to the RAW
+ * token-axis — `WordToken.rawIndex`, the 0-based position of the word
+ * in the source array passed to `markSentenceBoundaries` (which
+ * INCLUDES paragraph + dash tokens). This keeps chunk indices on the
+ * same axis as the engine's raw `nextIndex`, so `chunk.startIndex ===
+ * N` and `engine.nextIndex === N` always point at the same token —
+ * load-bearing for #47 scrubber + #48 cross-mode position persistence.
  *
  * No DOM, no chrome.* / browser.* — safe for src/core/.
  */
@@ -24,15 +27,19 @@ export type ChunkSize = 1 | 2 | 3;
 /**
  * A display chunk — one or more words shown together at a single RSVP tick.
  *
- * `startIndex` / `endIndex` are inclusive positions into the input word
- * stream (the array passed to `buildChunks`). For the engine, the input
- * is the filtered word stream, so consumers can map directly back to
- * the word axis without further bookkeeping.
+ * `startIndex` / `endIndex` are inclusive positions on the RAW token-axis
+ * — the `rawIndex` of the chunk's first / last `WordToken`. The raw axis
+ * is what the engine's `nextIndex` indexes against (and what
+ * `markSentenceBoundaries` numbers from), so consumers can compare
+ * chunk bounds against engine state directly. For a stream with no
+ * paragraph / dash tokens this collapses to the filtered-word position
+ * (back-compat with the pre-rawIndex shape); with structural tokens
+ * interleaved, the two axes diverge and the raw axis wins.
  *
  * `words` holds references to the original `MarkedToken` objects (NOT
  * copies) so downstream consumers can compare by reference and inspect
- * boundary metadata (`sentenceStart` / `sentenceEnd`) without re-walking
- * the source array.
+ * boundary metadata (`sentenceStart` / `sentenceEnd` / `rawIndex`)
+ * without re-walking the source array.
  */
 export interface Chunk {
   words: WordToken[];
@@ -72,8 +79,13 @@ export function buildChunks(words: WordToken[], chunkSize: ChunkSize): Chunk[] {
     }
     chunks.push({
       words: chunkWords,
-      startIndex: i,
-      endIndex: j - 1,
+      // Raw-axis indices: take the rawIndex of the FIRST and LAST
+      // words. For dense word streams this is identical to (i, j-1);
+      // for streams with paragraph / dash tokens interleaved, the
+      // raw indices skip over the structural slots so the chunk's
+      // bounds align with the engine's nextIndex axis.
+      startIndex: chunkWords[0].rawIndex,
+      endIndex: chunkWords[chunkWords.length - 1].rawIndex,
       text: chunkWords.map((w) => w.text).join(' '),
     });
     i = j;

--- a/src/core/rsvp-engine/chunks.ts
+++ b/src/core/rsvp-engine/chunks.ts
@@ -1,0 +1,82 @@
+/**
+ * Multi-word chunk builder for RSVP.
+ *
+ * Port of `chriscantu/speed-reader`'s Safari `chunk-builder.js`. Groups
+ * a word-only token stream into display chunks of size 1, 2, or 3 while
+ * respecting sentence boundaries — a chunk NEVER spans a sentence start.
+ *
+ * Indices in the output (`startIndex` / `endIndex`) index into the
+ * filtered word stream — the position of each `kind: 'word'` token in
+ * the array passed in. Consumers responsible for the engine word axis
+ * receive that same array, so the indices are directly addressable.
+ *
+ * No DOM, no chrome.* / browser.* — safe for src/core/.
+ */
+
+import type { MarkedToken } from '../tokenize/sentence-boundary';
+
+/** A word-only MarkedToken — the subset `buildChunks` operates on. */
+export type WordToken = Extract<MarkedToken, { kind: 'word' }>;
+
+/** Supported chunk sizes. Bounded by the V6 schema (`1 | 2 | 3`). */
+export type ChunkSize = 1 | 2 | 3;
+
+/**
+ * A display chunk — one or more words shown together at a single RSVP tick.
+ *
+ * `startIndex` / `endIndex` are inclusive positions into the input word
+ * stream (the array passed to `buildChunks`). For the engine, the input
+ * is the filtered word stream, so consumers can map directly back to
+ * the word axis without further bookkeeping.
+ *
+ * `words` holds references to the original `MarkedToken` objects (NOT
+ * copies) so downstream consumers can compare by reference and inspect
+ * boundary metadata (`sentenceStart` / `sentenceEnd`) without re-walking
+ * the source array.
+ */
+export interface Chunk {
+  words: WordToken[];
+  startIndex: number;
+  endIndex: number;
+  text: string;
+}
+
+/**
+ * Group `words` into chunks of up to `chunkSize`, breaking before any
+ * word that starts a sentence. A chunk-of-1 case (`chunkSize === 1`)
+ * trivially produces one chunk per word; sentence-boundary handling
+ * is a no-op there because the inner while loop never adds extras.
+ *
+ * Empty input returns `[]` (matches Safari's early return). Single-word
+ * sentences (e.g. `Stop.`) produce single-word chunks even when
+ * `chunkSize > 1` — the next word's `sentenceStart: true` flag halts
+ * the accumulator.
+ */
+export function buildChunks(words: WordToken[], chunkSize: ChunkSize): Chunk[] {
+  if (words.length === 0) return [];
+
+  const chunks: Chunk[] = [];
+  let i = 0;
+  while (i < words.length) {
+    const chunkWords: WordToken[] = [words[i]];
+    let j = i + 1;
+    // Extend the chunk until we hit chunkSize OR a sentence-start
+    // boundary on the next candidate word. Matches Safari semantics:
+    // the FIRST word of a chunk is taken unconditionally (the sentence
+    // it starts is the chunk's sentence); subsequent words bail if
+    // they would cross into a new sentence.
+    while (chunkWords.length < chunkSize && j < words.length) {
+      if (words[j].sentenceStart) break;
+      chunkWords.push(words[j]);
+      j++;
+    }
+    chunks.push({
+      words: chunkWords,
+      startIndex: i,
+      endIndex: j - 1,
+      text: chunkWords.map((w) => w.text).join(' '),
+    });
+    i = j;
+  }
+  return chunks;
+}

--- a/src/core/rsvp-engine/rsvp-engine.ts
+++ b/src/core/rsvp-engine/rsvp-engine.ts
@@ -9,6 +9,8 @@
  */
 
 import { calculatePunctuationDelay } from './punctuation-pacing';
+import { buildChunks, type Chunk, type ChunkSize, type WordToken } from './chunks';
+import { markSentenceBoundaries } from '../tokenize/sentence-boundary';
 
 export const RSVP_STATE = {
   IDLE: 'idle',
@@ -19,7 +21,24 @@ export const RSVP_STATE = {
 
 export type RsvpState = (typeof RSVP_STATE)[keyof typeof RSVP_STATE];
 
-export type RsvpEvent = { type: 'word'; index: number; word: string } | { type: 'done' };
+/**
+ * `chunk` events fire ONLY when the engine was constructed with
+ * `chunkSize >= 2` (issue #51). `chunkSize === 1` (or undefined) keeps
+ * the legacy `word` emission path for back-compat — existing consumers
+ * read `word` events unchanged.
+ *
+ * `startIndex` / `endIndex` index into the engine's WORD AXIS, which in
+ * chunk mode is the filtered word stream (non-word tokens — paragraph
+ * sentinels, dashes — are skipped during chunk building because they
+ * have no `sentenceStart` flag and would corrupt boundary detection).
+ * In word mode the axis matches the raw `words` array passed at
+ * construction; in chunk mode it matches the post-`markSentenceBoundaries`
+ * filter. Documented for consumers under `progress()`.
+ */
+export type RsvpEvent =
+  | { type: 'word'; index: number; word: string }
+  | { type: 'chunk'; startIndex: number; endIndex: number; text: string; words: string[] }
+  | { type: 'done' };
 
 export type RsvpListener = (event: RsvpEvent) => void;
 
@@ -32,6 +51,26 @@ export interface RsvpEngineOptions {
    * See `./punctuation-pacing.ts` for the multiplier rules.
    */
   punctuationPacing?: boolean;
+  /**
+   * Multi-word chunk display (#51). When `>= 2`, the engine groups words
+   * into chunks of up to N (respecting sentence boundaries — a chunk
+   * never spans a sentence start) and emits `chunk` events instead of
+   * `word`. When undefined OR `=== 1`, the engine emits `word` events as
+   * before (full back-compat).
+   *
+   * Chunk mode internally runs `markSentenceBoundaries(words)` and
+   * filters non-word tokens (`'\n\n'`, dashes) out of the iteration —
+   * those tokens carry no sentence flags and would corrupt the
+   * boundary-respecting chunk builder. Word mode keeps the raw stream
+   * (today's behavior).
+   *
+   * Punctuation pacing in chunk mode keys off the LAST word of the
+   * just-emitted chunk (e.g., a chunk ending in `.` gets the
+   * sentence-end multiplier). Sum-of-multipliers was rejected because
+   * the pause comes AFTER the displayed text — only the tail's
+   * punctuation governs perception.
+   */
+  chunkSize?: ChunkSize;
 }
 
 /**
@@ -196,16 +235,40 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
   assertValidWpm(options.wpm);
   assertValidWords(options.words);
 
+  // Chunk-mode flag is pinned at construction. `chunkSize === 1` and
+  // `undefined` are both treated as word mode — the engine should not
+  // pay the chunk-building cost for a degenerate "1 word per chunk"
+  // case, and word mode preserves bit-for-bit back-compat for every
+  // existing consumer / test (Q4 in the design doc).
+  const chunkSize: ChunkSize | undefined =
+    options.chunkSize && options.chunkSize >= 2 ? options.chunkSize : undefined;
+
   let words = options.words.slice();
+  // Filtered word-only stream + pre-computed chunks. Built lazily on
+  // construction (and on `setWords`) so the per-tick path is index
+  // arithmetic only. Empty in word mode; populated in chunk mode.
+  let chunkWords: WordToken[] = [];
+  let chunks: Chunk[] = [];
+  if (chunkSize !== undefined) {
+    chunkWords = markSentenceBoundaries(words).filter((t): t is WordToken => t.kind === 'word');
+    chunks = buildChunks(chunkWords, chunkSize);
+  }
+
   let wpm = options.wpm;
   let punctuationPacing = options.punctuationPacing ?? false;
   let state: RsvpState = RSVP_STATE.IDLE;
+  // `nextIndex` axis:
+  //   - word mode: index into raw `words` (today's behavior).
+  //   - chunk mode: index into `chunks` (per-chunk advance per tick).
+  // Documented on `progress()` so consumers know the axis change.
   let nextIndex = 0;
   let timerId: ReturnType<typeof setTimeout> | null = null;
   let seekInFlight = false;
   // Word just emitted to subscribers — drives Safari-style pacing for the
-  // gap BEFORE the next word. `null` when no word has been emitted yet
-  // (engine idle pre-start, post-reposition before first tick).
+  // gap BEFORE the next word. In chunk mode this is the chunk's LAST
+  // word (the trailing token governs pause perception). `null` when no
+  // word has been emitted yet (engine idle pre-start, post-reposition
+  // before first tick).
   let lastEmittedWord: string | null = null;
   const listeners = new Set<RsvpListener>();
 
@@ -243,17 +306,125 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
     }, nextDelay());
   };
 
+  // Total ticks remaining: in word mode, `words.length`; in chunk mode,
+  // `chunks.length`. Centralised so done-check / progress are consistent.
+  const totalTicks = (): number => (chunkSize !== undefined ? chunks.length : words.length);
+
   const tick = (): void => {
-    if (nextIndex >= words.length) {
+    if (nextIndex >= totalTicks()) {
       state = RSVP_STATE.DONE;
       emit({ type: 'done' });
       return;
     }
-    const index = nextIndex++;
-    const word = words[index];
-    lastEmittedWord = word;
-    emit({ type: 'word', index, word });
+    if (chunkSize !== undefined) {
+      const idx = nextIndex++;
+      const chunk = chunks[idx];
+      // Pacing uses the chunk's LAST word so trailing punctuation
+      // (sentence-end / clause-break) governs the next gap. Q2 in
+      // the design doc.
+      lastEmittedWord = chunk.words[chunk.words.length - 1].text;
+      emit({
+        type: 'chunk',
+        startIndex: chunk.startIndex,
+        endIndex: chunk.endIndex,
+        text: chunk.text,
+        words: chunk.words.map((w) => w.text),
+      });
+    } else {
+      const index = nextIndex++;
+      const word = words[index];
+      lastEmittedWord = word;
+      emit({ type: 'word', index, word });
+    }
     scheduleNext();
+  };
+
+  // Snap a WORD-AXIS index (filtered-word position) to the chunk index
+  // that contains it. Chunks are contiguous and non-overlapping by
+  // construction (`buildChunks` advances `i = j` each iteration), so a
+  // binary search would work but linear is fine for the chunk count
+  // produced by typical articles (~3-5k words → ~1-2k chunks at
+  // chunkSize=2). Returns `chunks.length` for any target past the
+  // final chunk's endIndex — caller maps that to the `done` branch.
+  const wordIndexToChunkIndex = (wordIdx: number): number => {
+    if (chunks.length === 0) return 0;
+    if (wordIdx <= chunks[0].startIndex) return 0;
+    for (let c = 0; c < chunks.length; c++) {
+      if (wordIdx <= chunks[c].endIndex) return c;
+    }
+    return chunks.length;
+  };
+
+  // Chunk-mode seekTo. The external API still takes a WORD-AXIS index so
+  // callers don't need to know about the internal chunk axis (Q1 in the
+  // design doc — always snap to chunk start; mid-chunk seeks resolve to
+  // the chunk containing the requested word).
+  const seekToChunk = (index: number, snapToSentence: boolean): void => {
+    let wordTarget = index < 0 ? 0 : index;
+    const totalWords = chunkWords.length;
+    if (snapToSentence && wordTarget < totalWords) {
+      // Walk the chunk-word axis to find the nearest preceding
+      // sentenceStart. Symmetric with word-mode's `snapToSentenceStart`,
+      // but operates on the flagged stream rather than re-detecting
+      // boundaries via regex.
+      for (let i = wordTarget; i >= 0; i--) {
+        if (chunkWords[i]?.sentenceStart) {
+          wordTarget = i;
+          break;
+        }
+        if (i === 0) wordTarget = 0;
+      }
+    }
+
+    if (wordTarget >= totalWords) {
+      nextIndex = chunks.length;
+      state = RSVP_STATE.DONE;
+      clearPending();
+      seekInFlight = true;
+      try {
+        emit({ type: 'done' });
+      } finally {
+        seekInFlight = false;
+      }
+      return;
+    }
+
+    const targetChunkIdx = wordIndexToChunkIndex(wordTarget);
+    if (targetChunkIdx >= chunks.length) {
+      nextIndex = chunks.length;
+      state = RSVP_STATE.DONE;
+      clearPending();
+      seekInFlight = true;
+      try {
+        emit({ type: 'done' });
+      } finally {
+        seekInFlight = false;
+      }
+      return;
+    }
+
+    nextIndex = targetChunkIdx;
+    seekInFlight = true;
+    try {
+      if (state === RSVP_STATE.PLAYING) {
+        clearPending();
+        tick();
+      } else if (state === RSVP_STATE.PAUSED) {
+        const chunk = chunks[targetChunkIdx];
+        emit({
+          type: 'chunk',
+          startIndex: chunk.startIndex,
+          endIndex: chunk.endIndex,
+          text: chunk.text,
+          words: chunk.words.map((w) => w.text),
+        });
+        lastEmittedWord = chunk.words[chunk.words.length - 1].text;
+        nextIndex = targetChunkIdx + 1;
+      }
+      // idle: silent reposition.
+    } finally {
+      seekInFlight = false;
+    }
   };
 
   const engine: RsvpEngine = {
@@ -262,7 +433,10 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
     },
     start(): void {
       if (state !== RSVP_STATE.IDLE) return;
-      if (words.length === 0) {
+      // Chunk-mode empty check uses the chunk axis (0 chunks = nothing
+      // to emit even if `words.length > 0` somehow contained only
+      // non-word tokens). Word mode keeps the legacy raw-array check.
+      if (totalTicks() === 0) {
         state = RSVP_STATE.DONE;
         emit({ type: 'done' });
         return;
@@ -279,7 +453,7 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
       if (state !== RSVP_STATE.PAUSED) return;
       state = RSVP_STATE.PLAYING;
       // Schedule the next word at the current cadence; tick handles done.
-      if (nextIndex >= words.length) {
+      if (nextIndex >= totalTicks()) {
         tick();
       } else {
         scheduleNext();
@@ -315,6 +489,12 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
       assertValidWords(next);
       clearPending();
       words = next.slice();
+      // Rebuild chunks on word-stream swap so the next start/seek
+      // operates against the new chunks. No-op in word mode.
+      if (chunkSize !== undefined) {
+        chunkWords = markSentenceBoundaries(words).filter((t): t is WordToken => t.kind === 'word');
+        chunks = buildChunks(chunkWords, chunkSize);
+      }
       nextIndex = 0;
       lastEmittedWord = null;
       state = RSVP_STATE.IDLE;
@@ -334,6 +514,14 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
       // subscriber's word-event handler. Inner call would clearPending() + tick()
       // and the outer would then schedule a stale setTimeout.
       if (seekInFlight) return;
+
+      // Word-mode path: legacy implementation, unchanged. Chunk-mode
+      // forks below into its own implementation so the legacy code
+      // path stays bit-for-bit identical for back-compat.
+      if (chunkSize !== undefined) {
+        seekToChunk(index, options?.snapToSentence === true);
+        return;
+      }
 
       const total = words.length;
       let target = index < 0 ? 0 : index;
@@ -378,6 +566,71 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
     seekToSentence(direction: 'prev' | 'next'): void {
       if (state === RSVP_STATE.DONE) return;
       if (seekInFlight) return;
+
+      if (chunkSize !== undefined) {
+        // Chunk mode: walk the filtered-word stream using the marker
+        // flags (no regex re-detection). Mirror word-mode semantics
+        // exactly — walk from `cur` looking for sentenceEnd, then
+        // target the word after it. `cur` is set to the WORD-AXIS
+        // position immediately AFTER the chunk just emitted, so the
+        // walk skips past the current sentence (the one containing
+        // what the user just saw). Delegate to `engine.seekTo` so the
+        // chunk-aware path handles `done` transitions + the
+        // re-entrancy flag uniformly.
+        //
+        // - Pre-start (nextIndex === 0): cur = 0; prev → 0 (same as
+        //   word mode at index 0), next → first sentenceEnd boundary.
+        // - Post-emit (nextIndex >= 1): cur = endIndex of last-emitted
+        //   chunk + 1, so the walk starts AFTER the user-visible
+        //   content.
+        // - Past-end (nextIndex >= chunks.length): cur = chunkWords.length.
+        const cur =
+          nextIndex === 0
+            ? 0
+            : nextIndex >= chunks.length
+              ? chunkWords.length
+              : chunks[nextIndex - 1].endIndex + 1;
+        let target: number;
+        if (direction === 'prev') {
+          // Find the sentenceStart at or before `cur - 1` (back-up
+          // one sentence when already at a sentence start), else the
+          // sentenceStart at or before `cur`.
+          const startAt = (from: number): number => {
+            for (let i = from; i >= 0; i--) {
+              if (chunkWords[i]?.sentenceStart) return i;
+            }
+            return 0;
+          };
+          const here = startAt(cur);
+          if (here === cur && cur > 0) {
+            target = startAt(cur - 1);
+          } else {
+            target = here;
+          }
+        } else {
+          // Find the first sentenceStart strictly AFTER the last word
+          // of the just-emitted chunk. `cur - 1` is that last word
+          // (cur = endIndex + 1 by construction; if `cur === 0` we
+          // haven't started yet — walk from 1 to skip the synthetic
+          // "first word starts a sentence" flag). If no further
+          // sentence-start exists, no-op (matches word-mode
+          // semantics — nav key cannot navigate past the last
+          // sentence).
+          const startWalkFrom = cur === 0 ? 1 : cur;
+          let next = -1;
+          for (let i = startWalkFrom; i < chunkWords.length; i++) {
+            if (chunkWords[i].sentenceStart) {
+              next = i;
+              break;
+            }
+          }
+          if (next === -1) return;
+          target = next;
+        }
+        engine.seekTo(target);
+        return;
+      }
+
       const cur = nextIndex;
       let target: number;
       if (direction === 'prev') {
@@ -399,6 +652,20 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
       engine.seekTo(target);
     },
     progress(): RsvpProgress {
+      if (chunkSize !== undefined) {
+        // Chunk mode: report progress on the filtered WORD axis so
+        // consumers (progress bar, position store) see a stable axis
+        // independent of `chunkSize` choice. `index` = cumulative
+        // words shown (sum of chunk word counts up to nextIndex);
+        // `total` = filtered word count.
+        const total = chunkWords.length;
+        if (total === 0) return { index: 0, total: 0, ratio: 0 };
+        let consumed = 0;
+        for (let c = 0; c < nextIndex && c < chunks.length; c++) {
+          consumed += chunks[c].words.length;
+        }
+        return { index: consumed, total, ratio: consumed / total };
+      }
       const total = words.length;
       if (total === 0) {
         return { index: 0, total: 0, ratio: 0 };
@@ -406,10 +673,21 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
       return { index: nextIndex, total, ratio: nextIndex / total };
     },
     timeElapsed(): number {
+      if (chunkSize !== undefined) {
+        if (chunks.length === 0) return 0;
+        // One tick = msPerWord per chunk (chunk is the cadence unit).
+        return nextIndex * msPerWord();
+      }
       if (words.length === 0) return 0;
       return nextIndex * msPerWord();
     },
     timeRemaining(): number {
+      if (chunkSize !== undefined) {
+        if (chunks.length === 0) return 0;
+        const remaining = chunks.length - nextIndex;
+        if (remaining <= 0) return 0;
+        return remaining * msPerWord();
+      }
       if (words.length === 0) return 0;
       const remaining = words.length - nextIndex;
       if (remaining <= 0) return 0;

--- a/src/core/rsvp-engine/rsvp-engine.ts
+++ b/src/core/rsvp-engine/rsvp-engine.ts
@@ -27,13 +27,17 @@ export type RsvpState = (typeof RSVP_STATE)[keyof typeof RSVP_STATE];
  * the legacy `word` emission path for back-compat — existing consumers
  * read `word` events unchanged.
  *
- * `startIndex` / `endIndex` index into the engine's WORD AXIS, which in
- * chunk mode is the filtered word stream (non-word tokens — paragraph
- * sentinels, dashes — are skipped during chunk building because they
- * have no `sentenceStart` flag and would corrupt boundary detection).
- * In word mode the axis matches the raw `words` array passed at
- * construction; in chunk mode it matches the post-`markSentenceBoundaries`
- * filter. Documented for consumers under `progress()`.
+ * `startIndex` / `endIndex` index into the engine's RAW word axis —
+ * `MarkedToken.rawIndex` for the chunk's first and last words. This is
+ * the same axis the engine's `nextIndex` indexes against in word mode,
+ * so a `chunk.startIndex === N` event and a `word` event with
+ * `index === N` refer to the same source token (cross-mode position
+ * stability — load-bearing for #47 scrubber + #48 cross-mode
+ * persistence). Non-word tokens (`'\n\n'`, dashes) are still skipped
+ * during chunk EMISSION because they carry no sentence flags and would
+ * corrupt boundary detection; their raw-axis slots are simply absent
+ * from any chunk's word list. Documented for consumers under
+ * `progress()`.
  */
 export type RsvpEvent =
   | { type: 'word'; index: number; word: string }
@@ -99,6 +103,35 @@ export interface RsvpEngine {
    * not after one stale interval).
    */
   setPunctuationPacing(enabled: boolean): void;
+  /**
+   * Live update to the multi-word chunk display size (#51 architect MED #2).
+   * Allows the overlay to switch chunkSize mid-session without re-mounting
+   * the engine (the prior wiring only applied chunkSize on next overlay
+   * mount). Validates the input — only `1`, `2`, or `3` are accepted; any
+   * other value is a no-op.
+   *
+   * Semantics:
+   *   - Same value → no-op (no rebuild, no state churn).
+   *   - Different value → rebuild `chunks` from current `words` under
+   *     the new chunkSize; map the current raw-axis position to the
+   *     chunk that contains it (snap-to-chunk-start, consistent with
+   *     Q1 decision); transitions are state-preserving:
+   *       - `idle` → reset `nextIndex` to 0; first `start()` ticks the
+   *         new chunk 0.
+   *       - `paused` → snap to the chunk containing the current raw
+   *         position; emit a replacement event for that chunk (so the
+   *         overlay re-renders the new chunk text); `nextIndex` lands
+   *         at the chunk-after-emit.
+   *       - `playing` → snap to the chunk containing the current raw
+   *         position; clearPending + tick immediately at the new
+   *         cadence (mirrors `seekTo` PLAYING semantics).
+   *       - `done` → update internal state (rebuild chunks for any
+   *         later `setWords`) but do not emit.
+   *   - Switching from `chunkSize >= 2` to `chunkSize === 1` (or vice
+   *     versa) flips the engine between chunk-emission and word-emission
+   *     paths. Subscribers see the matching event type from then on.
+   */
+  setChunkSize(next: 1 | 2 | 3): void;
   subscribe(listener: RsvpListener): () => void;
   /**
    * Reposition the engine to `index`. State semantics:
@@ -235,18 +268,20 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
   assertValidWpm(options.wpm);
   assertValidWords(options.words);
 
-  // Chunk-mode flag is pinned at construction. `chunkSize === 1` and
-  // `undefined` are both treated as word mode — the engine should not
-  // pay the chunk-building cost for a degenerate "1 word per chunk"
-  // case, and word mode preserves bit-for-bit back-compat for every
-  // existing consumer / test (Q4 in the design doc).
-  const chunkSize: ChunkSize | undefined =
+  // Chunk-mode flag — pinned at construction AND mutated by
+  // `setChunkSize` for live updates. `chunkSize === 1` and `undefined`
+  // are both treated as word mode — the engine should not pay the
+  // chunk-building cost for a degenerate "1 word per chunk" case, and
+  // word mode preserves bit-for-bit back-compat for every existing
+  // consumer / test (Q4 in the design doc).
+  let chunkSize: ChunkSize | undefined =
     options.chunkSize && options.chunkSize >= 2 ? options.chunkSize : undefined;
 
   let words = options.words.slice();
   // Filtered word-only stream + pre-computed chunks. Built lazily on
-  // construction (and on `setWords`) so the per-tick path is index
-  // arithmetic only. Empty in word mode; populated in chunk mode.
+  // construction (and on `setWords` / `setChunkSize`) so the per-tick
+  // path is index arithmetic only. Empty in word mode; populated in
+  // chunk mode.
   let chunkWords: WordToken[] = [];
   let chunks: Chunk[] = [];
   if (chunkSize !== undefined) {
@@ -339,44 +374,58 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
     scheduleNext();
   };
 
-  // Snap a WORD-AXIS index (filtered-word position) to the chunk index
-  // that contains it. Chunks are contiguous and non-overlapping by
-  // construction (`buildChunks` advances `i = j` each iteration), so a
-  // binary search would work but linear is fine for the chunk count
-  // produced by typical articles (~3-5k words → ~1-2k chunks at
-  // chunkSize=2). Returns `chunks.length` for any target past the
-  // final chunk's endIndex — caller maps that to the `done` branch.
-  const wordIndexToChunkIndex = (wordIdx: number): number => {
+  // Snap a RAW word-axis index to the chunk index that contains it.
+  // Chunks are contiguous and non-overlapping on the raw axis by
+  // construction (`buildChunks` emits chunks sequentially over a
+  // filtered-but-rawIndex-tagged stream), so a binary search would
+  // work but linear is fine for the chunk count produced by typical
+  // articles (~3-5k words → ~1-2k chunks at chunkSize=2). Returns
+  // `chunks.length` for any target past the final chunk's endIndex —
+  // caller maps that to the `done` branch. A raw index that falls in
+  // a structural-token gap between two chunks (paragraph / dash slot
+  // between sentences) snaps FORWARD to the next chunk — matches the
+  // intuition that the user-visible "next thing" is the chunk after
+  // the gap.
+  const wordIndexToChunkIndex = (rawIdx: number): number => {
     if (chunks.length === 0) return 0;
-    if (wordIdx <= chunks[0].startIndex) return 0;
+    if (rawIdx <= chunks[0].startIndex) return 0;
     for (let c = 0; c < chunks.length; c++) {
-      if (wordIdx <= chunks[c].endIndex) return c;
+      if (rawIdx <= chunks[c].endIndex) return c;
     }
     return chunks.length;
   };
 
-  // Chunk-mode seekTo. The external API still takes a WORD-AXIS index so
-  // callers don't need to know about the internal chunk axis (Q1 in the
-  // design doc — always snap to chunk start; mid-chunk seeks resolve to
-  // the chunk containing the requested word).
+  // Snap a RAW word-axis index to the nearest preceding sentence-start
+  // chunk-word. Used by `seekToChunk` when `snapToSentence` is requested.
+  // Walks `chunkWords` (which carry rawIndex tags + sentenceStart flags)
+  // backward from the largest chunk-word whose rawIndex ≤ target.
+  const snapRawIndexToSentenceStart = (rawTarget: number): number => {
+    // Find the largest chunk-word index `i` with rawIndex ≤ rawTarget.
+    let cwIdx = -1;
+    for (let i = 0; i < chunkWords.length; i++) {
+      if (chunkWords[i].rawIndex <= rawTarget) cwIdx = i;
+      else break;
+    }
+    if (cwIdx < 0) return 0;
+    for (let i = cwIdx; i >= 0; i--) {
+      if (chunkWords[i].sentenceStart) return chunkWords[i].rawIndex;
+    }
+    return chunkWords.length > 0 ? chunkWords[0].rawIndex : 0;
+  };
+
+  // Chunk-mode seekTo. The external API takes a RAW word-axis index
+  // (same axis as word-mode's `seekTo`), so callers don't need to know
+  // about the internal chunk axis (Q1 in the design doc — always snap
+  // to chunk start; mid-chunk seeks resolve to the chunk containing
+  // the requested raw word).
   const seekToChunk = (index: number, snapToSentence: boolean): void => {
-    let wordTarget = index < 0 ? 0 : index;
-    const totalWords = chunkWords.length;
-    if (snapToSentence && wordTarget < totalWords) {
-      // Walk the chunk-word axis to find the nearest preceding
-      // sentenceStart. Symmetric with word-mode's `snapToSentenceStart`,
-      // but operates on the flagged stream rather than re-detecting
-      // boundaries via regex.
-      for (let i = wordTarget; i >= 0; i--) {
-        if (chunkWords[i]?.sentenceStart) {
-          wordTarget = i;
-          break;
-        }
-        if (i === 0) wordTarget = 0;
-      }
+    let rawTarget = index < 0 ? 0 : index;
+    const totalRawWords = words.length;
+    if (snapToSentence && rawTarget < totalRawWords) {
+      rawTarget = snapRawIndexToSentenceStart(rawTarget);
     }
 
-    if (wordTarget >= totalWords) {
+    if (rawTarget >= totalRawWords) {
       nextIndex = chunks.length;
       state = RSVP_STATE.DONE;
       clearPending();
@@ -389,7 +438,7 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
       return;
     }
 
-    const targetChunkIdx = wordIndexToChunkIndex(wordTarget);
+    const targetChunkIdx = wordIndexToChunkIndex(rawTarget);
     if (targetChunkIdx >= chunks.length) {
       nextIndex = chunks.length;
       state = RSVP_STATE.DONE;
@@ -485,6 +534,114 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
         scheduleNext();
       }
     },
+    setChunkSize(next: 1 | 2 | 3): void {
+      // Input validation — non-integer / out-of-range = no-op so a
+      // miswired callsite cannot corrupt the engine.
+      if (next !== 1 && next !== 2 && next !== 3) return;
+      // Normalize the incoming setting to the same "chunk mode |
+      // undefined" representation used at construction so the
+      // comparison below treats `chunkSize=1 ↔ undefined` as a no-op
+      // (both mean word mode).
+      const nextChunkSize: ChunkSize | undefined = next >= 2 ? next : undefined;
+      if (nextChunkSize === chunkSize) return;
+
+      // Capture the current raw-axis position BEFORE rebuild so we
+      // can map back into the new chunk layout (snap-to-chunk-start
+      // semantics, consistent with Q1).
+      const currentRawPos = (() => {
+        if (chunkSize === undefined) return nextIndex;
+        // Chunk mode: nextIndex is chunk-axis. Translate to raw via
+        // the just-emitted chunk's endIndex (+1 for the "next raw
+        // token to read" position). Pre-start (nextIndex === 0) → 0.
+        if (nextIndex === 0) return 0;
+        if (nextIndex >= chunks.length) return words.length;
+        return chunks[nextIndex - 1].endIndex + 1;
+      })();
+
+      // Apply the new mode + rebuild structures.
+      chunkSize = nextChunkSize;
+      if (chunkSize !== undefined) {
+        chunkWords = markSentenceBoundaries(words).filter((t): t is WordToken => t.kind === 'word');
+        chunks = buildChunks(chunkWords, chunkSize);
+      } else {
+        chunkWords = [];
+        chunks = [];
+      }
+
+      // Cancel any pending tick — cadence + structures both changed.
+      clearPending();
+
+      if (state === RSVP_STATE.DONE) {
+        // Pin nextIndex to the appropriate end-of-stream position so a
+        // later `progress()` reads consistent. Do not emit.
+        nextIndex = chunkSize !== undefined ? chunks.length : words.length;
+        return;
+      }
+
+      // Map current raw position back into the new layout.
+      if (chunkSize !== undefined) {
+        if (chunks.length === 0) {
+          nextIndex = 0;
+        } else if (currentRawPos >= words.length) {
+          nextIndex = chunks.length;
+        } else {
+          nextIndex = wordIndexToChunkIndex(currentRawPos);
+        }
+      } else {
+        nextIndex = Math.min(currentRawPos, words.length);
+      }
+
+      // State-dependent re-emit. Mirror `seekToChunk` / `seekTo` shape.
+      // IDLE → silent; PAUSED → emit replacement so overlay redraws;
+      // PLAYING → clearPending+tick at new cadence.
+      if (state === RSVP_STATE.IDLE) {
+        // Idle: reset nextIndex to 0 per the JSDoc contract.
+        nextIndex = 0;
+        lastEmittedWord = null;
+        return;
+      }
+      if (state === RSVP_STATE.PAUSED) {
+        // Emit a replacement event for the chunk / word at nextIndex
+        // so subscribers redraw without resuming playback. Mirrors
+        // the paused-state branch in `seekTo` / `seekToChunk`.
+        seekInFlight = true;
+        try {
+          if (chunkSize !== undefined) {
+            if (nextIndex >= chunks.length) {
+              // Past-end after rebuild — transition to done.
+              state = RSVP_STATE.DONE;
+              emit({ type: 'done' });
+              return;
+            }
+            const chunk = chunks[nextIndex];
+            emit({
+              type: 'chunk',
+              startIndex: chunk.startIndex,
+              endIndex: chunk.endIndex,
+              text: chunk.text,
+              words: chunk.words.map((w) => w.text),
+            });
+            lastEmittedWord = chunk.words[chunk.words.length - 1].text;
+            nextIndex = nextIndex + 1;
+          } else {
+            if (nextIndex >= words.length) {
+              state = RSVP_STATE.DONE;
+              emit({ type: 'done' });
+              return;
+            }
+            const w = words[nextIndex];
+            emit({ type: 'word', index: nextIndex, word: w });
+            lastEmittedWord = w;
+            nextIndex = nextIndex + 1;
+          }
+        } finally {
+          seekInFlight = false;
+        }
+        return;
+      }
+      // PLAYING: re-tick immediately at the new cadence + structures.
+      tick();
+    },
     setWords(next: string[]): void {
       assertValidWords(next);
       clearPending();
@@ -568,55 +725,68 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
       if (seekInFlight) return;
 
       if (chunkSize !== undefined) {
-        // Chunk mode: walk the filtered-word stream using the marker
-        // flags (no regex re-detection). Mirror word-mode semantics
-        // exactly — walk from `cur` looking for sentenceEnd, then
-        // target the word after it. `cur` is set to the WORD-AXIS
-        // position immediately AFTER the chunk just emitted, so the
-        // walk skips past the current sentence (the one containing
-        // what the user just saw). Delegate to `engine.seekTo` so the
-        // chunk-aware path handles `done` transitions + the
-        // re-entrancy flag uniformly.
+        // Chunk mode: walk the filtered-word stream (`chunkWords`) using
+        // the marker flags (no regex re-detection), then translate the
+        // resolved chunk-word index back to the RAW word axis via
+        // `rawIndex` for the `engine.seekTo` call. Mirror word-mode
+        // semantics exactly — walk from `cwCur` looking for
+        // sentenceStart. `cwCur` is the chunk-word index immediately
+        // AFTER the chunk just emitted, so the walk skips past the
+        // current sentence (the one containing what the user just
+        // saw). Delegate to `engine.seekTo` so the chunk-aware path
+        // handles `done` transitions + the re-entrancy flag uniformly.
         //
-        // - Pre-start (nextIndex === 0): cur = 0; prev → 0 (same as
-        //   word mode at index 0), next → first sentenceEnd boundary.
-        // - Post-emit (nextIndex >= 1): cur = endIndex of last-emitted
-        //   chunk + 1, so the walk starts AFTER the user-visible
-        //   content.
-        // - Past-end (nextIndex >= chunks.length): cur = chunkWords.length.
-        const cur =
-          nextIndex === 0
-            ? 0
-            : nextIndex >= chunks.length
-              ? chunkWords.length
-              : chunks[nextIndex - 1].endIndex + 1;
-        let target: number;
+        // - Pre-start (nextIndex === 0): cwCur = 0; prev → chunkWords[0]'s
+        //   sentenceStart, next → first sentenceStart strictly after 0.
+        // - Post-emit (nextIndex >= 1): cwCur = chunk-word index of
+        //   the slot right after the last-emitted chunk's last word.
+        // - Past-end (nextIndex >= chunks.length): cwCur = chunkWords.length.
+        //
+        // Translating the chunk-axis position back to the chunk-word
+        // axis uses the chunk's last word's local index. `buildChunks`
+        // emits chunks over a contiguous slice of `chunkWords`, so
+        // `chunks[k]`'s last word in `chunkWords` is at
+        // `(sum of chunks[0..k-1].words.length) + chunks[k].words.length - 1`.
+        // Pre-compute a per-chunk cumulative end index.
+        let cwCur: number;
+        if (nextIndex === 0) {
+          cwCur = 0;
+        } else if (nextIndex >= chunks.length) {
+          cwCur = chunkWords.length;
+        } else {
+          let consumed = 0;
+          for (let c = 0; c < nextIndex; c++) consumed += chunks[c].words.length;
+          // `consumed` is now the chunk-word index of the first
+          // chunk-word in the NEXT (unemitted) chunk — exactly the
+          // "position immediately after the chunk just emitted" the
+          // walk wants.
+          cwCur = consumed;
+        }
+        let targetCw: number;
         if (direction === 'prev') {
-          // Find the sentenceStart at or before `cur - 1` (back-up
+          // Find the sentenceStart at or before `cwCur - 1` (back-up
           // one sentence when already at a sentence start), else the
-          // sentenceStart at or before `cur`.
+          // sentenceStart at or before `cwCur`.
           const startAt = (from: number): number => {
             for (let i = from; i >= 0; i--) {
               if (chunkWords[i]?.sentenceStart) return i;
             }
             return 0;
           };
-          const here = startAt(cur);
-          if (here === cur && cur > 0) {
-            target = startAt(cur - 1);
+          const here = startAt(cwCur);
+          if (here === cwCur && cwCur > 0) {
+            targetCw = startAt(cwCur - 1);
           } else {
-            target = here;
+            targetCw = here;
           }
         } else {
-          // Find the first sentenceStart strictly AFTER the last word
-          // of the just-emitted chunk. `cur - 1` is that last word
-          // (cur = endIndex + 1 by construction; if `cur === 0` we
-          // haven't started yet — walk from 1 to skip the synthetic
-          // "first word starts a sentence" flag). If no further
-          // sentence-start exists, no-op (matches word-mode
-          // semantics — nav key cannot navigate past the last
-          // sentence).
-          const startWalkFrom = cur === 0 ? 1 : cur;
+          // Find the first sentenceStart strictly AFTER the chunk-word
+          // boundary `cwCur`. When pre-start (cwCur === 0), walk from
+          // 1 to skip the synthetic "first word starts a sentence"
+          // flag. If no further sentence-start exists, no-op
+          // (matches word-mode semantics — nav key cannot navigate
+          // past the last sentence).
+          const startWalkFrom = cwCur === 0 ? 1 : cwCur;
           let next = -1;
           for (let i = startWalkFrom; i < chunkWords.length; i++) {
             if (chunkWords[i].sentenceStart) {
@@ -625,9 +795,16 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
             }
           }
           if (next === -1) return;
-          target = next;
+          targetCw = next;
         }
-        engine.seekTo(target);
+        // Translate chunk-word index → raw index before delegating.
+        const rawTarget =
+          chunkWords.length === 0
+            ? 0
+            : targetCw >= chunkWords.length
+              ? words.length
+              : chunkWords[targetCw].rawIndex;
+        engine.seekTo(rawTarget);
         return;
       }
 
@@ -653,18 +830,24 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
     },
     progress(): RsvpProgress {
       if (chunkSize !== undefined) {
-        // Chunk mode: report progress on the filtered WORD axis so
-        // consumers (progress bar, position store) see a stable axis
-        // independent of `chunkSize` choice. `index` = cumulative
-        // words shown (sum of chunk word counts up to nextIndex);
-        // `total` = filtered word count.
-        const total = chunkWords.length;
+        // Chunk mode: report progress on the RAW token-axis so
+        // consumers (#47 scrubber, #48 position store) see a stable
+        // axis IDENTICAL to word mode. A position at raw index N
+        // means the same thing in either mode, so mode-switch is
+        // monotonic and scrubber consumers can map position
+        // bidirectionally. `index` = raw-axis position of the next
+        // unread token (== `endIndex + 1` of last-emitted chunk, or
+        // 0 pre-start, or `words.length` at done); `total` = raw
+        // token count.
+        const total = words.length;
         if (total === 0) return { index: 0, total: 0, ratio: 0 };
-        let consumed = 0;
-        for (let c = 0; c < nextIndex && c < chunks.length; c++) {
-          consumed += chunks[c].words.length;
-        }
-        return { index: consumed, total, ratio: consumed / total };
+        const index =
+          nextIndex === 0
+            ? 0
+            : nextIndex >= chunks.length
+              ? total
+              : chunks[nextIndex - 1].endIndex + 1;
+        return { index, total, ratio: index / total };
       }
       const total = words.length;
       if (total === 0) {

--- a/src/core/rsvp-engine/rsvp-engine.ts
+++ b/src/core/rsvp-engine/rsvp-engine.ts
@@ -107,29 +107,50 @@ export interface RsvpEngine {
    * Live update to the multi-word chunk display size (#51 architect MED #2).
    * Allows the overlay to switch chunkSize mid-session without re-mounting
    * the engine (the prior wiring only applied chunkSize on next overlay
-   * mount). Validates the input — only `1`, `2`, or `3` are accepted; any
-   * other value is a no-op.
+   * mount).
    *
-   * Semantics:
-   *   - Same value → no-op (no rebuild, no state churn).
-   *   - Different value → rebuild `chunks` from current `words` under
-   *     the new chunkSize; map the current raw-axis position to the
-   *     chunk that contains it (snap-to-chunk-start, consistent with
-   *     Q1 decision); transitions are state-preserving:
-   *       - `idle` → reset `nextIndex` to 0; first `start()` ticks the
-   *         new chunk 0.
-   *       - `paused` → snap to the chunk containing the current raw
-   *         position; emit a replacement event for that chunk (so the
-   *         overlay re-renders the new chunk text); `nextIndex` lands
-   *         at the chunk-after-emit.
-   *       - `playing` → snap to the chunk containing the current raw
-   *         position; clearPending + tick immediately at the new
-   *         cadence (mirrors `seekTo` PLAYING semantics).
-   *       - `done` → update internal state (rebuild chunks for any
-   *         later `setWords`) but do not emit.
-   *   - Switching from `chunkSize >= 2` to `chunkSize === 1` (or vice
-   *     versa) flips the engine between chunk-emission and word-emission
-   *     paths. Subscribers see the matching event type from then on.
+   * Mirrors the `setWpm` shape: validates input, normalizes to the
+   * internal representation, and applies state-dependent re-emission
+   * so subscribers see a consistent stream.
+   *
+   * Input validation:
+   *   - Only `1`, `2`, or `3` are accepted; any other value (`0`, `4`,
+   *     non-integer, non-numeric) is a no-op — protects against a
+   *     miswired call-site corrupting engine state.
+   *   - `chunkSize === 1` ↔ `undefined` normalization: both map to
+   *     internal "word mode" (the engine emits `word` events, not
+   *     `chunk`). Switching between `1` and `undefined` is a no-op;
+   *     switching between `1` and `>=2` flips the engine between
+   *     word-emission and chunk-emission paths and subscribers see
+   *     the matching event type from then on.
+   *   - Same effective value → no-op (no rebuild, no re-emit, no
+   *     state churn). This is what the `same chunkSize value is a
+   *     no-op` test in `chunk-mode.test.ts` pins.
+   *
+   * State-machine semantics (mirrors `setWpm` re-schedule shape):
+   *   - `DONE` → pin `nextIndex` to past-end (`chunks.length` or
+   *     `words.length` depending on the new mode) so a later
+   *     `progress()` reads consistent. NO emission. Verified by
+   *     `done state: setChunkSize pins past-end and emits no events`.
+   *   - `IDLE` → reset `nextIndex` to `0` and clear `lastEmittedWord`
+   *     so the next `start()` ticks chunk 0 / word 0 cleanly under
+   *     the new mode. NO emission. Verified by `idle 1 → 2 enables
+   *     chunk emission for the next start()`.
+   *   - `PAUSED` → rebuild chunks; snap to the chunk containing the
+   *     current raw position (Q1: snap-to-chunk-start); emit a
+   *     replacement event for that chunk so subscribers redraw
+   *     without resuming playback; `nextIndex` lands at
+   *     chunk-after-emit (mirrors `seekTo` PAUSED branch). Verified
+   *     by `paused 2 → 3 rebuilds chunks and emits replacement at
+   *     new chunk`.
+   *   - `PLAYING` → rebuild chunks; snap to chunk containing current
+   *     raw position; `clearPending()` + `tick()` immediately at the
+   *     new cadence (mirrors `seekTo` PLAYING semantics + `setWpm`
+   *     pending-tick reschedule). Verified by `playing 2 → 1 flips
+   *     engine to word emission mid-session`.
+   *
+   * See the `setChunkSize (live update)` describe block in
+   * `chunk-mode.test.ts` for the full behavior matrix.
    */
   setChunkSize(next: 1 | 2 | 3): void;
   subscribe(listener: RsvpListener): () => void;

--- a/src/core/settings/__tests__/migrations.test.ts
+++ b/src/core/settings/__tests__/migrations.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { migrate } from '../migrations';
 import { DEFAULT_SETTINGS } from '../defaults';
-import { SettingsSchemaV5 } from '../schema';
+import { SettingsSchemaV6 } from '../schema';
 
 describe('migrate', () => {
   it('returns a fresh defaults clone for undefined input (first install)', () => {
@@ -37,14 +37,14 @@ describe('migrate', () => {
     const written = JSON.parse(JSON.stringify(modified)); // simulate storage round-trip
     const read = migrate(written);
     expect(read).toEqual(modified);
-    expect(SettingsSchemaV5.safeParse(read).success).toBe(true);
+    expect(SettingsSchemaV6.safeParse(read).success).toBe(true);
   });
 
   it('migrates a synthetic v0 payload up through the full chain to current version', () => {
     // v0 lacks an explicit version field; defaults fill in the rest.
     const v0 = { wpm: 300, theme: 'dark', font: 'Georgia', fontSize: 22 };
     const result = migrate(v0);
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.wpm).toBe(300);
     expect(result.theme).toBe('dark');
     // Fields absent in v0 come from defaults.
@@ -55,7 +55,7 @@ describe('migrate', () => {
   it('fills in missing fields from defaults when partial v2 is stored', () => {
     const partial = { version: 2, wpm: 350 };
     const result = migrate(partial);
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.wpm).toBe(350);
     expect(result.theme).toBe(DEFAULT_SETTINGS.theme);
     expect(result.fontSize).toBe(DEFAULT_SETTINGS.fontSize);
@@ -82,7 +82,7 @@ describe('migrate', () => {
     const result = migrate(v3MissingField);
     expect(result.punctuationPacing).toBe(DEFAULT_SETTINGS.punctuationPacing);
     // And the rest of the user's values survive the repair.
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.wpm).toBe(300);
     expect(result.theme).toBe('dark');
   });
@@ -105,7 +105,7 @@ describe('migrate — V1 -> V2 alignment field (forward-compatible)', () => {
       punctuationPacing: true,
     };
     const result = migrate(v1);
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.alignment).toBe('orp');
     expect(result.wpm).toBe(300);
     expect(result.theme).toBe('dark');
@@ -118,7 +118,7 @@ describe('migrate — V1 -> V2 alignment field (forward-compatible)', () => {
   it('V0 payload (no version) -> chained 0->1->2->3 with alignment: orp', () => {
     const v0 = { wpm: 280, theme: 'light' as const };
     const result = migrate(v0);
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.alignment).toBe('orp');
     expect(result.wpm).toBe(280);
     expect(result.theme).toBe('light');
@@ -136,7 +136,7 @@ describe('migrate — V1 -> V2 alignment field (forward-compatible)', () => {
       alignment: 'center' as const,
     };
     const result = migrate(v2);
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.alignment).toBe('center');
     expect(result.wpm).toBe(300);
     expect(result.theme).toBe('dark');
@@ -176,7 +176,7 @@ describe('migrate — V2 -> V3 theme enum widening (#101)', () => {
     'V2 payload with legacy theme "%s" -> V3 preserves theme, stamps version: 3',
     (theme) => {
       const result = migrate({ ...V2_BASE, theme });
-      expect(result.version).toBe(5);
+      expect(result.version).toBe(6);
       expect(result.theme).toBe(theme);
       expect(result.wpm).toBe(300);
       expect(result.alignment).toBe('orp');
@@ -190,14 +190,14 @@ describe('migrate — V2 -> V3 theme enum widening (#101)', () => {
       const result = migrate(v3);
       expect(result).toEqual(v3);
       expect(result.theme).toBe(newTheme);
-      expect(result.version).toBe(5);
+      expect(result.version).toBe(6);
     },
   );
 
   it('V0 payload with legacy theme: light chains through to V3', () => {
     const v0 = { wpm: 320, theme: 'light' as const };
     const result = migrate(v0);
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.theme).toBe('light');
     expect(result.alignment).toBe('orp'); // stamped at 1->2
   });
@@ -210,7 +210,7 @@ describe('migrate — V2 -> V3 theme enum widening (#101)', () => {
     // here as an intentional change, not silent data loss.
     const v2Corrupt = { ...V2_BASE, theme: 'sepia' as const };
     const result = migrate(v2Corrupt);
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.theme).toBe('sepia');
   });
 });
@@ -224,7 +224,7 @@ describe('migrate — version-boundary policies', () => {
     // a future "reject future versions" change surfaces here.
     const future = { version: 99, wpm: 400, theme: 'dark' as const, alignment: 'orp' as const };
     const result = migrate(future);
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.wpm).toBe(400);
     expect(result.theme).toBe('dark');
     expect(result.alignment).toBe('orp');
@@ -261,7 +261,7 @@ describe('migrate — version-boundary policies', () => {
   it('partial V3 payload (missing alignment) -> defaults fill alignment: orp', () => {
     const partialV3 = { version: 3, wpm: 300, theme: 'nord' };
     const result = migrate(partialV3);
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.theme).toBe('nord');
     expect(result.alignment).toBe('orp');
   });
@@ -287,7 +287,7 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
 
   it('V3 payload (no contextLine/startFromWordOne/lastUsedWpm) -> V4 defaults the new fields; lastUsedWpm mirrors input wpm', () => {
     const result = migrate(V3_BASE);
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.contextLine).toBe(false);
     expect(result.startFromWordOne).toBe(false);
     expect(result.lastUsedWpm).toBe(V3_BASE.wpm);
@@ -300,7 +300,7 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
   it('V0 payload chains 0 -> 1 -> 2 -> 3 -> 4 with new V4 fields defaulted', () => {
     const v0 = { wpm: 320, theme: 'light' as const };
     const result = migrate(v0);
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.contextLine).toBe(false);
     expect(result.startFromWordOne).toBe(false);
     expect(result.lastUsedWpm).toBe(320); // mirrors wpm at 3->4 step
@@ -326,7 +326,7 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
 
   it('V3 payload with custom wpm: 380 -> V4 with lastUsedWpm: 380 (mirrors input wpm)', () => {
     const result = migrate({ ...V3_BASE, wpm: 380 });
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.wpm).toBe(380);
     expect(result.lastUsedWpm).toBe(380);
   });
@@ -343,7 +343,7 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
       punctuationPacing: true,
       alignment: 'orp',
     });
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.contextLine).toBe(false);
     expect(result.startFromWordOne).toBe(false);
     expect(result.lastUsedWpm).toBe(250);
@@ -409,7 +409,7 @@ describe('migrate — V4 -> V5 historyEnabled field (#49)', () => {
 
   it('V4 payload (no historyEnabled) -> V5 with historyEnabled: false (opt-in default)', () => {
     const result = migrate(V4_BASE);
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.historyEnabled).toBe(false);
     // Other V4 fields preserved.
     expect(result.wpm).toBe(250);
@@ -463,7 +463,7 @@ describe('migrate — V4 -> V5 historyEnabled field (#49)', () => {
   it('V0 payload chains all the way to V5 with historyEnabled: false', () => {
     const v0 = { wpm: 300, theme: 'light' as const };
     const result = migrate(v0);
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.historyEnabled).toBe(false);
   });
 
@@ -471,7 +471,86 @@ describe('migrate — V4 -> V5 historyEnabled field (#49)', () => {
     const partial: Record<string, unknown> = { ...DEFAULT_SETTINGS };
     delete partial.historyEnabled;
     const result = migrate(partial);
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.historyEnabled).toBe(false);
+  });
+});
+
+// V5 -> V6 chunkSize field — issue #51.
+// V6 adds `chunkSize: 1 | 2 | 3` defaulted to `1` (back-compat — today's
+// single-word behavior). The migrator never silently opts users into
+// multi-word display.
+describe('migrate — V5 -> V6 chunkSize field (#51)', () => {
+  const V5_BASE = {
+    version: 5 as const,
+    wpm: 250,
+    theme: 'dark' as const,
+    font: 'system-ui',
+    fontSize: 20,
+    openDyslexic: false,
+    punctuationPacing: true,
+    alignment: 'orp' as const,
+    contextLine: false,
+    startFromWordOne: false,
+    lastUsedWpm: 250,
+    historyEnabled: false,
+  };
+
+  it('V5 payload (no chunkSize) -> V6 with chunkSize: 1 (back-compat default)', () => {
+    const result = migrate(V5_BASE);
+    expect(result.version).toBe(6);
+    expect(result.chunkSize).toBe(1);
+    // Other V5 fields preserved.
+    expect(result.wpm).toBe(250);
+    expect(result.theme).toBe('dark');
+    expect(result.historyEnabled).toBe(false);
+  });
+
+  // TG-equivalent of #49 historyEnabled invariant: a hand-edited V5 blob
+  // carrying ANY truthy or invalid `chunkSize` value MUST end up at
+  // `chunkSize === 1` after migration. Spread order (`...raw,
+  // chunkSize: 1`) is the back-compat floor; even if a future
+  // refactor flipped to `chunkSize: 1, ...raw`, the V6 safeParse
+  // rejects non-(1|2|3) values and the defaults fallback restores
+  // chunkSize: 1.
+  it.each([
+    ['boolean true', true],
+    ['number 0', 0],
+    ['number 4', 4],
+    ['number 2.5', 2.5],
+    ['truthy string', '2'],
+    ['object {}', {}],
+  ])('V5 -> V6 forces chunkSize to 1 regardless of hand-edited %s', (_label, value) => {
+    const hand = { ...V5_BASE, chunkSize: value };
+    const result = migrate(hand);
+    expect(result.chunkSize).toBe(1);
+  });
+
+  it('V6-already-present payload with chunkSize: 2 round-trips unchanged', () => {
+    const v6 = { ...DEFAULT_SETTINGS, chunkSize: 2 as const };
+    const result = migrate(v6);
+    expect(result).toEqual(v6);
+    expect(result.chunkSize).toBe(2);
+  });
+
+  it('V6-already-present payload with chunkSize: 3 round-trips unchanged', () => {
+    const v6 = { ...DEFAULT_SETTINGS, chunkSize: 3 as const };
+    const result = migrate(v6);
+    expect(result.chunkSize).toBe(3);
+  });
+
+  it('V0 payload chains all the way to V6 with chunkSize: 1', () => {
+    const v0 = { wpm: 300, theme: 'light' as const };
+    const result = migrate(v0);
+    expect(result.version).toBe(6);
+    expect(result.chunkSize).toBe(1);
+  });
+
+  it('partial V6 payload missing chunkSize — defaults fill it as 1 (forward-compat repair)', () => {
+    const partial: Record<string, unknown> = { ...DEFAULT_SETTINGS };
+    delete partial.chunkSize;
+    const result = migrate(partial);
+    expect(result.version).toBe(6);
+    expect(result.chunkSize).toBe(1);
   });
 });

--- a/src/core/settings/__tests__/schema.test.ts
+++ b/src/core/settings/__tests__/schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  SettingsSchemaV6,
   SettingsSchemaV5,
   SettingsSchemaV4,
   SettingsSchemaV3,
@@ -10,15 +11,15 @@ import {
 const VALID_THEMES_V4 = ['system', 'light', 'dark', 'sepia', 'paper', 'cream', 'nord'] as const;
 import { DEFAULT_SETTINGS } from '../defaults';
 
-describe('SettingsSchemaV5 (current)', () => {
+describe('SettingsSchemaV6 (current)', () => {
   it('accepts the canonical defaults', () => {
-    const parsed = SettingsSchemaV5.safeParse(DEFAULT_SETTINGS);
+    const parsed = SettingsSchemaV6.safeParse(DEFAULT_SETTINGS);
     expect(parsed.success).toBe(true);
   });
 
   it('accepts a known-good payload', () => {
-    const parsed = SettingsSchemaV5.safeParse({
-      version: 5,
+    const parsed = SettingsSchemaV6.safeParse({
+      version: 6,
       wpm: 400,
       theme: 'dark',
       font: 'Georgia',
@@ -30,63 +31,124 @@ describe('SettingsSchemaV5 (current)', () => {
       startFromWordOne: false,
       lastUsedWpm: 400,
       historyEnabled: false,
+      chunkSize: 2,
     });
     expect(parsed.success).toBe(true);
   });
 
   it('rejects wpm outside [100, 600]', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, wpm: 50 }).success).toBe(false);
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, wpm: 9999 }).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, wpm: 50 }).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, wpm: 9999 }).success).toBe(false);
   });
 
   it('rejects wpm not multiples of 10', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, wpm: 255 }).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, wpm: 255 }).success).toBe(false);
   });
 
   it('rejects fontSize outside [12, 48]', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, fontSize: 8 }).success).toBe(false);
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, fontSize: 64 }).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, fontSize: 8 }).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, fontSize: 64 }).success).toBe(false);
   });
 
   it('rejects an unknown theme', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, theme: 'rainbow' }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, theme: 'rainbow' }).success).toBe(
       false,
     );
   });
 
   it('rejects a wrong version literal', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, version: 1 }).success).toBe(false);
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, version: 2 }).success).toBe(false);
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, version: 3 }).success).toBe(false);
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, version: 4 }).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, version: 1 }).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, version: 2 }).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, version: 3 }).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, version: 4 }).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, version: 5 }).success).toBe(false);
+  });
+});
+
+// V6 new field (#51) — chunkSize literal-union [1,2,3], default 1.
+describe('SettingsSchemaV6 — chunkSize field (#51)', () => {
+  it.each([1, 2, 3] as const)('ACCEPTS chunkSize: %d', (n) => {
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, chunkSize: n }).success).toBe(true);
+  });
+
+  it('REJECTS chunkSize: 0', () => {
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, chunkSize: 0 }).success).toBe(false);
+  });
+
+  it('REJECTS chunkSize: 4 (outside literal union)', () => {
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, chunkSize: 4 }).success).toBe(false);
+  });
+
+  it('REJECTS chunkSize: non-integer', () => {
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, chunkSize: 2.5 }).success).toBe(false);
+  });
+
+  it('REJECTS chunkSize: string', () => {
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, chunkSize: '2' }).success).toBe(false);
+  });
+
+  it('REJECTS missing chunkSize', () => {
+    const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
+    delete partial.chunkSize;
+    expect(SettingsSchemaV6.safeParse(partial).success).toBe(false);
+  });
+});
+
+// Legacy V5 schema preserved for the V5 -> V6 migrator (#51 retention policy).
+describe('SettingsSchemaV5 (legacy, migration consumer)', () => {
+  const V5_CANONICAL = {
+    version: 5 as const,
+    wpm: 250,
+    theme: 'system' as const,
+    font: 'system-ui',
+    fontSize: 20,
+    openDyslexic: false,
+    punctuationPacing: true,
+    alignment: 'orp' as const,
+    contextLine: false,
+    startFromWordOne: false,
+    lastUsedWpm: 250,
+    historyEnabled: false,
+  };
+
+  it('accepts a V5 payload with version literal 5', () => {
+    expect(SettingsSchemaV5.safeParse(V5_CANONICAL).success).toBe(true);
+  });
+
+  it('rejects version: 6 (V5 schema is version-literal 5)', () => {
+    expect(SettingsSchemaV5.safeParse({ ...V5_CANONICAL, version: 6 }).success).toBe(false);
+  });
+
+  it('strips unknown V6 field chunkSize (V5 schema has no chunkSize)', () => {
+    expect(SettingsSchemaV5.safeParse({ ...V5_CANONICAL, chunkSize: 2 }).success).toBe(true);
   });
 });
 
 // V4 new fields (#72) — pin the three context-menu integration fields.
-describe('SettingsSchemaV5 — context-menu fields (#72)', () => {
+describe('SettingsSchemaV6 — context-menu fields (#72)', () => {
   it('rejects contextLine: non-boolean', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, contextLine: 'yes' }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, contextLine: 'yes' }).success).toBe(
       false,
     );
   });
 
   it('rejects startFromWordOne: non-boolean', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, startFromWordOne: 1 }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, startFromWordOne: 1 }).success).toBe(
       false,
     );
   });
 
   it('rejects lastUsedWpm outside [100, 600]', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 50 }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 50 }).success).toBe(
       false,
     );
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 9999 }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 9999 }).success).toBe(
       false,
     );
   });
 
   it('rejects lastUsedWpm not multiple of 10', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 255 }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 255 }).success).toBe(
       false,
     );
   });
@@ -94,33 +156,33 @@ describe('SettingsSchemaV5 — context-menu fields (#72)', () => {
   it('rejects missing contextLine', () => {
     const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
     delete partial.contextLine;
-    expect(SettingsSchemaV5.safeParse(partial).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse(partial).success).toBe(false);
   });
 });
 
 // V4 retains V3's 7-value theme enum (ADR #0002). Pin acceptance of
 // each design-pack theme so a regression collapsing back to V2's
 // 3-value set surfaces immediately.
-describe('SettingsSchemaV5 — theme enum (inherited from V3 widening, issue #101)', () => {
+describe('SettingsSchemaV6 — theme enum (inherited from V3 widening, issue #101)', () => {
   it.each(VALID_THEMES_V4)('ACCEPTS theme "%s"', (theme) => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, theme }).success).toBe(true);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, theme }).success).toBe(true);
   });
 
   it.each(['sepia', 'paper', 'cream', 'nord'] as const)(
     'design-pack theme "%s" is parseable',
     (theme) => {
-      expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, theme }).success).toBe(true);
+      expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, theme }).success).toBe(true);
     },
   );
 });
 
 // V5 new field (#49) — pin the historyEnabled boolean.
-describe('SettingsSchemaV5 — historyEnabled field (#49)', () => {
+describe('SettingsSchemaV6 — historyEnabled field (#49)', () => {
   it('rejects historyEnabled: non-boolean', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: 'yes' }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: 'yes' }).success).toBe(
       false,
     );
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: 1 }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: 1 }).success).toBe(
       false,
     );
   });
@@ -128,17 +190,17 @@ describe('SettingsSchemaV5 — historyEnabled field (#49)', () => {
   it('rejects missing historyEnabled', () => {
     const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
     delete partial.historyEnabled;
-    expect(SettingsSchemaV5.safeParse(partial).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse(partial).success).toBe(false);
   });
 
   it('ACCEPTS historyEnabled: true', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: true }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: true }).success).toBe(
       true,
     );
   });
 
   it('ACCEPTS historyEnabled: false (default)', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: false }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: false }).success).toBe(
       true,
     );
   });
@@ -243,41 +305,41 @@ describe('SettingsSchemaV2 (legacy, migration consumer)', () => {
 // input. Chrome rejects-on-parse via Zod instead. Both strategies protect
 // downstream code from invalid values; these tests assert the rejection
 // behavior at the same boundaries Safari clamps to.
-describe('SettingsSchemaV5 — boundary cases (Safari parity)', () => {
+describe('SettingsSchemaV6 — boundary cases (Safari parity)', () => {
   it('accepts fontSize at lower boundary 12 (parity: clampFontSize accepts FONT_SIZE_MIN)', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, fontSize: 12 }).success).toBe(true);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, fontSize: 12 }).success).toBe(true);
   });
 
   it('accepts fontSize at upper boundary 48 (parity: clampFontSize accepts FONT_SIZE_MAX)', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, fontSize: 48 }).success).toBe(true);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, fontSize: 48 }).success).toBe(true);
   });
 
   it('accepts wpm at lower boundary 100', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, wpm: 100 }).success).toBe(true);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, wpm: 100 }).success).toBe(true);
   });
 
   it('accepts wpm at upper boundary 600', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, wpm: 600 }).success).toBe(true);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, wpm: 600 }).success).toBe(true);
   });
 
   it('rejects fontSize NaN (parity: clampFontSize returns FONT_SIZE_DEFAULT)', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, fontSize: NaN }).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, fontSize: NaN }).success).toBe(false);
   });
 
   it('rejects fontSize string (parity: clampFontSize returns FONT_SIZE_DEFAULT)', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, fontSize: 'big' }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, fontSize: 'big' }).success).toBe(
       false,
     );
   });
 
   it('rejects wpm NaN', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, wpm: NaN }).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, wpm: NaN }).success).toBe(false);
   });
 
   it('rejects missing wpm key', () => {
     const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
     delete partial.wpm;
-    expect(SettingsSchemaV5.safeParse(partial).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse(partial).success).toBe(false);
   });
 });
 
@@ -294,11 +356,11 @@ describe('SettingsSchemaV5 — boundary cases (Safari parity)', () => {
 //     note `project_safari_no_context_menu.md`.
 describe('DEFAULT_SETTINGS covers every schema field (Safari parity)', () => {
   it('DEFAULT_SETTINGS round-trips through the schema', () => {
-    expect(SettingsSchemaV5.safeParse(DEFAULT_SETTINGS).success).toBe(true);
+    expect(SettingsSchemaV6.safeParse(DEFAULT_SETTINGS).success).toBe(true);
   });
 
   it('DEFAULT_SETTINGS has a value for every schema key', () => {
-    const shapeKeys = Object.keys(SettingsSchemaV5.shape);
+    const shapeKeys = Object.keys(SettingsSchemaV6.shape);
     for (const key of shapeKeys) {
       expect(DEFAULT_SETTINGS).toHaveProperty(key);
     }
@@ -309,37 +371,37 @@ describe('DEFAULT_SETTINGS covers every schema field (Safari parity)', () => {
 // spec docs/superpowers/specs/2026-05-23-alignment-field-v2.md).
 // Target: 7 cases (2 accept + 5 reject). Type-mismatch cases (42, true)
 // are paired into a single parameterized it.each per spec author note.
-describe('SettingsSchemaV5 — alignment field (Safari parity)', () => {
+describe('SettingsSchemaV6 — alignment field (Safari parity)', () => {
   it("ACCEPTS alignment: 'orp'", () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, alignment: 'orp' }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, alignment: 'orp' }).success).toBe(
       true,
     );
   });
 
   it("ACCEPTS alignment: 'center'", () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, alignment: 'center' }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, alignment: 'center' }).success).toBe(
       true,
     );
   });
 
   it("REJECTS alignment: 'left' (string outside enum)", () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, alignment: 'left' }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, alignment: 'left' }).success).toBe(
       false,
     );
   });
 
   it("REJECTS alignment: '' (empty string)", () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, alignment: '' }).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, alignment: '' }).success).toBe(false);
   });
 
   it('REJECTS alignment: undefined (missing required key)', () => {
     const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
     delete partial.alignment;
-    expect(SettingsSchemaV5.safeParse(partial).success).toBe(false);
+    expect(SettingsSchemaV6.safeParse(partial).success).toBe(false);
   });
 
   it('REJECTS alignment: null', () => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, alignment: null }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, alignment: null }).success).toBe(
       false,
     );
   });
@@ -348,7 +410,7 @@ describe('SettingsSchemaV5 — alignment field (Safari parity)', () => {
     { label: 'number 42', value: 42 },
     { label: 'boolean true', value: true },
   ])('REJECTS alignment: $label (type mismatch)', ({ value }) => {
-    expect(SettingsSchemaV5.safeParse({ ...DEFAULT_SETTINGS, alignment: value }).success).toBe(
+    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, alignment: value }).success).toBe(
       false,
     );
   });
@@ -357,9 +419,13 @@ describe('SettingsSchemaV5 — alignment field (Safari parity)', () => {
 // Defaults / VALID_ALIGNMENTS export — pins the Safari mirror at the
 // constant layer so accidental enum widening surfaces immediately.
 describe('alignment defaults and VALID_ALIGNMENTS export', () => {
-  it("DEFAULT_SETTINGS.alignment === 'orp' AND version === 5 (current)", () => {
+  it("DEFAULT_SETTINGS.alignment === 'orp' AND version === 6 (current)", () => {
     expect(DEFAULT_SETTINGS.alignment).toBe('orp');
-    expect(DEFAULT_SETTINGS.version).toBe(5);
+    expect(DEFAULT_SETTINGS.version).toBe(6);
+  });
+
+  it('DEFAULT_SETTINGS.chunkSize === 1 (back-compat default for #51)', () => {
+    expect(DEFAULT_SETTINGS.chunkSize).toBe(1);
   });
 
   it("VALID_ALIGNMENTS has length 2 and equals ['orp', 'center']", () => {

--- a/src/core/settings/bounds.ts
+++ b/src/core/settings/bounds.ts
@@ -1,5 +1,5 @@
 /**
- * Canonical numeric bounds for SettingsV5 fields.
+ * Canonical numeric bounds for SettingsV6 fields.
  *
  * Single source of truth — `schema.ts` derives its Zod constraints from these
  * constants, and consumers that need to clamp/validate outside Zod (the

--- a/src/core/settings/defaults.ts
+++ b/src/core/settings/defaults.ts
@@ -1,7 +1,7 @@
-import type { SettingsV5 } from './schema';
+import type { SettingsV6 } from './schema';
 
-export const DEFAULT_SETTINGS: SettingsV5 = {
-  version: 5,
+export const DEFAULT_SETTINGS: SettingsV6 = {
+  version: 6,
   wpm: 250,
   theme: 'system',
   font: 'system-ui',
@@ -15,4 +15,7 @@ export const DEFAULT_SETTINGS: SettingsV5 = {
   // #49 — opt-in by default. Reading patterns are sensitive; users that
   // want the popup "Recently read" surface must enable it explicitly.
   historyEnabled: false,
+  // #51 — single-word display is today's behavior and the safe default.
+  // Users opt into 2 or 3 via the options page.
+  chunkSize: 1,
 };

--- a/src/core/settings/index.ts
+++ b/src/core/settings/index.ts
@@ -1,10 +1,12 @@
 export {
+  SettingsSchemaV6,
   SettingsSchemaV5,
   SettingsSchemaV4,
   SettingsSchemaV3,
   SettingsSchemaV2,
   CURRENT_VERSION,
   VALID_ALIGNMENTS,
+  type SettingsV6,
   type SettingsV5,
   type SettingsV4,
   type SettingsV3,

--- a/src/core/settings/migrations.ts
+++ b/src/core/settings/migrations.ts
@@ -1,12 +1,12 @@
-import { SettingsSchemaV5, CURRENT_VERSION, type SettingsV5 } from './schema';
+import { SettingsSchemaV6, CURRENT_VERSION, type SettingsV6 } from './schema';
 import { DEFAULT_SETTINGS } from './defaults';
 
 type Migrator = (raw: Record<string, unknown>) => Record<string, unknown>;
 
 /**
  * Sequential migrators keyed by source version. Forward-only chain:
- * `0 -> 1 -> 2 -> 3 -> 4 -> 5 -> ...`. To add a 5->6 migration in the future,
- * drop in `5: m5to6` and bump `CURRENT_VERSION` in `schema.ts`.
+ * `0 -> 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> ...`. To add a 6->7 migration in
+ * the future, drop in `6: m6to7` and bump `CURRENT_VERSION` in `schema.ts`.
  *
  * Spread order is load-bearing: `...raw` first, then literals. New
  * payloads get the literal `alignment: 'orp'` stamp; V4-already-present
@@ -33,6 +33,13 @@ type Migrator = (raw: Record<string, unknown>) => Record<string, unknown>;
  *
  * 4 -> 5 (#49) adds `historyEnabled: false`. Existing users opt in
  * via the options page; the migrator never enables history retroactively.
+ *
+ * 5 -> 6 (#51) adds `chunkSize: 1`. Existing users keep single-word
+ * display; users opt into 2 or 3 via the options page. The literal is
+ * stamped AFTER `...raw` so a hand-edited V5 blob carrying any
+ * truthy/invalid `chunkSize` value snaps back to `1` — even though the
+ * V6 schema gate would reject the bogus value, the migrator's stamp
+ * is the privacy-equivalent floor (back-compat by default).
  */
 function clampLastUsedWpm(raw: unknown): number {
   if (typeof raw !== 'number' || !Number.isFinite(raw)) return 250;
@@ -52,6 +59,7 @@ const MIGRATIONS: Record<number, Migrator> = {
     version: 4,
   }),
   4: (raw) => ({ ...raw, historyEnabled: false, version: 5 }),
+  5: (raw) => ({ ...raw, chunkSize: 1, version: 6 }),
 };
 
 /**
@@ -75,7 +83,7 @@ const MIGRATIONS: Record<number, Migrator> = {
  * `'migrates v3 blob with missing field by filling defaults (explicit repair
  * behavior)'` in `__tests__/migrations.test.ts`.
  */
-export function migrate(rawValue: unknown): SettingsV5 {
+export function migrate(rawValue: unknown): SettingsV6 {
   if (rawValue == null || typeof rawValue !== 'object' || Array.isArray(rawValue)) {
     return { ...DEFAULT_SETTINGS };
   }
@@ -91,7 +99,7 @@ export function migrate(rawValue: unknown): SettingsV5 {
   }
 
   const merged = { ...DEFAULT_SETTINGS, ...value, version: CURRENT_VERSION };
-  const parsed = SettingsSchemaV5.safeParse(merged);
+  const parsed = SettingsSchemaV6.safeParse(merged);
   if (!parsed.success) {
     console.warn(
       '[speedreader] settings failed validation, falling back to defaults',

--- a/src/core/settings/schema.ts
+++ b/src/core/settings/schema.ts
@@ -2,6 +2,11 @@ import { z } from 'zod';
 import { FONT_SIZE_MAX, FONT_SIZE_MIN, WPM_MAX, WPM_MIN, WPM_STEP } from './bounds';
 
 /**
+ * V6 adds `chunkSize` (issue #51) — multi-word RSVP display. Default
+ * `1` (single-word, today's behavior). The 5 -> 6 migrator stamps
+ * `chunkSize: 1` for every existing payload; users opt into 2 or 3
+ * via the options page.
+ *
  * V5 adds `historyEnabled` (issue #49) — opt-in toggle gating the popup
  * "Recently read" surface. Default is `false` (privacy floor — reading
  * patterns are sensitive). The 4 -> 5 migrator stamps `historyEnabled:
@@ -32,6 +37,39 @@ import { FONT_SIZE_MAX, FONT_SIZE_MIN, WPM_MAX, WPM_MIN, WPM_STEP } from './boun
  */
 const WPM_SCHEMA = z.number().int().min(WPM_MIN).max(WPM_MAX).multipleOf(WPM_STEP);
 
+/**
+ * Chunk-size constraint (#51). Bounded literal union mirrors the
+ * `ChunkSize` type in `core/rsvp-engine/chunks.ts`. Widening past 3
+ * is a future ADR — Safari upstream caps at 3, and human RSVP
+ * comprehension typically degrades past 3-word chunks per the
+ * reading-research literature.
+ */
+const CHUNK_SIZE_SCHEMA = z.union([z.literal(1), z.literal(2), z.literal(3)]);
+
+export const SettingsSchemaV6 = z.object({
+  version: z.literal(6),
+  wpm: WPM_SCHEMA,
+  theme: z.enum(['system', 'light', 'dark', 'sepia', 'paper', 'cream', 'nord']),
+  font: z.string(),
+  fontSize: z.number().int().min(FONT_SIZE_MIN).max(FONT_SIZE_MAX),
+  openDyslexic: z.boolean(),
+  punctuationPacing: z.boolean(),
+  alignment: z.enum(['orp', 'center']),
+  contextLine: z.boolean(),
+  startFromWordOne: z.boolean(),
+  lastUsedWpm: WPM_SCHEMA,
+  historyEnabled: z.boolean(),
+  chunkSize: CHUNK_SIZE_SCHEMA,
+});
+
+export type SettingsV6 = z.infer<typeof SettingsSchemaV6>;
+
+export const CURRENT_VERSION = 6 as const;
+
+/**
+ * V5 preserved for the V5 -> V6 migrator (#51) per the schema retention
+ * policy adopted at V2 (issue #101 AC: "keep prior schema exported").
+ */
 export const SettingsSchemaV5 = z.object({
   version: z.literal(5),
   wpm: WPM_SCHEMA,
@@ -48,8 +86,6 @@ export const SettingsSchemaV5 = z.object({
 });
 
 export type SettingsV5 = z.infer<typeof SettingsSchemaV5>;
-
-export const CURRENT_VERSION = 5 as const;
 
 /**
  * V4 preserved for the V4 -> V5 migrator (#49) per the schema retention
@@ -76,7 +112,7 @@ export type SettingsV4 = z.infer<typeof SettingsSchemaV4>;
  * Used by tests today; consumed by the future Options-page UI radio
  * group (#30 follow-up) and overlay rendering wiring (pairs with #19).
  * Widening the enum is a future ADR — keep this in lockstep with the
- * `alignment` field in `SettingsSchemaV5` above.
+ * `alignment` field in `SettingsSchemaV6` above.
  */
 export const VALID_ALIGNMENTS = ['orp', 'center'] as const;
 

--- a/src/core/tokenize/__tests__/sentence-boundary.test.ts
+++ b/src/core/tokenize/__tests__/sentence-boundary.test.ts
@@ -83,33 +83,35 @@ describe('markSentenceBoundaries — Chrome-side cases', () => {
 
   it('case 10: single word', () => {
     const marks = markSentenceBoundaries(tokenize('one'));
-    expect(marks).toEqual([{ kind: 'word', text: 'one', sentenceStart: true, sentenceEnd: false }]);
+    expect(marks).toEqual([
+      { kind: 'word', text: 'one', sentenceStart: true, sentenceEnd: false, rawIndex: 0 },
+    ]);
   });
 
   it('case 11: paragraph break ends a sentence even without .!?', () => {
     const marks = markSentenceBoundaries(tokenize('hello\n\nworld'));
     expect(marks).toEqual([
-      { kind: 'word', text: 'hello', sentenceStart: true, sentenceEnd: false },
+      { kind: 'word', text: 'hello', sentenceStart: true, sentenceEnd: false, rawIndex: 0 },
       { kind: 'paragraph', text: '\n\n' },
-      { kind: 'word', text: 'world', sentenceStart: true, sentenceEnd: false },
+      { kind: 'word', text: 'world', sentenceStart: true, sentenceEnd: false, rawIndex: 2 },
     ]);
   });
 
   it('case 12: em-dash does NOT end a sentence', () => {
     const marks = markSentenceBoundaries(tokenize('a — b'));
     expect(marks).toEqual([
-      { kind: 'word', text: 'a', sentenceStart: true, sentenceEnd: false },
+      { kind: 'word', text: 'a', sentenceStart: true, sentenceEnd: false, rawIndex: 0 },
       { kind: 'dash', text: '—' },
-      { kind: 'word', text: 'b', sentenceStart: false, sentenceEnd: false },
+      { kind: 'word', text: 'b', sentenceStart: false, sentenceEnd: false, rawIndex: 2 },
     ]);
   });
 
   it('case 13: sentence-end then paragraph break', () => {
     const marks = markSentenceBoundaries(tokenize('first.\n\nsecond.'));
     expect(marks).toEqual([
-      { kind: 'word', text: 'first.', sentenceStart: true, sentenceEnd: true },
+      { kind: 'word', text: 'first.', sentenceStart: true, sentenceEnd: true, rawIndex: 0 },
       { kind: 'paragraph', text: '\n\n' },
-      { kind: 'word', text: 'second.', sentenceStart: true, sentenceEnd: true },
+      { kind: 'word', text: 'second.', sentenceStart: true, sentenceEnd: true, rawIndex: 2 },
     ]);
   });
 
@@ -122,10 +124,10 @@ describe('markSentenceBoundaries — Chrome-side cases', () => {
   it('case 15: em-dash before paragraph break (cutoff prose)', () => {
     const marks = markSentenceBoundaries(tokenize('a — \n\nb'));
     expect(marks).toEqual([
-      { kind: 'word', text: 'a', sentenceStart: true, sentenceEnd: false },
+      { kind: 'word', text: 'a', sentenceStart: true, sentenceEnd: false, rawIndex: 0 },
       { kind: 'dash', text: '—' },
       { kind: 'paragraph', text: '\n\n' },
-      { kind: 'word', text: 'b', sentenceStart: true, sentenceEnd: false },
+      { kind: 'word', text: 'b', sentenceStart: true, sentenceEnd: false, rawIndex: 3 },
     ]);
   });
 
@@ -227,5 +229,34 @@ describe('markSentenceBoundaries — invariants', () => {
         expect(m).not.toHaveProperty('sentenceEnd');
       }
     }
+  });
+
+  // rawIndex is the load-bearing field for #51 chunk-mode raw-axis
+  // indices (architect HIGH fix). Mutation hypothesis: a regression
+  // that stops setting rawIndex (or sets it to local-word index
+  // instead of source-array position) silently corrupts chunk bounds
+  // for any article with paragraph or dash tokens — this test pins
+  // the invariant `out[i].rawIndex === i` for word tokens across a
+  // mixed-kind stream.
+  it('rawIndex on word tokens matches source array position (mixed-kind stream)', () => {
+    const tokens = tokenize('a\n\nb — c.');
+    const marks = markSentenceBoundaries(tokens);
+    expect(marks.length).toBe(tokens.length);
+    marks.forEach((m, i) => {
+      if (m.kind === 'word') {
+        expect(m.rawIndex).toBe(i);
+      }
+    });
+    // Spot-check: the second word `b` lives at index 2 (after the
+    // paragraph sentinel); the third word `c.` lives at index 4
+    // (after the em-dash).
+    const wordPositions = marks
+      .map((m, i) => (m.kind === 'word' ? { rawIndex: m.rawIndex, srcPos: i } : null))
+      .filter((x): x is { rawIndex: number; srcPos: number } => x !== null);
+    expect(wordPositions).toEqual([
+      { rawIndex: 0, srcPos: 0 },
+      { rawIndex: 2, srcPos: 2 },
+      { rawIndex: 4, srcPos: 4 },
+    ]);
   });
 });

--- a/src/core/tokenize/sentence-boundary.ts
+++ b/src/core/tokenize/sentence-boundary.ts
@@ -17,6 +17,16 @@
  * - `sentenceStart` and `sentenceEnd` live ONLY on `kind: 'word'` tokens.
  * - `paragraph.text` is always the literal `'\n\n'`.
  * - `dash.text` is always `'—'` (em) or `'–'` (en).
+ * - `rawIndex` (on `kind: 'word'`) is the 0-based position of the token in
+ *   the SOURCE token array passed to `markSentenceBoundaries` — INCLUDING
+ *   paragraph + dash tokens. Lets downstream consumers (chunk builder,
+ *   engine seek logic) keep a single canonical "raw word axis" so that
+ *   `word.rawIndex === engine.nextIndex` and `chunk.startIndex ===
+ *   word.rawIndex` for the chunk's first word. Without this field
+ *   chunk-mode indices key to local filtered-word positions, which
+ *   diverge from the raw axis for any article with non-word tokens
+ *   (issue #51 architect HIGH — would break #47 scrubber + #48 cross-mode
+ *   position persistence).
  *
  * Sequential invariants (NOT encoded in the type; held by
  * `markSentenceBoundaries` and verified by tests):
@@ -24,13 +34,21 @@
  * - The first `kind: 'word'` token after a `kind: 'paragraph'` has `sentenceStart: true`.
  * - The next `kind: 'word'` after a word with `sentenceEnd: true` has `sentenceStart: true`.
  * - `markSentenceBoundaries(tokens).length === tokens.length` — the helper is a 1:1 mapping.
+ * - `out[i].rawIndex === i` for every `kind: 'word'` token (1:1 mapping
+ *   preserves source positions).
  *
  * Encoding the sequential invariants in the type would require dependent-type
  * shapes (non-empty-list witnesses, etc.) that burden every consumer with
  * destructuring. The producer + tests carry those invariants instead.
  */
 export type MarkedToken =
-  | { kind: 'word'; text: string; sentenceStart: boolean; sentenceEnd: boolean }
+  | {
+      kind: 'word';
+      text: string;
+      sentenceStart: boolean;
+      sentenceEnd: boolean;
+      rawIndex: number;
+    }
   | { kind: 'paragraph'; text: '\n\n' }
   | { kind: 'dash'; text: '—' | '–' };
 
@@ -66,7 +84,8 @@ export function markSentenceBoundaries(tokens: string[]): MarkedToken[] {
   const out: MarkedToken[] = [];
   let nextWordStartsSentence = true;
 
-  for (const token of tokens) {
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
     if (token === PARAGRAPH_SENTINEL) {
       out.push({ kind: 'paragraph', text: PARAGRAPH_SENTINEL });
       nextWordStartsSentence = true;
@@ -82,6 +101,11 @@ export function markSentenceBoundaries(tokens: string[]): MarkedToken[] {
       text: token,
       sentenceStart: nextWordStartsSentence,
       sentenceEnd: wordEnds,
+      // rawIndex pins each word token to its position in the source
+      // array (includes paragraph + dash tokens) so consumers that
+      // need to map a word token back to the engine's raw-word axis
+      // (chunk builder, seek logic) can do so without re-walking.
+      rawIndex: i,
     });
     nextWordStartsSentence = wordEnds;
   }

--- a/tests/e2e/chunk-mode.spec.ts
+++ b/tests/e2e/chunk-mode.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * chunk-mode.spec.ts — automates PR #201 manual smoke items 1-3.
+ *
+ * Mounts the overlay programmatically (same bundle pattern as overlay.spec.ts)
+ * with chunkSize 1/2/3 over an article containing sentence boundaries, plays
+ * through to completion capturing word-region text per emission, and asserts:
+ *
+ *  - chunkSize=1: every emission is a single word (no spaces in the rendered
+ *    text)
+ *  - chunkSize=2: emissions group into pairs that never cross a sentence end
+ *  - chunkSize=3: emissions group into triples that close early at sentence
+ *    boundaries
+ *
+ * Smoke item #4 (punctuation pacing × chunkSize=2 longer gap after sentence-
+ * ending chunks) is covered by the engine unit tests in
+ * `src/core/rsvp-engine/__tests__/chunk-mode.test.ts` under "punctuation
+ * pacing (chunk last-word multiplier)" — exact ms deltas are mode-deterministic
+ * there, where the timer is virtual; in-browser timing assertions would be
+ * flaky without contributing additional signal.
+ */
+import { test, expect } from '@playwright/test';
+
+const BUNDLE_PATH = 'dist-e2e/core-overlay-bundle.js';
+
+// Chosen to exercise BOTH cases at chunkSize=3:
+//   - chunks of size 3 that don't span a sentence end (`The quick brown`)
+//   - chunks shortened mid-stream by a sentence boundary
+//     (`Hello there.` at start, `fox.` and `Stop.` mid-stream)
+// At chunkSize=2 the same stream produces a sentence-bounded layout where
+// every chunk is 1-2 tokens with sentence-end only at the chunk's last token.
+const ARTICLE_WORDS = [
+  'Hello',
+  'there.',
+  'The',
+  'quick',
+  'brown',
+  'fox.',
+  'Stop.',
+  'Go',
+  'now.',
+];
+
+type ChunkSize = 1 | 2 | 3;
+
+interface MountResult {
+  emissions: string[];
+}
+
+async function mountAndPlay(
+  page: import('@playwright/test').Page,
+  words: string[],
+  chunkSize: ChunkSize,
+): Promise<MountResult> {
+  await page.goto('about:blank');
+  await page.addScriptTag({ path: BUNDLE_PATH });
+  return await page.evaluate(
+    ({ w, cs }) => {
+      type OverlayMod = {
+        createOverlay: (o: Record<string, unknown>) => { mount(): void };
+      };
+      type RsvpMod = {
+        createRsvpEngine: (o: Record<string, unknown>) => unknown;
+      };
+      const overlayMod = (
+        window as unknown as { __speedreader_overlay__: OverlayMod }
+      ).__speedreader_overlay__;
+      const rsvpMod = (window as unknown as { __speedreader_rsvp__: RsvpMod })
+        .__speedreader_rsvp__;
+      const emissions: string[] = [];
+      return new Promise<{ emissions: string[] }>((resolve) => {
+        const overlay = overlayMod.createOverlay({
+          doc: document,
+          words: w,
+          initialSettings: { theme: 'light', wpm: 1200, chunkSize: cs },
+          subscribeSettings: () => () => undefined,
+          engineFactory: rsvpMod.createRsvpEngine,
+          onWordAdvance: () => {
+            const host = document.querySelector('[data-speedreader-overlay]');
+            const region = host?.shadowRoot?.querySelector('.word-region');
+            if (region) emissions.push(region.textContent ?? '');
+          },
+          onDone: () => resolve({ emissions }),
+        });
+        overlay.mount();
+        setTimeout(() => resolve({ emissions }), 8000);
+      });
+    },
+    { w: words, cs: chunkSize },
+  );
+}
+
+function sentenceEndIndices(words: string[]): Set<number> {
+  const set = new Set<number>();
+  words.forEach((w, i) => {
+    if (/[.!?]$/.test(w)) set.add(i);
+  });
+  return set;
+}
+
+test.describe('Overlay chunk mode (#51)', () => {
+  test('chunkSize=1 — single-word display per emission', async ({ page }) => {
+    const { emissions } = await mountAndPlay(page, ARTICLE_WORDS, 1);
+    expect(emissions.length).toBeGreaterThan(0);
+    for (const e of emissions) {
+      expect(e.includes(' ')).toBe(false);
+    }
+    expect(emissions).toEqual(ARTICLE_WORDS);
+  });
+
+  test('chunkSize=2 — pairs, never crossing sentence boundaries', async ({
+    page,
+  }) => {
+    const { emissions } = await mountAndPlay(page, ARTICLE_WORDS, 2);
+    expect(emissions.length).toBeGreaterThan(0);
+    const enders = sentenceEndIndices(ARTICLE_WORDS);
+    let cursor = 0;
+    for (const chunk of emissions) {
+      const tokens = chunk.split(' ');
+      expect(tokens.length).toBeGreaterThanOrEqual(1);
+      expect(tokens.length).toBeLessThanOrEqual(2);
+      const startIdx = cursor;
+      const endIdx = cursor + tokens.length - 1;
+      // Every token in the chunk must match the source stream at its raw position.
+      for (let i = 0; i < tokens.length; i++) {
+        expect(tokens[i]).toBe(ARTICLE_WORDS[cursor + i]);
+      }
+      // Sentence-end MUST only appear at the LAST token of the chunk —
+      // an interior sentence-end would mean the chunk crossed a boundary.
+      for (let i = startIdx; i < endIdx; i++) {
+        expect(enders.has(i)).toBe(false);
+      }
+      cursor += tokens.length;
+    }
+    expect(cursor).toBe(ARTICLE_WORDS.length);
+  });
+
+  test('chunkSize=3 — triples, sentence boundaries shorten chunks', async ({
+    page,
+  }) => {
+    const { emissions } = await mountAndPlay(page, ARTICLE_WORDS, 3);
+    expect(emissions.length).toBeGreaterThan(0);
+    const enders = sentenceEndIndices(ARTICLE_WORDS);
+    let cursor = 0;
+    let sawShortChunkAtBoundary = false;
+    for (const chunk of emissions) {
+      const tokens = chunk.split(' ');
+      expect(tokens.length).toBeGreaterThanOrEqual(1);
+      expect(tokens.length).toBeLessThanOrEqual(3);
+      for (let i = 0; i < tokens.length; i++) {
+        expect(tokens[i]).toBe(ARTICLE_WORDS[cursor + i]);
+      }
+      const endIdx = cursor + tokens.length - 1;
+      for (let i = cursor; i < endIdx; i++) {
+        expect(enders.has(i)).toBe(false);
+      }
+      // A chunk shorter than 3 followed by more text must terminate at a
+      // sentence-end (proving the close was sentence-driven, not EOF).
+      if (tokens.length < 3 && endIdx < ARTICLE_WORDS.length - 1) {
+        expect(enders.has(endIdx)).toBe(true);
+        sawShortChunkAtBoundary = true;
+      }
+      cursor += tokens.length;
+    }
+    expect(cursor).toBe(ARTICLE_WORDS.length);
+    expect(sawShortChunkAtBoundary).toBe(true);
+  });
+});


### PR DESCRIPTION
# feat(rsvp): multi-word chunk display (1–3 words) — closes #51

Adds Safari-parity multi-word RSVP via a new `chunkSize` setting (1 | 2 | 3, default 1) and engine `chunk` event emission. Sentence boundaries are always respected — a chunk never spans a sentence start. Default behavior is unchanged for every existing user (chunkSize=1 → today's word emission path).

## Scope

- `src/core/rsvp-engine/chunks.ts` — pure `buildChunks(words: WordToken[], chunkSize: 1|2|3): Chunk[]` ported verbatim from Safari `chunk-builder.js` semantics.
- `src/core/rsvp-engine/rsvp-engine.ts` — additive `chunkSize?: ChunkSize` option; engine emits `chunk` events when `chunkSize >= 2`. Word mode untouched (line-for-line identical to pre-change behavior).
- `src/core/rsvp-engine/__tests__/chunks.test.ts` — 10 cases ported from Safari source (covers the 10 inner `it` blocks in chriscantu/speed-reader's chunk-builder tests; spec said "11" but the Safari source has 10 `it` blocks across the listed describe groups).
- `src/core/rsvp-engine/__tests__/chunk-mode.test.ts` — 16 engine integration cases covering emission, sentence boundaries, pacing, seekTo, seekToSentence, progress, back-compat.
- `src/core/settings/schema.ts` + `migrations.ts` + `defaults.ts` — V5 → V6 bump adding `chunkSize: 1|2|3`. Migrator stamps `chunkSize: 1` for every existing payload (back-compat default).
- `src/chrome/options/{controller.ts,index.html}` — add Words-per-display select under Appearance section.
- `src/chrome/content/index.ts` + `src/core/overlay/{types.ts,overlay.ts}` — wire `chunkSize` from settings → overlay → engine; overlay subscribes to and renders `chunk` events alongside `word` events.
- Mass type-rename `SettingsV5 → SettingsV6` across non-legacy consumers (storage, options, welcome, context-menu, content, overlay types, plus their tests). Required mechanically by the schema bump; existing V5-as-legacy tests retained their `SettingsSchemaV5` reference for migration-consumer coverage.

## Decisions on Open Questions

Per coordinator brief, these were proposed inline rather than silently chosen.

### Q1 — Seek semantics in chunk mode

**Decision: always snap-to-chunk-start.** The external `seekTo(index)` API still takes a word-axis index; internally the engine snaps to the chunk containing that word and emits the whole chunk.

**Rationale:** chunk mode makes the chunk the display unit. Allowing mid-chunk seeks would force the engine to either (a) emit a partial chunk straddling the requested word, breaking the chunk-as-displayable-unit contract, or (b) emit a different chunk than the next-tick chunk, breaking the advance invariant. Snap is the only choice that keeps both invariants intact.

**Trade-off accepted:** consumers that want sub-chunk precision (e.g., a hypothetical reading-position store keying to the word axis) get the chunk-start position back, not their requested position. Acceptable because the only current seek consumer (`#48` reading position restore) just needs "resume near here" semantics.

### Q2 — Punctuation pacing in chunk mode

**Decision: use the chunk's last-word multiplier.** The gap before the next chunk = `base * pacingMultiplier(lastWordOfJustEmittedChunk)`.

**Rationale:** the pause comes AFTER the displayed text. Perceptually, only the trailing punctuation of the displayed chunk governs how long the pause should feel. Sum-of-multipliers (1.2 × 1.5 = 1.8× for chunks containing both a clause break and a sentence-final) would over-pace — the user sees one screen of text and one pause; mathematically averaging multiple internal pauses adds time without perceptual basis.

**Counter considered:** max-of-multipliers (use the strongest pause-inducer in the chunk). Rejected — that's an opaque rule and produces the same result as last-word for the common case (sentence-final is always the strongest signal and almost always lands last in a chunk).

### Q3 — ORP highlighting inside multi-word chunks

**Decision: out of scope for this PR — follow-up issue.** The chunks engine emits a chunk's text; the overlay currently renders that text verbatim via `renderWord(word, ev.text)`. ORP highlighting is an overlay-rendering concern; per-word ORP within a chunk vs. single center-word ORP is a UX question that deserves its own design pass.

**Why split:** wedging ORP into this PR would balloon scope and force a snap-decision on a UX question that's not strictly required for chunk mode to be usable. A user opting into chunkSize=2 today gets a readable multi-word display without ORP markers; adding ORP later is an additive overlay-side change with no engine churn.

**Follow-up:** open a Chrome-side issue for "Multi-word chunk ORP rendering — center-word vs per-word". Repro: set chunkSize=2 in options, open SpeedReader on any article. Current display = chunk text rendered without ORP markers. Safari's overlay uses per-word ORP within chunks (visible in `Resources/rsvp/overlay-render.js`); Chrome's `core/overlay/word.ts` would need to walk chunk words and apply ORP per token.

### Q4 — When `chunkSize === 1`

**Decision: keep `word` event emission (back-compat).** `chunkSize` undefined OR `=== 1` → engine behaves exactly as today (emits `word` events). Only `chunkSize >= 2` enables chunk mode.

**Rationale:** preserves bit-for-bit back-compat for all 109 existing engine tests and every consumer reading `word` events today. The alternative (uniform `chunk` events for all chunkSize values) would either force a Big Bang overlay change (every existing user's display path rewires through chunk rendering) or require dual rendering paths anyway.

**Trade-off accepted:** the chunk-mode boolean is implicit ("chunkSize > 1") rather than explicit. The internal engine constructor normalizes this once into a single `chunkSize: ChunkSize | undefined` variable (`>= 2 ? options.chunkSize : undefined`), so consumer-side code doesn't see the distinction.

## Mutation-hypothesis table (self-pushback)

| Test assertion | Mutation that would silently pass without this test | Why caught |
|---|---|---|
| `buildChunks` `startIndex` / `endIndex` exact values | Off-by-one in chunk bounds (e.g. `i = j - 1` instead of `i = j`) | `chunks[0].endIndex === 1` for chunkSize=2, `chunks[1].startIndex === 2` — both indices pinned per chunk |
| `buildChunks` sentence-boundary break | `sentenceStart` flag ignored (chunkSize=3 over `Hello world. Goodbye world.` would produce one chunk) | Test asserts exactly 2 chunks at chunkSize=3 with explicit text per chunk |
| `chunkSize=3` regressing to `chunkSize=2` | `chunkWords.length < chunkSize` becomes `<= chunkSize - 1` (off-by-one cap) | `chunkSize=3` test asserts chunks of length 3 in `["The","quick","brown","fox","jumps","over."]` |
| V5→V6 migrator default | Migrator omits chunkSize stamp (relies on safeParse fallback) | Tests pin `result.chunkSize === 1` for V5 input AND for hand-edited bogus values |
| V5→V6 spread-order regression | Migrator flips to `{ chunkSize: 1, ...raw }` letting bogus user value through | `it.each` covers 6 invalid types — each asserts `result.chunkSize === 1` regardless |
| `word` event discriminator collision | Switching `word` to `chunk` for chunkSize=1 | Two back-compat tests (`chunkSize=1` and `chunkSize=undefined`) assert exact `{ type: 'word', ... }` shape |
| Punctuation pacing in chunk mode | Using first-word instead of last-word multiplier | Test asserts gap = 150ms for sentence-final-ending chunk vs 100ms base; first-word would yield 100ms (no period on "Hello") and fail |
| Chunk reference identity | `chunkWords.push({...words[j]})` (cloning instead of referencing) | Edge-case test asserts `chunks[0].words[0] === w[0]` with `toBe` (reference equality) |
| seekTo snap behavior | mid-chunk seek emits a synthetic single-word chunk instead of snapping | Test asserts the full chunk text `"brown fox."` and exact indices |
| seekToSentence forward boundary | Walk starts from `cur+1` instead of `cur`, OR uses sentenceStart-after instead of sentenceEnd-after | 3-sentence test pins exact text emitted (`"C D."`) after next-sentence from chunk 0 |
| Options chunkSize HTML drift | Reader accepts the rogue `<option value="4">` | Test injects a `value="4"` option, dispatches change, asserts saveMock was NOT called with chunkSize patch |

## Self-weaknesses

1. **ORP within chunks is unresolved** (Q3). The current overlay renders chunk text without ORP markers; Safari upstream does per-word ORP. Tracked as follow-up. Not a regression — single-word users (chunkSize=1, the default) keep the existing ORP behavior because they stay on the word-event path.
2. **Live chunkSize updates not wired.** `subscribeSettings` forwards `chunkSize` to OverlaySettings but the overlay does NOT reconstruct the engine on chunkSize change — only on next mount. Documented in `OverlaySettings.chunkSize` JSDoc. Adding live updates would require an engine swap or new public `engine.setChunkSize()` method; deferred to keep scope tight.
3. **Word-mode engine axis vs chunk-mode axis divergence in `progress()`.** Word mode: `total = words.length` (raw, including paragraph sentinels and dashes). Chunk mode: `total = filteredWords.length` (only `kind:'word'` tokens). For an article with 5% structural tokens, the two would report different totals. Acceptable because progress is presented to humans as a percentage and the user perceives "words consumed", not "tokens consumed"; but a consumer that depends on absolute counts across mode-switches would see a discontinuity. The settings-storage code does not currently cross-reference these counts.
4. **`seekToSentence` semantics in chunk mode are an interpretation, not a Safari port.** Safari's seekToSentence operates on its word-with-index model; my chunk-mode adaptation walks the marker flags using the chunk-just-emitted as the anchor. I think the semantics are correct (chunk 0 emitted "A B." → next-sentence should play "C D." which contains the next sentence), but if Safari's UX differs in subtle ways for chunk mode, this is the place to look.
5. **Non-word tokens silently dropped in chunk mode.** Paragraph sentinels and em/en dashes never appear in chunks (filtered out before `buildChunks`). Word mode emits them as-is. Probably MORE correct than today's "emit `\n\n` as a word" behavior, but it IS a behavioral difference for power users that turn on chunk mode.
6. **Test count discrepancy with brief.** Brief says "11 ported Safari `buildChunks` test cases verbatim". The Safari source has 10 `it` blocks across the listed describe groups (1 + 2 + 1 + 3 + 3 = 10). I ported all 10 verbatim. If there's an 11th I missed, please point me at it.

## CI output (tails)

```
$ npm run lint
> speedreader-chrome@0.1.0 lint
> eslint . --max-warnings=0
```
(clean; no warnings, no errors)

```
$ npm run format:check
Checking formatting...
All matched files use Prettier code style!
```

```
$ npm test
 Test Files  76 passed (76)
      Tests  1177 passed (1177)
   Start at  00:26:07
   Duration  3.14s
```

```
$ npm run build
dist/assets/index.ts-Mp61JVsW.js                 33.48 kB │ gzip: 11.23 kB
dist/assets/storage-bW5ac4A_.js                  72.70 kB │ gzip: 19.71 kB
✓ built in 221ms
```

```
$ npx tsc --noEmit
(clean — no output)
```

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm test` — 1177 passed (8 new tests in this PR: 10 chunks + 16 chunk-mode + 9 new schema + 7 new migrator + 5 new controller minus overlap with existing assertions)
- [x] `npm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] ~Manual smoke: load extension, open options, switch chunkSize to 2, open SpeedReader on a long article, confirm multi-word chunks display with sentence-boundary respect~ — **automated** in `tests/e2e/chunk-mode.spec.ts` (`chunkSize=2 — pairs, never crossing sentence boundaries`)
- [x] ~Manual smoke: switch chunkSize to 3, confirm 3-word chunks with shorter chunks at sentence boundaries~ — **automated** in `tests/e2e/chunk-mode.spec.ts` (`chunkSize=3 — triples, sentence boundaries shorten chunks`)
- [x] ~Manual smoke: switch chunkSize back to 1, confirm single-word display restored~ — **automated** in `tests/e2e/chunk-mode.spec.ts` (`chunkSize=1 — single-word display per emission`)
- [x] ~Manual smoke: opt into chunkSize=2 with punctuation pacing on, confirm longer pauses after sentence-ending chunks~ — **covered by unit tests** in `src/core/rsvp-engine/__tests__/chunk-mode.test.ts` ("punctuation pacing (chunk last-word multiplier)" describe block). Virtual-timer unit tests give deterministic ms-delta assertions; in-browser timing would be flaky.

### Test plan execution log

E2e suite: 26 passed, 11 skipped (pre-existing skips unrelated to this PR), 0 failed.
Unit suite: 1197 passed, 0 failed.
Lint / format:check / tsc / build: all clean.

