### PR TITLE
feat(overlay): polish bundle — ORP alignment + chunk ORP + scrubber auto-hide (#52)

### DIFF
--- a/src/chrome/content/__tests__/alignment-wire.test.ts
+++ b/src/chrome/content/__tests__/alignment-wire.test.ts
@@ -1,0 +1,184 @@
+/**
+ * alignment-wire.test.ts — issue #52 PART A (test-gap HIGH #1)
+ *
+ * End-to-end wire from `chrome.storage.sync.get` → loadSettings →
+ * createOverlay (`initialSettings.alignment` slot) → subscribeSettings
+ * push → host `data-alignment` attribute. The unit tests in
+ * `core/overlay/__tests__/alignment-wire.test.ts` pin the overlay's
+ * local behaviour; this file pins the chrome-glue boundary so a
+ * regression that drops `alignment: settings.alignment` from the CS
+ * payload or the subscribe wiring lands as a test failure rather
+ * than a silent default at the boundary.
+ *
+ * This is the same defect class as the original "alignment dead since V3"
+ * bug — the schema slot existed but no boundary code read it. The unit
+ * tests can't detect that the CS doesn't forward — only this boundary
+ * test can.
+ *
+ * Mutation guards:
+ *   - Dropping `alignment: settings.alignment` from the initial-mount
+ *     payload fails the first test (host attribute would default to
+ *     'orp' regardless of stored value).
+ *   - Dropping `alignment: s.alignment` from the subscribe payload
+ *     fails the second test (the live push from orp → center would
+ *     have no effect at the host attribute).
+ */
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
+import type { SettingsV6 } from '../../../core/settings/schema';
+import { OVERLAY_ATTR } from '../../../core/overlay/constants';
+
+const SETTINGS_KEY = 'speedreader.settings';
+const EXT_ID = 'test-ext';
+
+type Listener = (
+  msg: unknown,
+  sender: { id?: string },
+  sendResponse: (r: unknown) => void,
+) => unknown;
+
+type StorageChangedListener = (
+  changes: Record<string, { newValue?: unknown; oldValue?: unknown }>,
+  area: string,
+) => void;
+
+interface ChromeMock {
+  runtime: {
+    id: string;
+    onMessage: { addListener: (l: Listener) => void };
+    getURL: ReturnType<typeof vi.fn>;
+  };
+  storage: {
+    sync: {
+      get: ReturnType<typeof vi.fn>;
+      set: ReturnType<typeof vi.fn>;
+    };
+    onChanged: {
+      addListener: ReturnType<typeof vi.fn>;
+      removeListener: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+function installChromeMock(stored: SettingsV6): {
+  mock: ChromeMock;
+  getListener: () => Listener;
+  emitStorageChange: (next: SettingsV6) => void;
+} {
+  let capturedListener: Listener | undefined;
+  const storageListeners: StorageChangedListener[] = [];
+  const mock: ChromeMock = {
+    runtime: {
+      id: EXT_ID,
+      onMessage: {
+        addListener: (l: Listener) => {
+          capturedListener = l;
+        },
+      },
+      getURL: vi.fn((path: string) => `chrome-extension://${EXT_ID}/${path}`),
+    },
+    storage: {
+      sync: {
+        get: vi.fn().mockResolvedValue({ [SETTINGS_KEY]: stored }),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      onChanged: {
+        addListener: vi.fn((l: StorageChangedListener) => {
+          storageListeners.push(l);
+        }),
+        removeListener: vi.fn(),
+      },
+    },
+  };
+  (globalThis as unknown as { chrome: ChromeMock }).chrome = mock;
+  return {
+    mock,
+    getListener: () => {
+      if (!capturedListener) throw new Error('content script never registered listener');
+      return capturedListener;
+    },
+    emitStorageChange: (next: SettingsV6) => {
+      for (const l of storageListeners) {
+        l({ [SETTINGS_KEY]: { newValue: next, oldValue: stored } }, 'sync');
+      }
+    },
+  };
+}
+
+function getHost(): HTMLElement {
+  const host = document.body.querySelector('[data-speedreader-overlay]');
+  if (!(host instanceof HTMLElement)) {
+    throw new Error('overlay host missing');
+  }
+  return host;
+}
+
+async function mountOverlay(getListener: () => Listener): Promise<void> {
+  document.body.innerHTML = '<article>The quick brown fox jumps over the lazy dog.</article>';
+  await import('../index');
+  const listener = getListener();
+  const respond = vi.fn();
+  listener({ type: 'activate-reader' }, { id: EXT_ID }, respond);
+  expect(respond).toHaveBeenCalledWith({ ok: true });
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('content script — alignment wire boundary (#52 PART A)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (globalThis as unknown as { chrome?: unknown }).chrome;
+    document.body.innerHTML = '';
+    document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+    vi.resetModules();
+  });
+
+  test('initialSettings.alignment reflects stored value — host data-alignment="center" on mount', async () => {
+    // The overlay forwards initialSettings.alignment to the host
+    // data-alignment attribute. With stored alignment='center', a
+    // regression that hardcodes alignment:'orp' (or drops the field) at
+    // the mount-site payload would leave the host on the default 'orp'
+    // and fail this test.
+    const { getListener } = installChromeMock({
+      ...DEFAULT_SETTINGS,
+      alignment: 'center',
+    });
+    await mountOverlay(getListener);
+    expect(getHost().getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('center');
+  });
+
+  test('initialSettings.alignment="orp" wires through (default value also passes the boundary)', async () => {
+    const { getListener } = installChromeMock({
+      ...DEFAULT_SETTINGS,
+      alignment: 'orp',
+    });
+    await mountOverlay(getListener);
+    expect(getHost().getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('orp');
+  });
+
+  test('subscribeSettings push delivers alignment change — live update flips host attribute', async () => {
+    // Start at alignment='orp'. Then push alignment='center'; the overlay's
+    // subscribe handler MUST receive the new value and flip the host
+    // data-alignment attribute. A regression that drops
+    // `alignment: s.alignment` from the subscribe payload would leave the
+    // attribute on 'orp' and fail this test.
+    const { getListener, emitStorageChange } = installChromeMock({
+      ...DEFAULT_SETTINGS,
+      alignment: 'orp',
+    });
+    await mountOverlay(getListener);
+    expect(getHost().getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('orp');
+
+    emitStorageChange({ ...DEFAULT_SETTINGS, alignment: 'center' });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getHost().getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('center');
+  });
+});

--- a/src/chrome/content/index.ts
+++ b/src/chrome/content/index.ts
@@ -276,6 +276,12 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
             // reconstruction required); changes apply on next overlay
             // mount.
             chunkSize: settings.chunkSize,
+            // #52 PART A — ORP alignment. Drives the host
+            // `data-alignment` attribute that styles.ts consumes via
+            // `:host([data-alignment="…"])` selectors. Live-updated
+            // via subscribeSettings below so a user can toggle modes
+            // mid-session.
+            alignment: settings.alignment,
           },
           subscribeSettings: (listener) =>
             subscribeSettings((s) =>
@@ -286,6 +292,7 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
                 openDyslexic: s.openDyslexic,
                 font: resolveFontId(s),
                 chunkSize: s.chunkSize,
+                alignment: s.alignment,
               }),
             ),
           // OpenDyslexic font URL (#27, #10). `core/` cannot call

--- a/src/core/overlay/__tests__/alignment-wire.test.ts
+++ b/src/core/overlay/__tests__/alignment-wire.test.ts
@@ -104,6 +104,43 @@ describe('createOverlay — alignment wire-up (#52 PART A)', () => {
     overlay.unmount();
   });
 
+  test('alignment mid-emission: live push does NOT rebuild word DOM (CSS-only switch)', () => {
+    // Test-gap MED #5 — alignment is a CSS-only switch (data-alignment on
+    // host drives :host([data-alignment="…"]) selectors). The overlay
+    // MUST NOT call renderWord / renderChunk on a subscribeSettings push;
+    // doing so would cause a flash of layout swap mid-emission. We assert
+    // by capturing the rendered .word-run shape BEFORE and AFTER the
+    // push and confirming identity (same element instance).
+    let notify: SettingsSubscriber = () => undefined;
+    const overlay = createOverlay(
+      defaultOpts({
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, alignment: 'orp' },
+        subscribeSettings: (cb) => {
+          notify = cb;
+          return () => undefined;
+        },
+      }),
+    );
+    overlay.mount();
+    const host = getHost();
+    const region = host.shadowRoot?.querySelector('.word-region');
+    if (!region) throw new Error('missing word-region');
+    const runBefore = region.querySelector('.word-run');
+    if (!runBefore) throw new Error('expected .word-run before push');
+    const childrenBefore = Array.from(runBefore.children);
+    // Push alignment change.
+    notify({ theme: 'system', wpm: 300, fontSize: 20, alignment: 'center' });
+    // Host attribute flipped (live update works).
+    expect(host.getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('center');
+    // Word DOM is UNCHANGED — same element instance, same children.
+    const runAfter = region.querySelector('.word-run');
+    expect(runAfter).toBe(runBefore);
+    if (!runAfter) throw new Error('expected .word-run after push');
+    const childrenAfter = Array.from(runAfter.children);
+    expect(childrenAfter).toEqual(childrenBefore);
+    overlay.unmount();
+  });
+
   test('subscribeSettings echo with same alignment does not churn the attribute', () => {
     // No observable side-effect to assert beyond "no throw and value stays
     // the same" — but a regression that always re-wrote the attribute would

--- a/src/core/overlay/__tests__/alignment-wire.test.ts
+++ b/src/core/overlay/__tests__/alignment-wire.test.ts
@@ -1,0 +1,152 @@
+/**
+ * alignment-wire.test.ts — issue #52 PART A
+ *
+ * Wires `OverlaySettings.alignment` through to a `data-alignment` host
+ * attribute. The schema slot existed at V6 but the overlay didn't read
+ * it — switching to `'center'` was a silent no-op.
+ *
+ * Mutation guards:
+ *   - Dropping the host.setAttribute('data-alignment', …) at mount fails
+ *     the mount-time assertion.
+ *   - Dropping the subscribeSettings alignment update fails the
+ *     live-push assertion.
+ *   - Defaulting to `'center'` (wrong default) fails the unspecified-
+ *     setting test (must default to 'orp').
+ *   - A regression that wrote the attribute on the modal (not the host)
+ *     fails the host-attribute assertion.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createOverlay } from '../overlay';
+import type { OverlayOptions, OverlaySettings, SettingsSubscriber } from '../types';
+import { createRsvpEngine } from '../../rsvp-engine';
+import { OVERLAY_ATTR } from '../constants';
+
+function defaultOpts(overrides: Partial<OverlayOptions> = {}): OverlayOptions {
+  return {
+    doc: document,
+    words: ['Hello.', 'How', 'are', 'you?'],
+    initialSettings: { theme: 'system', wpm: 300, fontSize: 20 },
+    subscribeSettings: () => () => undefined,
+    engineFactory: createRsvpEngine,
+    ...overrides,
+  };
+}
+
+function getHost(): HTMLElement {
+  const el = document.body.querySelector(`[${OVERLAY_ATTR.HOST}]`);
+  if (!(el instanceof HTMLElement)) throw new Error('overlay host missing');
+  return el;
+}
+
+describe('createOverlay — alignment wire-up (#52 PART A)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    document.querySelectorAll(`[${OVERLAY_ATTR.HOST}]`).forEach((n) => n.remove());
+    vi.useRealTimers();
+  });
+
+  test('mount with alignment="orp" writes data-alignment="orp" on host', () => {
+    const overlay = createOverlay(
+      defaultOpts({
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, alignment: 'orp' },
+      }),
+    );
+    overlay.mount();
+    expect(getHost().getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('orp');
+    overlay.unmount();
+  });
+
+  test('mount with alignment="center" writes data-alignment="center" on host', () => {
+    const overlay = createOverlay(
+      defaultOpts({
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, alignment: 'center' },
+      }),
+    );
+    overlay.mount();
+    expect(getHost().getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('center');
+    overlay.unmount();
+  });
+
+  test('mount with alignment omitted defaults to "orp"', () => {
+    const overlay = createOverlay(
+      defaultOpts({
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20 },
+      }),
+    );
+    overlay.mount();
+    expect(getHost().getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('orp');
+    overlay.unmount();
+  });
+
+  test('subscribeSettings push from orp → center updates host attribute', () => {
+    let notify: SettingsSubscriber = () => undefined;
+    const overlay = createOverlay(
+      defaultOpts({
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, alignment: 'orp' },
+        subscribeSettings: (cb) => {
+          notify = cb;
+          return () => undefined;
+        },
+      }),
+    );
+    overlay.mount();
+    expect(getHost().getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('orp');
+    const next: OverlaySettings = {
+      theme: 'system',
+      wpm: 300,
+      fontSize: 20,
+      alignment: 'center',
+    };
+    notify(next);
+    expect(getHost().getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('center');
+    overlay.unmount();
+  });
+
+  test('subscribeSettings echo with same alignment does not churn the attribute', () => {
+    // No observable side-effect to assert beyond "no throw and value stays
+    // the same" — but a regression that always re-wrote the attribute would
+    // still pass this; the guard is the explicit currentAlignment !==
+    // s.alignment short-circuit in overlay.ts. This test pins the contract
+    // that echo emissions are tolerated.
+    let notify: SettingsSubscriber = () => undefined;
+    const overlay = createOverlay(
+      defaultOpts({
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, alignment: 'center' },
+        subscribeSettings: (cb) => {
+          notify = cb;
+          return () => undefined;
+        },
+      }),
+    );
+    overlay.mount();
+    notify({ theme: 'system', wpm: 300, fontSize: 20, alignment: 'center' });
+    expect(getHost().getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('center');
+    overlay.unmount();
+  });
+});
+
+describe('OVERLAY_CSS — alignment selectors (#52 PART A)', () => {
+  test('stylesheet scopes a word-run grid under :host([data-alignment="orp"])', async () => {
+    const { OVERLAY_CSS } = await import('../styles');
+    // The orp branch must define the 3-column grid on .word-run so the
+    // focus character anchors at the center column across successive runs.
+    expect(OVERLAY_CSS).toMatch(
+      /:host\(\[data-alignment="orp"\]\)\s+\.word-run\s*\{[^}]*display:\s*grid/,
+    );
+    expect(OVERLAY_CSS).toMatch(
+      /:host\(\[data-alignment="orp"\]\)\s+\.word-run\s*\{[^}]*grid-template-columns:\s*1fr\s+auto\s+1fr/,
+    );
+  });
+
+  test('stylesheet scopes a centered layout under :host([data-alignment="center"])', async () => {
+    const { OVERLAY_CSS } = await import('../styles');
+    // Center mode must override the orp grid by reverting display on
+    // .word-run. The `text-align: center` on the parent .word-region
+    // continues to centre the inline content.
+    expect(OVERLAY_CSS).toMatch(
+      /:host\(\[data-alignment="center"\]\)\s+\.word-run\s*\{[^}]*display:\s*block/,
+    );
+  });
+});

--- a/src/core/overlay/__tests__/chunk-orp.test.ts
+++ b/src/core/overlay/__tests__/chunk-orp.test.ts
@@ -125,6 +125,48 @@ describe('renderChunk — per-word ORP render (#52 PART C)', () => {
     expect(region.childNodes).toHaveLength(1);
     expect(region.querySelectorAll(`.${OVERLAY_CLASS.WORD_RUN}`)).toHaveLength(1);
   });
+
+  test('empty-string word inside chunk — no throw, still emits N runs each with focus span', () => {
+    // Test-gap MED #3 — degenerate input edge. Engine guards against
+    // emitting empty chunks in practice, but renderChunk MUST tolerate an
+    // empty-string word (splitWordAtFocus has its own empty-input guard
+    // returning all-empty parts; dropping that guard would crash here).
+    const doc = document.implementation.createHTMLDocument('t');
+    const region = doc.createElement('div');
+    expect(() => renderChunk(region, '', ['', 'b'])).not.toThrow();
+    const runs = region.querySelectorAll(`.${OVERLAY_CLASS.WORD_RUN}`);
+    expect(runs).toHaveLength(2);
+    // Each run still has a .focus span (even if textContent is empty for
+    // the empty-string word) — structural invariant preserved.
+    for (const run of runs) {
+      expect(run.querySelectorAll('.focus')).toHaveLength(1);
+    }
+  });
+
+  test('whitespace-only words inside chunk — no throw, structurally intact', () => {
+    // Test-gap MED #3 — whitespace-only tokens (' ', '\t'). Tokenizer
+    // strips these in practice, but renderChunk's contract is to render
+    // whatever it's given without crashing.
+    const doc = document.implementation.createHTMLDocument('t');
+    const region = doc.createElement('div');
+    expect(() => renderChunk(region, '  ', [' ', 'b'])).not.toThrow();
+    const runs = region.querySelectorAll(`.${OVERLAY_CLASS.WORD_RUN}`);
+    expect(runs).toHaveLength(2);
+  });
+
+  test('single-word chunk with single-char word — no throw, exactly one .focus span', () => {
+    // Test-gap MED #3 — short-word edge (orp() returns 0 for stripped
+    // length <= 3 → focus index 0). Verifies the boundary path through
+    // splitWordAtFocus.
+    const doc = document.implementation.createHTMLDocument('t');
+    const region = doc.createElement('div');
+    expect(() => renderChunk(region, 'a', ['a'])).not.toThrow();
+    expect(region.querySelectorAll(`.${OVERLAY_CLASS.WORD_RUN}`)).toHaveLength(1);
+    expect(region.querySelectorAll('.focus')).toHaveLength(1);
+    // Focus char IS 'a' (the entire word, idx 0).
+    const focus = region.querySelector('.focus');
+    expect(focus?.textContent).toBe('a');
+  });
 });
 
 describe('createOverlay — chunk ORP integration (#52 PART C)', () => {

--- a/src/core/overlay/__tests__/chunk-orp.test.ts
+++ b/src/core/overlay/__tests__/chunk-orp.test.ts
@@ -1,0 +1,178 @@
+/**
+ * chunk-orp.test.ts — issue #52 PART C (#51 Q3 deferred)
+ *
+ * Chunk events in #51 rendered `ev.text` (the full joined chunk string)
+ * via `renderWord`, which called `splitWordAtFocus` on the WHOLE chunk.
+ * Result: nonsense ORP split on multi-word strings (`splitWordAtFocus`
+ * of `"The quick"` returned `focus = 'e'` somewhere in the middle, not
+ * one focus character per word).
+ *
+ * Fix: new `renderChunk(region, chunkText, chunkWords)` renders each
+ * word as its own .word-run with before/focus/after spans; runs
+ * separated by space text nodes. The chunk text remains the aria-live
+ * value (single readable unit) — that's covered in chunk-render.test.ts.
+ *
+ * Mutation guards:
+ *   - Falling back to renderWord(region, ev.text) fails the per-word
+ *     focus-count assertion (1 focus vs N=words.length focuses).
+ *   - Omitting space text nodes fails the joined-textContent assertion.
+ *   - Wrapping words in the wrong tag (no .word-run class) fails the
+ *     selector-bound assertion.
+ *   - Setting focus class on the wrong word index fails the
+ *     per-word-spans-order assertion.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createOverlay } from '../overlay';
+import type { OverlayOptions } from '../types';
+import { createRsvpEngine } from '../../rsvp-engine';
+import { OVERLAY_CLASS } from '../constants';
+import { renderChunk } from '../word';
+
+function getShadow(): ShadowRoot {
+  const host = document.body.querySelector('[data-speedreader-overlay]');
+  if (!(host instanceof HTMLElement) || !host.shadowRoot) {
+    throw new Error('overlay host missing or no shadow root');
+  }
+  return host.shadowRoot;
+}
+
+function getRegion(): HTMLElement {
+  const el = getShadow().querySelector<HTMLElement>(`.${OVERLAY_CLASS.WORD_REGION}`);
+  if (!el) throw new Error('overlay shadow: missing word-region');
+  return el;
+}
+
+function defaultOpts(overrides: Partial<OverlayOptions> = {}): OverlayOptions {
+  return {
+    doc: document,
+    words: ['The', 'quick', 'brown', 'fox.'],
+    initialSettings: { theme: 'system', wpm: 300, fontSize: 20, chunkSize: 2 },
+    subscribeSettings: () => () => undefined,
+    engineFactory: createRsvpEngine,
+    ...overrides,
+  };
+}
+
+describe('renderChunk — per-word ORP render (#52 PART C)', () => {
+  test('renders N .word-run children for N chunk words', () => {
+    const doc = document.implementation.createHTMLDocument('t');
+    const region = doc.createElement('div');
+    renderChunk(region, 'The quick', ['The', 'quick']);
+    const runs = region.querySelectorAll(`.${OVERLAY_CLASS.WORD_RUN}`);
+    expect(runs).toHaveLength(2);
+  });
+
+  test('each word-run contains exactly one .focus span (per-word ORP)', () => {
+    const doc = document.implementation.createHTMLDocument('t');
+    const region = doc.createElement('div');
+    renderChunk(region, 'The quick brown', ['The', 'quick', 'brown']);
+    const runs = region.querySelectorAll(`.${OVERLAY_CLASS.WORD_RUN}`);
+    expect(runs).toHaveLength(3);
+    for (const run of runs) {
+      const focuses = run.querySelectorAll('.focus');
+      expect(focuses).toHaveLength(1);
+    }
+  });
+
+  test('each word-run has three spans (before / focus / after)', () => {
+    const doc = document.implementation.createHTMLDocument('t');
+    const region = doc.createElement('div');
+    renderChunk(region, 'quick brown', ['quick', 'brown']);
+    const runs = region.querySelectorAll(`.${OVERLAY_CLASS.WORD_RUN}`);
+    for (const run of runs) {
+      // each run has exactly 3 immediate <span> children
+      const spans = run.querySelectorAll(':scope > span');
+      expect(spans).toHaveLength(3);
+      expect(spans[1].classList.contains('focus')).toBe(true);
+    }
+  });
+
+  test('word-runs are separated by space text nodes', () => {
+    const doc = document.implementation.createHTMLDocument('t');
+    const region = doc.createElement('div');
+    renderChunk(region, 'a b c', ['a', 'b', 'c']);
+    // Expected child sequence: run, space-text, run, space-text, run
+    const children = Array.from(region.childNodes);
+    expect(children).toHaveLength(5);
+    expect((children[0] as Element).className).toContain(OVERLAY_CLASS.WORD_RUN);
+    expect(children[1].nodeType).toBe(Node.TEXT_NODE);
+    expect(children[1].textContent).toBe(' ');
+    expect((children[2] as Element).className).toContain(OVERLAY_CLASS.WORD_RUN);
+    expect(children[3].textContent).toBe(' ');
+    expect((children[4] as Element).className).toContain(OVERLAY_CLASS.WORD_RUN);
+  });
+
+  test('joined textContent preserves the visible chunk string', () => {
+    const doc = document.implementation.createHTMLDocument('t');
+    const region = doc.createElement('div');
+    renderChunk(region, 'The quick brown', ['The', 'quick', 'brown']);
+    expect(region.textContent).toBe('The quick brown');
+  });
+
+  test('repeated calls replace prior content', () => {
+    const doc = document.implementation.createHTMLDocument('t');
+    const region = doc.createElement('div');
+    renderChunk(region, 'first second', ['first', 'second']);
+    renderChunk(region, 'third', ['third']);
+    expect(region.textContent).toBe('third');
+    expect(region.querySelectorAll(`.${OVERLAY_CLASS.WORD_RUN}`)).toHaveLength(1);
+  });
+
+  test('single-word chunk renders one word-run (no trailing space text node)', () => {
+    const doc = document.implementation.createHTMLDocument('t');
+    const region = doc.createElement('div');
+    renderChunk(region, 'solo', ['solo']);
+    expect(region.childNodes).toHaveLength(1);
+    expect(region.querySelectorAll(`.${OVERLAY_CLASS.WORD_RUN}`)).toHaveLength(1);
+  });
+});
+
+describe('createOverlay — chunk ORP integration (#52 PART C)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+    vi.useRealTimers();
+  });
+
+  test('chunk-mode emission renders one .focus per word in the chunk (not one per chunk-text)', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    // First chunk: "The quick" (chunkSize=2). The pre-fix render path called
+    // renderWord(region, "The quick") which produced ONE .focus span on
+    // splitWordAtFocus("The quick"). The fix renders two .word-run children,
+    // each with its own .focus — total 2.
+    const region = getRegion();
+    const focuses = region.querySelectorAll('.focus');
+    expect(focuses).toHaveLength(2);
+    overlay.unmount();
+  });
+
+  test('single-word mode (chunkSize=1) renders exactly one .word-run with one .focus', () => {
+    const overlay = createOverlay(
+      defaultOpts({
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, chunkSize: 1 },
+      }),
+    );
+    overlay.mount();
+    const region = getRegion();
+    // chunkSize=1 → word events, renderWord path → ONE .word-run wrapper
+    // (the wrapper is the grid container the orp-alignment CSS consumes,
+    // shared between single-word and chunk modes).
+    expect(region.querySelectorAll(`.${OVERLAY_CLASS.WORD_RUN}`)).toHaveLength(1);
+    // Exactly one .focus span (per-word ORP, single word).
+    const focuses = region.querySelectorAll('.focus');
+    expect(focuses).toHaveLength(1);
+    overlay.unmount();
+  });
+
+  test('chunk-mode visible text matches ev.text (aria-live announces full chunk)', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    expect(getRegion().textContent).toBe('The quick');
+    const live = getShadow().querySelector('[aria-live="polite"]');
+    expect(live?.textContent).toBe('The quick');
+    overlay.unmount();
+  });
+});

--- a/src/core/overlay/__tests__/scrubber-autohide.test.ts
+++ b/src/core/overlay/__tests__/scrubber-autohide.test.ts
@@ -1,0 +1,254 @@
+/**
+ * scrubber-autohide.test.ts — issue #52 PART D (#47 deferred + #206)
+ *
+ * Auto-hide chrome during active playback so the user's eye stays on the
+ * word region (matches Safari spec). Visibility state machine:
+ *
+ *   Hidden: engine.state === 'playing' AND no hover AND no focus-within
+ *           AND not mid-scrub
+ *   Visible: otherwise (paused, idle, done, hover, focus-within, mid-scrub)
+ *
+ * Mutation guards:
+ *   - Forgetting to hide on play fails the play-state assertion.
+ *   - Hiding while paused fails the paused-state assertion.
+ *   - display:none usage (instead of visibility/opacity) is detected via
+ *     computed-style check on opacity / pointer-events.
+ *   - Hiding while mid-scrub fails the scrub-active assertion (lose
+ *     scrubber while user is dragging = catastrophic UX).
+ *   - Hiding while focus-within fails the focus-retention assertion
+ *     (user tabbed to scrubber and lost focus on play).
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createOverlay } from '../overlay';
+import type { OverlayOptions } from '../types';
+import { createRsvpEngine, type RsvpEngine, type RsvpEngineOptions } from '../../rsvp-engine';
+import { OVERLAY_CLASS } from '../constants';
+
+const STREAM = ['Hello.', 'How', 'are', 'you?', 'I', 'am', 'fine.', 'Bye!'];
+
+type Holder = { engine: RsvpEngine | null };
+
+function defaultOpts(holder: Holder, overrides: Partial<OverlayOptions> = {}): OverlayOptions {
+  return {
+    doc: document,
+    words: STREAM.slice(),
+    initialSettings: { theme: 'system', wpm: 300, fontSize: 20 },
+    subscribeSettings: () => () => undefined,
+    engineFactory: (o: RsvpEngineOptions) => {
+      holder.engine = createRsvpEngine(o);
+      return holder.engine;
+    },
+    ...overrides,
+  };
+}
+
+function getShadow(): ShadowRoot {
+  const host = document.body.querySelector('[data-speedreader-overlay]');
+  if (!(host instanceof HTMLElement) || !host.shadowRoot) {
+    throw new Error('overlay host missing or no shadow root');
+  }
+  return host.shadowRoot;
+}
+
+function getArea(): HTMLElement {
+  const el = getShadow().querySelector<HTMLElement>(`.${OVERLAY_CLASS.SCRUBBER_AREA}`);
+  if (!el) throw new Error('overlay shadow: missing scrubber-area');
+  return el;
+}
+
+function isHidden(area: HTMLElement): boolean {
+  // The contract: opacity 0 + visibility hidden + pointer-events none
+  // (NEVER display:none — would collapse the layout slot and reflow).
+  // Reads the dataset flag we toggle (more reliable than computed style
+  // in jsdom which doesn't compute :host transitions). The flag mirrors
+  // the visible-state computation.
+  return area.dataset.hidden === 'true';
+}
+
+function engineOf(holder: Holder): RsvpEngine {
+  if (!holder.engine) throw new Error('engine not yet created');
+  return holder.engine;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+});
+
+describe('createOverlay — scrubber visibility state machine (#52 PART D)', () => {
+  test('engine playing + no hover + no focus → scrubber hidden', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    overlay.mount();
+    expect(engineOf(holder).state).toBe('playing');
+    expect(isHidden(getArea())).toBe(true);
+    overlay.unmount();
+  });
+
+  test('engine paused → scrubber visible', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    overlay.mount();
+    engineOf(holder).pause();
+    // togglePlayPause / pause via the play/pause btn drives the
+    // visibility recomputation. Calling pause() directly does too via
+    // the reflectEngineState → recomputeScrubberVisibility path.
+    const playPauseBtn = getShadow().querySelector<HTMLButtonElement>(
+      `.${OVERLAY_CLASS.PLAY_PAUSE_BTN}`,
+    );
+    if (!playPauseBtn) throw new Error('expected play-pause-btn');
+    // Synthesise the click path that the user would take (also exercises
+    // the recompute call inside togglePlayPause).
+    // engine.pause() above already moved state to paused; click would
+    // resume. So just call recompute via a state-driven event: trigger
+    // a no-op input on the scrubber to land in beginScrubSession, then
+    // step out. Simpler: rely on the post-pause recompute that the
+    // mounted overlay performs via reflectEngineState. The play/pause
+    // btn handler calls reflectEngineState after pause/resume which in
+    // turn triggers visibility recomputation.
+    // We already paused via engineOf().pause(); the engine state is now
+    // 'paused'. The visibility computation must read engine.state and
+    // surface visible. Force a recompute by dispatching mouseenter then
+    // mouseleave (cheap and deterministic).
+    const area = getArea();
+    area.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    area.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+    expect(isHidden(area)).toBe(false);
+    overlay.unmount();
+  });
+
+  test('engine playing + hover → scrubber visible', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    overlay.mount();
+    expect(engineOf(holder).state).toBe('playing');
+    const area = getArea();
+    expect(isHidden(area)).toBe(true);
+    area.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    expect(isHidden(area)).toBe(false);
+    overlay.unmount();
+  });
+
+  test('engine playing + hover then mouseleave → scrubber hidden again', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    overlay.mount();
+    const area = getArea();
+    area.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    expect(isHidden(area)).toBe(false);
+    area.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+    expect(isHidden(area)).toBe(true);
+    overlay.unmount();
+  });
+
+  test('engine playing + scrubber focus → scrubber visible (focus retention)', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    overlay.mount();
+    const area = getArea();
+    expect(isHidden(area)).toBe(true);
+    const scrubber = getShadow().querySelector<HTMLInputElement>(
+      `.${OVERLAY_CLASS.SCRUBBER_SLIDER}`,
+    );
+    if (!scrubber) throw new Error('missing scrubber');
+    // focusin bubbles, focus does not — use focusin to match the listener
+    // we bind on .scrubber-area.
+    scrubber.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(isHidden(area)).toBe(false);
+    overlay.unmount();
+  });
+
+  test('engine playing + focus then focusout → scrubber hidden again', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    overlay.mount();
+    const area = getArea();
+    const scrubber = getShadow().querySelector<HTMLInputElement>(
+      `.${OVERLAY_CLASS.SCRUBBER_SLIDER}`,
+    );
+    if (!scrubber) throw new Error('missing scrubber');
+    scrubber.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(isHidden(area)).toBe(false);
+    scrubber.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+    expect(isHidden(area)).toBe(true);
+    overlay.unmount();
+  });
+
+  test('engine playing + mid-scrub (scrubInProgress) → scrubber stays visible even on mouseleave', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    overlay.mount();
+    const area = getArea();
+    const scrubber = getShadow().querySelector<HTMLInputElement>(
+      `.${OVERLAY_CLASS.SCRUBBER_SLIDER}`,
+    );
+    if (!scrubber) throw new Error('missing scrubber');
+    // beginScrubSession via input event sets scrubInProgress = true.
+    // After this, scrubber MUST stay visible regardless of mouseleave.
+    scrubber.value = '3';
+    scrubber.dispatchEvent(new Event('input', { bubbles: true }));
+    // The input handler pauses the engine — recompute now reads state ===
+    // 'paused' which is naturally visible. To exercise the "playing +
+    // scrubInProgress" path, we instead must check that mid-scrub keeps
+    // the bar visible. Since input pauses, this test simplifies to:
+    // immediately after input event, area is visible.
+    expect(isHidden(area)).toBe(false);
+    // Now simulate mouseleave during scrub — must still be visible.
+    area.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+    expect(isHidden(area)).toBe(false);
+    overlay.unmount();
+  });
+
+  test('engine done → scrubber visible (terminal state)', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder, { words: ['Solo.'] }));
+    overlay.mount();
+    // Engine on a single-word stream emits the word then 'done' on the
+    // next tick. Drain timers to reach 'done'.
+    vi.runAllTimers();
+    expect(engineOf(holder).state).toBe('done');
+    expect(isHidden(getArea())).toBe(false);
+    overlay.unmount();
+  });
+
+  test('scrubber uses opacity/visibility (NOT display:none) to prevent layout reflow', () => {
+    // Mutation guard: a regression that used display:none would collapse
+    // the margin-block-start slot (12-24px) and reflow the word region
+    // vertical-center on each toggle. Assert via the inline style we
+    // write — the visibility flip MUST go through opacity + visibility,
+    // NOT display.
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    overlay.mount();
+    const area = getArea();
+    // Engine is playing, area is hidden — assert the hidden-state inline
+    // style does NOT mention display.
+    expect(area.style.display).not.toBe('none');
+    // Must use opacity 0 + visibility hidden + pointer-events none.
+    expect(area.style.opacity).toBe('0');
+    expect(area.style.visibility).toBe('hidden');
+    expect(area.style.pointerEvents).toBe('none');
+    overlay.unmount();
+  });
+
+  test('OVERLAY_CSS includes opacity transition on .scrubber-area for the auto-hide animation', async () => {
+    const { OVERLAY_CSS } = await import('../styles');
+    // Mutation guard: the transition is what makes the auto-hide feel
+    // smooth. A regression that dropped the transition would produce a
+    // jarring instant flip. The selector-bound assertion catches it.
+    expect(OVERLAY_CSS).toMatch(/\.scrubber-area\s*\{[^}]*transition:[^}]*opacity/);
+  });
+
+  test('prefers-reduced-motion disables the scrubber-area transition', async () => {
+    const { OVERLAY_CSS } = await import('../styles');
+    // The reduced-motion media block must override .scrubber-area's
+    // transition to none. The block also gates backdrop/modal transitions.
+    expect(OVERLAY_CSS).toMatch(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[^]*\.scrubber-area[^}]*transition:\s*none/,
+    );
+  });
+});

--- a/src/core/overlay/__tests__/scrubber-autohide.test.ts
+++ b/src/core/overlay/__tests__/scrubber-autohide.test.ts
@@ -178,7 +178,40 @@ describe('createOverlay — scrubber visibility state machine (#52 PART D)', () 
     overlay.unmount();
   });
 
-  test('engine playing + mid-scrub (scrubInProgress) → scrubber stays visible even on mouseleave', () => {
+  test('engine playing + mid-scrub via mousedown (scrubInProgress) → scrubber stays visible on mouseleave', async () => {
+    // Real mid-scrub assertion (kills the previous tautology). The prior
+    // test fired `input` which pauses the engine before recompute runs, so
+    // `shouldHide`'s `playing && scrubInProgress && !hovered` path was
+    // never exercised. Here we fire `mousedown` (which calls
+    // beginScrubSession AND scrubFromPause — but scrubFromPause only
+    // pauses when state IS 'playing'; the engine state IS still
+    // 'playing' BEFORE the pause runs, so the resulting state after
+    // mousedown is 'paused' regardless).
+    //
+    // The honest way to exercise the playing+scrubInProgress branch is
+    // to: (a) start playing, (b) flip scrubInProgress = true via a
+    // mousedown (this happens BEFORE scrubFromPause inside the same
+    // listener — beginScrubSession's recompute call observes
+    // engine.state === 'playing' AND scrubInProgress === true and
+    // therefore must NOT hide). We assert two things:
+    //   1. AFTER mousedown, the engine has transitioned to paused (which
+    //      itself keeps the bar visible — separate path).
+    //   2. BEFORE the input event arrives, the bar is visible because of
+    //      the scrubInProgress flag, not because of pause.
+    //
+    // To pin the scrubInProgress contribution specifically, we use the
+    // hover-then-leave sequence with engine still playing: prime
+    // scrubInProgress directly by hovering+mousedown, mouseleave, assert
+    // visible. The engine pause is a side-effect of scrubFromPause but
+    // the recompute fired inside beginScrubSession (BEFORE scrubFromPause)
+    // observes `playing && scrubInProgress && !hovered` — that recompute
+    // proves the path.
+    //
+    // Mutation guard (verified locally): dropping `&& !scrubInProgress`
+    // from `shouldHide` in overlay.ts causes this test to fail because
+    // the recompute inside beginScrubSession would hide the bar (the
+    // engine is still 'playing' at that exact moment, hover is false,
+    // focus is false).
     const holder: Holder = { engine: null };
     const overlay = createOverlay(defaultOpts(holder));
     overlay.mount();
@@ -187,19 +220,131 @@ describe('createOverlay — scrubber visibility state machine (#52 PART D)', () 
       `.${OVERLAY_CLASS.SCRUBBER_SLIDER}`,
     );
     if (!scrubber) throw new Error('missing scrubber');
-    // beginScrubSession via input event sets scrubInProgress = true.
-    // After this, scrubber MUST stay visible regardless of mouseleave.
-    scrubber.value = '3';
-    scrubber.dispatchEvent(new Event('input', { bubbles: true }));
-    // The input handler pauses the engine — recompute now reads state ===
-    // 'paused' which is naturally visible. To exercise the "playing +
-    // scrubInProgress" path, we instead must check that mid-scrub keeps
-    // the bar visible. Since input pauses, this test simplifies to:
-    // immediately after input event, area is visible.
+    expect(engineOf(holder).state).toBe('playing');
+    expect(isHidden(area)).toBe(true);
+    // Spy on every direct write to area.style.opacity. The mousedown
+    // handler runs synchronously:
+    //   1. beginScrubSession() → recompute (engine still 'playing',
+    //      scrubInProgress now true). With the guard, shouldHide=false,
+    //      opacity is written to '1'. Without the guard (mutation),
+    //      shouldHide=true, opacity is written to '0' — the mutation
+    //      reveal.
+    //   2. scrubFromPause() → engine.pause() → reflectEngineState →
+    //      recompute (engine now 'paused', shouldHide=false), opacity
+    //      written to '1'.
+    //
+    // With guard: observed opacity writes = ['1', '1']
+    // Without guard: observed opacity writes = ['0', '1']
+    //
+    // Asserting that no '0' write happens during the mousedown handler
+    // proves the scrubInProgress guard is present.
+    const opacityWrites: string[] = [];
+    // Save original style descriptor so we can restore it later.
+    const styleObj = area.style;
+    const origOpacityDescriptor = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(styleObj),
+      'opacity',
+    );
+    Object.defineProperty(styleObj, 'opacity', {
+      configurable: true,
+      get() {
+        return origOpacityDescriptor?.get?.call(this);
+      },
+      set(v: string) {
+        opacityWrites.push(v);
+        origOpacityDescriptor?.set?.call(this, v);
+      },
+    });
+    scrubber.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    // Restore the original descriptor so subsequent test cleanup is
+    // unaffected.
+    delete (styleObj as unknown as { opacity?: string }).opacity;
+    if (origOpacityDescriptor) {
+      Object.defineProperty(styleObj, 'opacity', origOpacityDescriptor);
+    }
+    // Final state: visible (paused).
     expect(isHidden(area)).toBe(false);
-    // Now simulate mouseleave during scrub — must still be visible.
+    expect(engineOf(holder).state).toBe('paused');
+    // No '0' write during the mousedown handler — the scrubInProgress
+    // guard kept the first recompute on the visible branch even though
+    // engine.state was still 'playing'. A regression that drops the
+    // `&& !scrubInProgress` check would write '0' first, then '1'.
+    expect(opacityWrites).not.toContain('0');
+    // At least one '1' write (the second recompute after pause).
+    expect(opacityWrites).toContain('1');
+    // Mouseleave during scrub session — paused state keeps it visible
+    // regardless, but the scrubInProgress flag also independently does.
     area.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
     expect(isHidden(area)).toBe(false);
+    overlay.unmount();
+  });
+
+  test('focus-driven reveal during playback is instant (no fade) — A11y MED #3', () => {
+    // WCAG SC 2.4.7 — focus indicator must be visible at the moment focus
+    // is received. The auto-hide fade (200ms) would leave the focus
+    // indicator at < 100% opacity during the fade. recomputeScrubberVisibility
+    // skips the transition specifically for hidden→visible transitions
+    // driven by focus.
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    overlay.mount();
+    const area = getArea();
+    expect(engineOf(holder).state).toBe('playing');
+    expect(isHidden(area)).toBe(true);
+    const scrubber = getShadow().querySelector<HTMLInputElement>(
+      `.${OVERLAY_CLASS.SCRUBBER_SLIDER}`,
+    );
+    if (!scrubber) throw new Error('missing scrubber');
+    scrubber.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    // After focusin: visible AND inline transition must be 'none' so the
+    // opacity is honored at 1 immediately, not animated over 200ms.
+    expect(isHidden(area)).toBe(false);
+    expect(area.style.opacity).toBe('1');
+    expect(area.style.visibility).toBe('visible');
+    expect(area.style.transition).toBe('none');
+    overlay.unmount();
+  });
+
+  test('rapid play/pause/play state thrash settles to a consistent final visibility', () => {
+    // Synchronous play/pause sequences must NOT desync the visibility
+    // state from the engine state. A regression that batched visibility
+    // writes via RAF (or a stale closure capturing engine.state) would
+    // leave the bar in an outdated state after the last toggle.
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    overlay.mount();
+    const area = getArea();
+    const playPauseBtn = getShadow().querySelector<HTMLButtonElement>(
+      `.${OVERLAY_CLASS.PLAY_PAUSE_BTN}`,
+    );
+    if (!playPauseBtn) throw new Error('missing play-pause-btn');
+    // Sequence A: pause/resume/pause → final state paused → bar visible.
+    playPauseBtn.click(); // pause
+    playPauseBtn.click(); // resume
+    playPauseBtn.click(); // pause
+    expect(engineOf(holder).state).toBe('paused');
+    expect(isHidden(area)).toBe(false);
+    // Sequence B: resume/pause/resume → final state playing → bar hidden
+    // (assuming no hover/focus, which is the default in jsdom).
+    playPauseBtn.click(); // resume
+    playPauseBtn.click(); // pause
+    playPauseBtn.click(); // resume
+    expect(engineOf(holder).state).toBe('playing');
+    expect(isHidden(area)).toBe(true);
+    overlay.unmount();
+  });
+
+  test('scrubberArea resolves to a .scrubber-area-classed element on mount (markup sanity)', () => {
+    // LOW #6 — guard against future markup refactors that reparent the
+    // scrubber under a non-.scrubber-area wrapper. The recompute reads
+    // scrubber.parentElement, so this sanity check catches both a missing
+    // class AND a missing parent.
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    overlay.mount();
+    const area = getArea();
+    expect(area).toBeInstanceOf(HTMLElement);
+    expect(area.classList.contains(OVERLAY_CLASS.SCRUBBER_AREA)).toBe(true);
     overlay.unmount();
   });
 
@@ -250,5 +395,45 @@ describe('createOverlay — scrubber visibility state machine (#52 PART D)', () 
     expect(OVERLAY_CSS).toMatch(
       /@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[^]*\.scrubber-area[^}]*transition:\s*none/,
     );
+  });
+
+  test('touch-primary .word-region uses flex+wrap layout (chunk-mode regression guard — architect H1)', async () => {
+    // SHIP BLOCKER for #52. The base .word-region rule uses
+    // `display: flex; flex-wrap: wrap; justify-content: center` so multiple
+    // .word-run siblings inside a chunk flow inline. The touch-primary
+    // (pointer: coarse) and (hover: none) media block previously OVERRODE
+    // .word-region with `display: grid; place-items: center`, causing
+    // multi-run chunks to stack/overlap inside a single grid cell on
+    // phones. The fix restores flex+wrap inside the touch-primary block.
+    //
+    // A regression that reintroduces `display: grid` (or any non-flex
+    // layout) inside the touch-primary .word-region rule fails this test.
+    const { OVERLAY_CSS } = await import('../styles');
+    // Extract the touch-primary media block. The /s flag (dotAll) lets `.`
+    // match across newlines inside the media block.
+    const blockMatch = OVERLAY_CSS.match(
+      /@media\s*\(pointer:\s*coarse\)\s*and\s*\(hover:\s*none\)\s*\{([^]*?)\n\}/,
+    );
+    if (!blockMatch) throw new Error('touch-primary media block missing');
+    const block = blockMatch[1];
+    // Extract the .word-region rule from inside the block. Strip CSS
+    // comments BEFORE the substantive assertions — a developer comment
+    // mentioning "display: grid" (e.g. when documenting the regression)
+    // would otherwise create a false negative.
+    const wordRegionMatch = block.match(/\.word-region\s*\{([^}]*)\}/);
+    if (!wordRegionMatch) throw new Error('.word-region rule missing inside touch-primary block');
+    const wordRegionRule = wordRegionMatch[1].replace(/\/\*[^]*?\*\//g, '');
+    // Must declare display: flex (NOT grid) so multi-run chunks render
+    // inline. Must declare flex-wrap so long chunks at handset widths
+    // break gracefully rather than overflowing the modal.
+    expect(wordRegionRule).toMatch(/display:\s*flex/);
+    expect(wordRegionRule).not.toMatch(/display:\s*grid/);
+    expect(wordRegionRule).toMatch(/flex-wrap:\s*wrap/);
+    // place-items is a grid/flex shorthand; the regression we're guarding
+    // against had place-items: center which the old display: grid
+    // honored to overlap runs in one cell. After the fix, place-items
+    // MUST NOT appear inside this rule (the base flex justify-content +
+    // align-items already centers the runs).
+    expect(wordRegionRule).not.toMatch(/place-items/);
   });
 });

--- a/src/core/overlay/__tests__/word.test.ts
+++ b/src/core/overlay/__tests__/word.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from 'vitest';
 import { renderWord } from '../word';
+import { OVERLAY_CLASS } from '../constants';
 
 describe('renderWord', () => {
-  test('writes three spans (before / focus / after) into the target element', () => {
+  test('writes a .word-run wrapper with three child spans (before / focus / after)', () => {
     const doc = document.implementation.createHTMLDocument('t');
     const region = doc.createElement('div');
     renderWord(region, 'example');
-    const spans = region.querySelectorAll('span');
+    const runs = region.querySelectorAll(`.${OVERLAY_CLASS.WORD_RUN}`);
+    expect(runs).toHaveLength(1);
+    const spans = runs[0].querySelectorAll(':scope > span');
     expect(spans).toHaveLength(3);
     expect(spans[0].textContent).toBe('ex');
     expect(spans[1].textContent).toBe('a');
@@ -18,7 +21,8 @@ describe('renderWord', () => {
     const doc = document.implementation.createHTMLDocument('t');
     const region = doc.createElement('div');
     renderWord(region, 'hi');
-    const spans = region.querySelectorAll('span');
+    const runs = region.querySelectorAll(`.${OVERLAY_CLASS.WORD_RUN}`);
+    const spans = runs[0].querySelectorAll(':scope > span');
     expect(spans[0].textContent).toBe('');
     expect(spans[1].textContent).toBe('h');
     expect(spans[2].textContent).toBe('i');
@@ -32,12 +36,16 @@ describe('renderWord', () => {
     expect(region.textContent).toBe('second');
   });
 
-  test('empty word clears region', () => {
+  test('empty word clears region textContent but keeps the .word-run wrapper', () => {
     const doc = document.implementation.createHTMLDocument('t');
     const region = doc.createElement('div');
     renderWord(region, 'preset');
     renderWord(region, '');
     expect(region.textContent).toBe('');
-    expect(region.querySelectorAll('span')).toHaveLength(3);
+    // Still emits a wrapper with three empty spans (degenerate empty-word
+    // contract; the engine never emits empty words in practice).
+    const runs = region.querySelectorAll(`.${OVERLAY_CLASS.WORD_RUN}`);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].querySelectorAll(':scope > span')).toHaveLength(3);
   });
 });

--- a/src/core/overlay/constants.ts
+++ b/src/core/overlay/constants.ts
@@ -19,6 +19,15 @@ export const OVERLAY_CLASS = Object.freeze({
   SCOPE_HEADER: 'scope-header',
   SCOPE_SUBTITLE: 'scope-subtitle',
   WORD_REGION: 'word-region',
+  /**
+   * Per-word wrapper inside `.word-region` (#52). Always present (one
+   * per word in single-word mode, N per chunk in chunk mode). Carries
+   * the 3-column ORP grid when `data-alignment="orp"` so each word's
+   * focus character anchors at the same horizontal position across
+   * successive runs. In chunk mode, multiple word-runs are separated
+   * by space text nodes inside `.word-region`.
+   */
+  WORD_RUN: 'word-run',
   ARIA_LIVE: 'aria-live',
   TRAP_SENTINEL: 'trap-sentinel',
   CLOSE_BTN: 'close-btn',
@@ -59,6 +68,14 @@ export const OVERLAY_ID = Object.freeze({
 /** HTML attribute names owned by the overlay (e.g., the host marker). */
 export const OVERLAY_ATTR = Object.freeze({
   HOST: 'data-speedreader-overlay',
+  /**
+   * Word alignment (#52). Written on the host element with values
+   * `'orp'` (default — 3-column ORP-aligned grid) or `'center'`
+   * (centered inline layout). `styles.ts` consumes via
+   * `:host([data-alignment="…"])` selectors. Matches the Safari
+   * upstream pattern (`docs/superpowers/specs/2026-04-04-orp-alignment-design.md`).
+   */
+  ALIGNMENT: 'data-alignment',
 });
 
 /**

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -704,16 +704,54 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     let scrubberHovered = false;
     let scrubberFocused = false;
     const scrubberArea = scrubber.parentElement;
+    // visibility:hidden removes the element from the AT rotor during playback —
+    // intentional reduction of noise; user can still discover via voice control
+    // because the label is preserved.
     const recomputeScrubberVisibility = (): void => {
       if (!scrubberArea) return;
       const playing = engine?.state === 'playing';
       const shouldHide = playing && !scrubberHovered && !scrubberFocused && !scrubInProgress;
+      const wasHidden = scrubberArea.dataset.hidden === 'true';
       if (shouldHide) {
         scrubberArea.style.opacity = '0';
         scrubberArea.style.visibility = 'hidden';
         scrubberArea.style.pointerEvents = 'none';
         scrubberArea.dataset.hidden = 'true';
       } else {
+        // A11y MED #3 — focus-reveal race. When the bar transitions
+        // hidden→visible because focus arrived (tab into the slider while
+        // the engine is playing), the 200ms CSS opacity transition would
+        // leave the focus indicator at < 100% opacity during the fade.
+        // WCAG SC 2.4.7 requires the focus indicator be visible at the
+        // moment focus is received. Skip the fade in this specific path
+        // by inlining `transition: none`, forcing a reflow, writing the
+        // visible state, then restoring the transition on the next frame
+        // so subsequent hover-driven reveals still animate.
+        if (wasHidden && scrubberFocused) {
+          scrubberArea.style.transition = 'none';
+          // Force reflow so the transition-none write takes effect before
+          // the opacity write below — without this, the browser may batch
+          // both writes and animate anyway.
+          void scrubberArea.offsetHeight;
+          scrubberArea.style.opacity = '1';
+          scrubberArea.style.visibility = 'visible';
+          scrubberArea.style.pointerEvents = '';
+          scrubberArea.dataset.hidden = 'false';
+          // Restore the CSS-declared transition on the next frame so
+          // future fade-outs / hover reveals retain the 200ms animation.
+          // requestAnimationFrame is preferred but fall back to setTimeout
+          // for environments without it (jsdom under fake timers).
+          const restoreTransition = (): void => {
+            if (scrubberArea) scrubberArea.style.transition = '';
+          };
+          const view2 = opts.doc.defaultView;
+          if (view2 && typeof view2.requestAnimationFrame === 'function') {
+            view2.requestAnimationFrame(restoreTransition);
+          } else {
+            setTimeout(restoreTransition, 0);
+          }
+          return;
+        }
         scrubberArea.style.opacity = '1';
         scrubberArea.style.visibility = 'visible';
         scrubberArea.style.pointerEvents = '';

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -11,7 +11,7 @@ import type {
   OverlayStatus,
 } from './types';
 import type { RsvpEngine } from '../rsvp-engine';
-import { renderWord } from './word';
+import { renderChunk, renderWord } from './word';
 import { buildSentenceContext } from './sentence-context';
 import { installFocusTrap } from './focus-trap';
 import {
@@ -413,6 +413,13 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     opts.doc.documentElement.style.overflow = 'hidden';
     host = opts.doc.createElement('div');
     host.setAttribute(HOST_ATTR, '');
+    // #52 PART A — alignment attribute mirrors the user's `alignment`
+    // setting on the host element. Styles in styles.ts consume via
+    // `:host([data-alignment="orp"])` / `:host([data-alignment="center"])`
+    // selectors. `subscribeSettings` updates the attribute on live push
+    // (see below). Default `'orp'` matches the schema default and the
+    // Safari upstream behaviour.
+    host.setAttribute(OVERLAY_ATTR.ALIGNMENT, opts.initialSettings.alignment ?? 'orp');
     // Critical positioning styles inline with !important so external host-page
     // CSS targeting `div` cannot override them. `:host` selector specificity
     // is (0,0,0) which any outer-document `div` rule beats; inline !important
@@ -503,6 +510,10 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     // short-circuit no-op emissions and only call `engine.setChunkSize`
     // when the value actually changed (#51 architect MED #2).
     let currentChunkSize: 1 | 2 | 3 = opts.initialSettings.chunkSize ?? 1;
+    // #52 PART A — local cache so the subscribeSettings handler can
+    // short-circuit no-op echoes and only re-write the host attribute
+    // when alignment actually changed. Default `'orp'` matches schema.
+    let currentAlignment: 'orp' | 'center' = opts.initialSettings.alignment ?? 'orp';
 
     // Single point of truth for keeping the slider + readout in sync with
     // `currentWpm`. Called from mount-time init, the ArrowUp/Down keyboard
@@ -588,6 +599,15 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
         currentChunkSize = nextChunkSize;
         engine?.setChunkSize(nextChunkSize);
       }
+      // #52 PART A — live alignment update. Flip the host attribute so
+      // the CSS `:host([data-alignment="…"])` selectors swap layout
+      // mid-session without a remount. Guarded on a real change so a
+      // no-op echo doesn't churn the attribute.
+      const nextAlignment: 'orp' | 'center' = s.alignment ?? 'orp';
+      if (nextAlignment !== currentAlignment) {
+        currentAlignment = nextAlignment;
+        host?.setAttribute(OVERLAY_ATTR.ALIGNMENT, nextAlignment);
+      }
     });
 
     const engineWords = scopeView ? scopeView.activeWords : opts.words;
@@ -663,6 +683,44 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       );
     };
 
+    // #52 PART D — scrubber visibility state machine.
+    //
+    // Hidden when ALL of:
+    //   - engine.state === 'playing'
+    //   - no hover on scrubber-area
+    //   - no focus-within scrubber-area
+    //   - not mid-scrub (scrubInProgress is false)
+    // Visible otherwise.
+    //
+    // Uses opacity + visibility + pointer-events (NOT display:none) so
+    // the layout slot stays reserved — display:none would collapse the
+    // margin-block-start and reflow the word region's vertical center
+    // every toggle, fighting RSVP cadence (FIX-5 ring-review guidance
+    // in styles.ts at the .scrubber-area block).
+    //
+    // The CSS transition (`transition: opacity 200ms ease-out, visibility
+    // 200ms`) is declared on .scrubber-area in styles.ts; prefers-reduced-
+    // motion overrides it to `transition: none`.
+    let scrubberHovered = false;
+    let scrubberFocused = false;
+    const scrubberArea = scrubber.parentElement;
+    const recomputeScrubberVisibility = (): void => {
+      if (!scrubberArea) return;
+      const playing = engine?.state === 'playing';
+      const shouldHide = playing && !scrubberHovered && !scrubberFocused && !scrubInProgress;
+      if (shouldHide) {
+        scrubberArea.style.opacity = '0';
+        scrubberArea.style.visibility = 'hidden';
+        scrubberArea.style.pointerEvents = 'none';
+        scrubberArea.dataset.hidden = 'true';
+      } else {
+        scrubberArea.style.opacity = '1';
+        scrubberArea.style.visibility = 'visible';
+        scrubberArea.style.pointerEvents = '';
+        scrubberArea.dataset.hidden = 'false';
+      }
+    };
+
     const reflectEngineState = (): void => {
       const s = engine?.state ?? 'idle';
       if (s === 'playing') {
@@ -682,6 +740,12 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
         playPauseBtn.textContent = OVERLAY_TEXT.PLAY_GLYPH;
         playPauseBtn.disabled = s === 'done';
       }
+      // Engine-state transitions can flip the auto-hide outcome (e.g.
+      // playing → paused → visible). Recompute here so any caller of
+      // reflectEngineState (togglePlayPause, swapToFull, start, done
+      // branch) keeps visibility in sync without each caller having to
+      // remember to call recompute themselves.
+      recomputeScrubberVisibility();
     };
 
     const clearPreview = (): void => {
@@ -762,14 +826,17 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
         // label follows (matches Safari spec render order).
         updateScrubber();
       } else if (ev.type === 'chunk') {
-        // #51 — multi-word display. ORP highlighting on the chunk is a
-        // separate concern (tracked as a follow-up issue); for now we
-        // render the chunk text verbatim into the word region. The
-        // aria-live region announces the whole chunk so screen readers
-        // hear the same unit the user sees. FIX-6 suppression applies
-        // here too — chunk-mode scrub would otherwise spam aria-live
-        // with replacement chunk text.
-        renderWord(word, ev.text);
+        // #51 + #52 PART C — multi-word display with per-word ORP. The
+        // pre-#52 path called `renderWord(word, ev.text)` which ran
+        // `splitWordAtFocus` over the WHOLE joined chunk string, producing
+        // a nonsensical focus position somewhere inside the join. The
+        // fix delegates to `renderChunk`, which builds one `.word-run`
+        // per chunk word (each with its own before/focus/after spans
+        // sourced from `splitWordAtFocus` on the individual word).
+        // aria-live still announces the WHOLE chunk text (single readable
+        // unit). FIX-6 suppression applies here too — chunk-mode scrub
+        // would otherwise spam aria-live with replacement chunk text.
+        renderChunk(word, ev.text, ev.words);
         if (!scrubInProgress) ariaLive.textContent = ev.text;
         if (opts.onWordAdvance && engine) {
           const p = engine.progress();
@@ -808,6 +875,12 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       engine.seekTo(resumedAt);
     }
     engine.start();
+    // #52 PART D — initial visibility computation now that engine state
+    // is settled. engine.start() emits the first word/chunk synchronously
+    // and may transition to 'done' on an empty stream; either way, the
+    // recompute below establishes the correct initial visibility before
+    // the user sees the mounted overlay.
+    recomputeScrubberVisibility();
     if (scopeView?.fallback === 'empty-selection') {
       // Overrides the word[0] textContent that fired via the subscribe
       // handler during engine.start(). The polite live-region status fires
@@ -1063,6 +1136,11 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
         scrubAnnouncementFired = true;
       }
       scrubInProgress = true;
+      // #52 PART D — scrubInProgress is an input into the auto-hide
+      // computation; recompute so a mid-drag user keeps the bar visible
+      // even if the engine state is still 'playing' (e.g. before the
+      // scrubFromPause call lands).
+      recomputeScrubberVisibility();
       // Reset the debounce window every event so a held Arrow / sustained
       // drag stays in one session.
       if (scrubDebounceTimer !== null) clearTimeout(scrubDebounceTimer);
@@ -1070,6 +1148,10 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
         scrubDebounceTimer = null;
         scrubInProgress = false;
         scrubAnnouncementFired = false;
+        // #52 PART D — scrubInProgress is now false; recompute so the
+        // bar can auto-hide if engine is back to 'playing' AND no hover
+        // / focus is active.
+        recomputeScrubberVisibility();
       }, SCRUB_DEBOUNCE_MS);
     };
     const scrubFromPause = (): void => {
@@ -1090,6 +1172,31 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       },
       { passive: true },
     );
+    // #52 PART D — hover + focus listeners drive the auto-hide override.
+    // Bound on the scrubber-area parent so hovering ANY part of the bar
+    // (including the time-label row) keeps it visible; bound to focusin /
+    // focusout (the bubbling counterparts of focus / blur) so a focused
+    // scrubber slider keeps the bar visible without each focusable child
+    // needing its own listener. The parent element is captured in
+    // `scrubberArea` (set during the recompute closure setup).
+    if (scrubberArea) {
+      scrubberArea.addEventListener('mouseenter', () => {
+        scrubberHovered = true;
+        recomputeScrubberVisibility();
+      });
+      scrubberArea.addEventListener('mouseleave', () => {
+        scrubberHovered = false;
+        recomputeScrubberVisibility();
+      });
+      scrubberArea.addEventListener('focusin', () => {
+        scrubberFocused = true;
+        recomputeScrubberVisibility();
+      });
+      scrubberArea.addEventListener('focusout', () => {
+        scrubberFocused = false;
+        recomputeScrubberVisibility();
+      });
+    }
     scrubber.addEventListener('input', () => {
       if (!engine) return;
       const raw = Number(scrubber.value);

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -286,6 +286,16 @@ export const OVERLAY_CSS = `
   inline-size: 100%;
   max-inline-size: 60ch;
   margin-inline: auto;
+  /* #52 PART D — auto-hide transition. Overlay JS toggles opacity +
+   * visibility + pointer-events inline; the 200ms ease-out transition
+   * here smooths the flip so the bar fades in/out rather than blinking.
+   * Visibility is transitioned alongside opacity so the bar becomes
+   * non-interactive at the right moment (visibility:hidden takes effect
+   * at the END of the transition for fade-out; the simultaneous
+   * pointer-events:none ensures input is blocked the instant hide
+   * begins). prefers-reduced-motion (below) drops the transition entirely
+   * so the flip is instant for users who opt out of motion. */
+  transition: opacity 200ms ease-out, visibility 200ms ease-out;
 }
 
 .scrubber-labels {
@@ -315,7 +325,24 @@ export const OVERLAY_CSS = `
 }
 
 .word-region {
+  /*
+   * Flex layout (#52 PART C) so multiple .word-run wrappers inside a
+   * chunk flow on one line separated by the space text nodes
+   * renderChunk injects. text-align: center is kept for legacy single-
+   * span content (e.g. tests that write textContent directly); the
+   * justify-content: center below is what actually centers the
+   * .word-run children produced by renderWord / renderChunk.
+   *
+   * Wrap so a long chunk on a narrow viewport breaks gracefully rather
+   * than overflowing the modal — flex-wrap keeps the modal width as the
+   * hard cap.
+   */
   text-align: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: baseline;
+  gap: 0 0.4ch;
   /*
    * When the in-modal A−/A+ stepper (#29) sets --rsvp-font-size as an
    * inline custom property, this font-size resolves to the user-chosen
@@ -332,6 +359,45 @@ export const OVERLAY_CSS = `
 
 .word-region .focus {
   color: var(--accent, #2563eb);
+}
+
+/* Word alignment (#52 PART A). Each word — single-word emission AND each
+ * word inside a chunk — is wrapped in a .word-run span. The
+ * data-alignment host attribute drives the per-run layout:
+ *
+ *   - "orp" (default, Safari upstream): 3-column grid where before /
+ *     focus / after sit in columns of width 1fr / auto / 1fr. The focus
+ *     character anchors at the same horizontal position across successive
+ *     runs so the eye doesn't micro-saccade between words. Matches the
+ *     Safari spec at docs/superpowers/specs/2026-04-04-orp-alignment-design.md.
+ *   - "center": inline layout (display: block on the run reverts the grid
+ *     and lets the centered .word-region parent center the inline
+ *     before/focus/after spans naturally).
+ *
+ * In chunk mode (chunkSize ≥ 2), multiple .word-run wrappers sit inside
+ * .word-region separated by space text nodes; the grid layout per-run
+ * keeps each word independently ORP-aligned (the chunk is read as a
+ * unit; cross-word column alignment is NOT a goal). */
+:host([data-alignment="orp"]) .word-run {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: baseline;
+}
+
+:host([data-alignment="orp"]) .word-run > span:first-child {
+  /* before — right-aligned so text flows TOWARD the focus column. */
+  text-align: end;
+}
+
+:host([data-alignment="orp"]) .word-run > span:last-child {
+  /* after — left-aligned so text flows AWAY from the focus column. */
+  text-align: start;
+}
+
+:host([data-alignment="center"]) .word-run {
+  /* Revert the grid; inline before/focus/after spans flow naturally
+   * inside the centered .word-region parent. */
+  display: block;
 }
 
 .aria-live {
@@ -454,6 +520,10 @@ export const OVERLAY_CSS = `
 
 @media (prefers-reduced-motion: reduce) {
   .backdrop, .modal { transition: none !important; animation: none !important; }
+  /* #52 PART D — drop the auto-hide fade for users who opt out of motion.
+   * The visibility / opacity flip still happens (the bar still hides on
+   * play, shows on pause/hover/focus), just instantly. */
+  .scrubber-area { transition: none !important; }
 }
 
 /*

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -560,8 +560,20 @@ export const OVERLAY_CSS = `
   }
   .word-region {
     flex: 1 1 auto;
-    display: grid;
-    place-items: center;
+    /* #52 PART C / architect H1 — preserve the flex+wrap layout from the
+     * base .word-region rule so chunk-mode (chunkSize >= 2) renders its
+     * multiple .word-run siblings inline on one line. The previous
+     * "display: grid; place-items: center" here OVERRODE the base flex
+     * layout, causing multi-run chunks to stack/overlap inside a single
+     * grid cell on touch-primary viewports. The base rule's
+     * "justify-content: center; align-items: baseline" already centers
+     * the runs horizontally; we only override align-items to "center" here
+     * so the runs are vertically centred within the now-larger touch
+     * .word-region flex slot. */
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
     /* Tap target hint for assistive tech / a11y devtools — the click
      * handler is wired in JS. */
     cursor: pointer;

--- a/src/core/overlay/types.ts
+++ b/src/core/overlay/types.ts
@@ -59,6 +59,20 @@ export interface OverlaySettings {
    * mode (engine emits `chunk` events with sentence-boundary respect).
    */
   chunkSize?: 1 | 2 | 3;
+  /**
+   * Word alignment (#52). `'orp'` (default) drives a 3-column CSS grid
+   * on each word-run so the ORP focus character anchors at the same
+   * horizontal position across successive words (matches Spritz / Reedy
+   * presentation). `'center'` reverts to centered inline layout (the
+   * pre-#52 behaviour and Spreeder / Velocity presentation).
+   *
+   * Optional so existing callers and tests that pre-date this field
+   * continue to type-check — overlay treats `undefined` as `'orp'`. The
+   * resolved value is written to the host `data-alignment` attribute,
+   * which `styles.ts` consumes via `:host([data-alignment="…"])`
+   * selectors. Live updates land via `subscribeSettings`.
+   */
+  alignment?: 'orp' | 'center';
 }
 
 export type SettingsSubscriber = (s: OverlaySettings) => void;

--- a/src/core/overlay/word.ts
+++ b/src/core/overlay/word.ts
@@ -1,16 +1,18 @@
 import { splitWordAtFocus } from '../orp';
+import { OVERLAY_CLASS } from './constants';
 
 /**
- * Render `word` into `region` as three <span> elements (before / focus / after).
- * The middle span carries the `focus` class for ORP-highlight styling. Repeated
- * calls replace the prior content.
- *
- * Pure DOM mutation — no chrome.*, safe for src/core. The caller provides the
- * region element; this module does not query the document.
+ * Build a single .word-run element with three child spans (before /
+ * focus / after) for `word`. The middle span carries the `focus` class
+ * for ORP-highlight styling. Internal helper shared by `renderWord` and
+ * `renderChunk` so both surfaces produce structurally identical per-word
+ * markup that the `:host([data-alignment="orp"]) .word-run` grid styles
+ * consume.
  */
-export function renderWord(region: Element, word: string): void {
+function buildWordRun(doc: Document, word: string): HTMLElement {
   const { before, focus, after } = splitWordAtFocus(word);
-  const doc = region.ownerDocument;
+  const run = doc.createElement('span');
+  run.className = OVERLAY_CLASS.WORD_RUN;
   const beforeSpan = doc.createElement('span');
   beforeSpan.textContent = before;
   const focusSpan = doc.createElement('span');
@@ -18,5 +20,57 @@ export function renderWord(region: Element, word: string): void {
   focusSpan.textContent = focus;
   const afterSpan = doc.createElement('span');
   afterSpan.textContent = after;
-  region.replaceChildren(beforeSpan, focusSpan, afterSpan);
+  run.append(beforeSpan, focusSpan, afterSpan);
+  return run;
+}
+
+/**
+ * Render `word` into `region` as a single `.word-run` wrapper containing
+ * three child spans (before / focus / after). The middle span carries
+ * the `focus` class for ORP-highlight styling. Repeated calls replace
+ * the prior content.
+ *
+ * The `.word-run` wrapper is the grid container that
+ * `:host([data-alignment="orp"]) .word-run` styles consume — single-word
+ * mode therefore shares the same alignment behaviour as chunk-mode
+ * (each chunk word renders as its own `.word-run`).
+ *
+ * Pure DOM mutation — no chrome.*, safe for src/core. The caller provides the
+ * region element; this module does not query the document.
+ */
+export function renderWord(region: Element, word: string): void {
+  const doc = region.ownerDocument;
+  region.replaceChildren(buildWordRun(doc, word));
+}
+
+/**
+ * Render a multi-word chunk into `region` as N `.word-run` wrappers
+ * (one per chunk word), separated by space text nodes. Each run carries
+ * its own before/focus/after spans so the ORP focus character is
+ * positioned per-word — `splitWordAtFocus` runs against the individual
+ * word, NOT the joined chunk text (the pre-#52 path called
+ * `renderWord(region, ev.text)` which produced a nonsensical focus
+ * position somewhere inside the joined string).
+ *
+ * `chunkText` is accepted for symmetry with `renderWord(region, ev.text)`
+ * and to make the function's contract self-evident at the call site;
+ * the rendered text is built from `chunkWords` (the same source the
+ * engine uses to join `ev.text`), so `region.textContent` is
+ * `chunkWords.join(' ')` by construction.
+ *
+ * Empty `chunkWords` clears the region (degenerate guard; the engine
+ * never emits an empty chunk in practice).
+ */
+export function renderChunk(region: Element, _chunkText: string, chunkWords: string[]): void {
+  const doc = region.ownerDocument;
+  if (chunkWords.length === 0) {
+    region.replaceChildren();
+    return;
+  }
+  const nodes: Node[] = [];
+  for (let i = 0; i < chunkWords.length; i++) {
+    if (i > 0) nodes.push(doc.createTextNode(' '));
+    nodes.push(buildWordRun(doc, chunkWords[i]));
+  }
+  region.replaceChildren(...nodes);
 }

--- a/tests/e2e/overlay-polish.spec.ts
+++ b/tests/e2e/overlay-polish.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * overlay-polish.spec.ts — issue #52 (PART A + C + D bundle)
+ *
+ * Browser-realistic coverage for the overlay polish bundle:
+ *   - PART A: alignment setting wired to host data-alignment attribute,
+ *     live-switchable via subscribeSettings.
+ *   - PART C: chunk-mode renders per-word ORP markers (.focus per word,
+ *     not one per joined chunk-text).
+ *   - PART D: scrubber auto-hides on play, returns on pause / hover /
+ *     focus, AND axe-core scan is clean across all states.
+ */
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const BUNDLE_PATH = 'dist-e2e/core-overlay-bundle.js';
+
+const ARTICLE_WORDS = ['Hello.', 'How', 'are', 'you?', 'I', 'am', 'fine.', 'Bye!'];
+
+test.describe('Overlay polish bundle (#52)', () => {
+  test('PART A — alignment setting drives data-alignment host attribute and live-updates', async ({
+    page,
+  }) => {
+    await page.goto('about:blank');
+    await page.addScriptTag({ path: BUNDLE_PATH });
+    const observed = await page.evaluate((words) => {
+      type OverlayMod = {
+        createOverlay: (o: Record<string, unknown>) => { mount(): void; unmount(): void };
+      };
+      type RsvpMod = { createRsvpEngine: (o: Record<string, unknown>) => unknown };
+      const overlayMod = (window as unknown as { __speedreader_overlay__: OverlayMod })
+        .__speedreader_overlay__;
+      const rsvpMod = (window as unknown as { __speedreader_rsvp__: RsvpMod }).__speedreader_rsvp__;
+      type Pusher = (s: Record<string, unknown>) => void;
+      const pushHolder: { fn: Pusher | null } = { fn: null };
+      const overlay = overlayMod.createOverlay({
+        doc: document,
+        words,
+        initialSettings: { theme: 'light', wpm: 300, fontSize: 20, alignment: 'orp' },
+        subscribeSettings: (listener: Pusher) => {
+          pushHolder.fn = listener;
+          return () => undefined;
+        },
+        engineFactory: rsvpMod.createRsvpEngine,
+      });
+      overlay.mount();
+      const host = document.querySelector('[data-speedreader-overlay]');
+      const mountAttr = host?.getAttribute('data-alignment') ?? null;
+      // Live push: flip to center.
+      pushHolder.fn?.({ theme: 'light', wpm: 300, fontSize: 20, alignment: 'center' });
+      const afterPushAttr = host?.getAttribute('data-alignment') ?? null;
+      return { mountAttr, afterPushAttr };
+    }, ARTICLE_WORDS);
+    expect(observed.mountAttr).toBe('orp');
+    expect(observed.afterPushAttr).toBe('center');
+  });
+
+  test('PART C — chunk mode emission renders one .focus span per chunk word', async ({ page }) => {
+    await page.goto('about:blank');
+    await page.addScriptTag({ path: BUNDLE_PATH });
+    // Stream starts with a non-sentence-end token so the first chunkSize=2
+    // emission groups two words together ("The" + "quick") — a stream like
+    // ['Hello.', …] would force a sentence-boundary chunk break and the
+    // first chunk would be the single token "Hello.".
+    const CHUNK_STREAM = ['The', 'quick', 'brown', 'fox.', 'Stop.'];
+    const focusCount = await page.evaluate((words) => {
+      type OverlayMod = {
+        createOverlay: (o: Record<string, unknown>) => { mount(): void };
+      };
+      type RsvpMod = { createRsvpEngine: (o: Record<string, unknown>) => unknown };
+      const overlayMod = (window as unknown as { __speedreader_overlay__: OverlayMod })
+        .__speedreader_overlay__;
+      const rsvpMod = (window as unknown as { __speedreader_rsvp__: RsvpMod }).__speedreader_rsvp__;
+      const overlay = overlayMod.createOverlay({
+        doc: document,
+        words,
+        initialSettings: { theme: 'light', wpm: 60, fontSize: 20, chunkSize: 2 },
+        subscribeSettings: () => () => undefined,
+        engineFactory: rsvpMod.createRsvpEngine,
+      });
+      overlay.mount();
+      const host = document.querySelector('[data-speedreader-overlay]');
+      const region = host?.shadowRoot?.querySelector('.word-region');
+      return region?.querySelectorAll('.focus').length ?? 0;
+    }, CHUNK_STREAM);
+    // chunkSize=2 over ['The', 'quick', …] → first chunk = ['The', 'quick']
+    // → 2 .word-run wrappers → 2 .focus spans (one per word).
+    expect(focusCount).toBe(2);
+  });
+
+  test('PART D — scrubber auto-hides on play and becomes visible on pause', async ({ page }) => {
+    await page.goto('about:blank');
+    await page.addScriptTag({ path: BUNDLE_PATH });
+    const observed = await page.evaluate((words) => {
+      type OverlayMod = {
+        createOverlay: (o: Record<string, unknown>) => { mount(): void };
+      };
+      type RsvpMod = { createRsvpEngine: (o: Record<string, unknown>) => unknown };
+      const overlayMod = (window as unknown as { __speedreader_overlay__: OverlayMod })
+        .__speedreader_overlay__;
+      const rsvpMod = (window as unknown as { __speedreader_rsvp__: RsvpMod }).__speedreader_rsvp__;
+      const overlay = overlayMod.createOverlay({
+        doc: document,
+        words,
+        initialSettings: { theme: 'light', wpm: 60, fontSize: 20 },
+        subscribeSettings: () => () => undefined,
+        engineFactory: rsvpMod.createRsvpEngine,
+      });
+      overlay.mount();
+      const host = document.querySelector('[data-speedreader-overlay]');
+      const root = (host as HTMLElement | null)?.shadowRoot;
+      const area = root?.querySelector('.scrubber-area') as HTMLElement | null;
+      const playPause = root?.querySelector('.play-pause-btn') as HTMLButtonElement | null;
+      if (!area || !playPause) return null;
+      const playingHidden = area.dataset.hidden;
+      playPause.click(); // pause
+      const pausedHidden = area.dataset.hidden;
+      return { playingHidden, pausedHidden };
+    }, ARTICLE_WORDS);
+    expect(observed).not.toBeNull();
+    expect(observed?.playingHidden).toBe('true');
+    expect(observed?.pausedHidden).toBe('false');
+  });
+
+  test('axe-core is clean across all states (orp, paused with scrubber visible)', async ({
+    page,
+  }) => {
+    await page.goto('about:blank');
+    await page.addScriptTag({ path: BUNDLE_PATH });
+    await page.evaluate((words) => {
+      type OverlayMod = {
+        createOverlay: (o: Record<string, unknown>) => { mount(): void };
+      };
+      type RsvpMod = { createRsvpEngine: (o: Record<string, unknown>) => unknown };
+      const overlayMod = (window as unknown as { __speedreader_overlay__: OverlayMod })
+        .__speedreader_overlay__;
+      const rsvpMod = (window as unknown as { __speedreader_rsvp__: RsvpMod }).__speedreader_rsvp__;
+      const overlay = overlayMod.createOverlay({
+        doc: document,
+        words,
+        initialSettings: { theme: 'light', wpm: 300, fontSize: 20, alignment: 'orp' },
+        subscribeSettings: () => () => undefined,
+        engineFactory: rsvpMod.createRsvpEngine,
+      });
+      overlay.mount();
+      // Pause so scrubber is visible for axe.
+      const host = document.querySelector('[data-speedreader-overlay]');
+      const playPause = host?.shadowRoot?.querySelector(
+        '.play-pause-btn',
+      ) as HTMLButtonElement | null;
+      playPause?.click();
+    }, ARTICLE_WORDS);
+    const results = await new AxeBuilder({ page }).include('[data-speedreader-overlay]').analyze();
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/tests/e2e/overlay-polish.spec.ts
+++ b/tests/e2e/overlay-polish.spec.ts
@@ -54,7 +54,9 @@ test.describe('Overlay polish bundle (#52)', () => {
     expect(observed.afterPushAttr).toBe('center');
   });
 
-  test('PART C — chunk mode emission renders one .focus span per chunk word', async ({ page }) => {
+  test('PART C — chunk mode emission renders one .focus span per chunk word (with run count + ORP chars)', async ({
+    page,
+  }) => {
     await page.goto('about:blank');
     await page.addScriptTag({ path: BUNDLE_PATH });
     // Stream starts with a non-sentence-end token so the first chunkSize=2
@@ -62,7 +64,7 @@ test.describe('Overlay polish bundle (#52)', () => {
     // ['Hello.', …] would force a sentence-boundary chunk break and the
     // first chunk would be the single token "Hello.".
     const CHUNK_STREAM = ['The', 'quick', 'brown', 'fox.', 'Stop.'];
-    const focusCount = await page.evaluate((words) => {
+    const observed = await page.evaluate((words) => {
       type OverlayMod = {
         createOverlay: (o: Record<string, unknown>) => { mount(): void };
       };
@@ -80,11 +82,27 @@ test.describe('Overlay polish bundle (#52)', () => {
       overlay.mount();
       const host = document.querySelector('[data-speedreader-overlay]');
       const region = host?.shadowRoot?.querySelector('.word-region');
-      return region?.querySelectorAll('.focus').length ?? 0;
+      const runs = region?.querySelectorAll('.word-run') ?? [];
+      const focusChars: string[] = [];
+      runs.forEach((run) => {
+        const focus = run.querySelector('.focus');
+        focusChars.push(focus?.textContent ?? '');
+      });
+      return {
+        runCount: runs.length,
+        focusCount: region?.querySelectorAll('.focus').length ?? 0,
+        focusChars,
+      };
     }, CHUNK_STREAM);
-    // chunkSize=2 over ['The', 'quick', …] → first chunk = ['The', 'quick']
-    // → 2 .word-run wrappers → 2 .focus spans (one per word).
-    expect(focusCount).toBe(2);
+    // LOW #7 — strengthened assertions. chunkSize=2 over ['The', 'quick', …]
+    // → first chunk = ['The', 'quick'] → 2 .word-run wrappers → 2 .focus
+    // spans (one per word). Per-word ORP via splitWordAtFocus:
+    //   - "The" (stripped len 3) → orp() returns 0 → focus char "T"
+    //   - "quick" (stripped len 5) → orp() returns floor(5*0.3)=1 → focus "u"
+    expect(observed.runCount).toBe(2);
+    expect(observed.focusCount).toBe(2);
+    expect(observed.focusChars[0]).toBe('T');
+    expect(observed.focusChars[1]).toBe('u');
   });
 
   test('PART D — scrubber auto-hides on play and becomes visible on pause', async ({ page }) => {
@@ -151,5 +169,177 @@ test.describe('Overlay polish bundle (#52)', () => {
     }, ARTICLE_WORDS);
     const results = await new AxeBuilder({ page }).include('[data-speedreader-overlay]').analyze();
     expect(results.violations).toEqual([]);
+  });
+
+  test('axe-core is clean in chunk-mode-paused state (A11y MED #5)', async ({ page }) => {
+    // Chunk mode emits multi-word .word-run siblings; axe must still pass
+    // (color contrast on focus chars, ARIA on aria-live, role="dialog", etc).
+    await page.goto('about:blank');
+    await page.addScriptTag({ path: BUNDLE_PATH });
+    const CHUNK_STREAM = ['The', 'quick', 'brown', 'fox.', 'Stop.'];
+    await page.evaluate((words) => {
+      type OverlayMod = {
+        createOverlay: (o: Record<string, unknown>) => { mount(): void };
+      };
+      type RsvpMod = { createRsvpEngine: (o: Record<string, unknown>) => unknown };
+      const overlayMod = (window as unknown as { __speedreader_overlay__: OverlayMod })
+        .__speedreader_overlay__;
+      const rsvpMod = (window as unknown as { __speedreader_rsvp__: RsvpMod }).__speedreader_rsvp__;
+      const overlay = overlayMod.createOverlay({
+        doc: document,
+        words,
+        initialSettings: { theme: 'light', wpm: 60, fontSize: 20, chunkSize: 2 },
+        subscribeSettings: () => () => undefined,
+        engineFactory: rsvpMod.createRsvpEngine,
+      });
+      overlay.mount();
+      const host = document.querySelector('[data-speedreader-overlay]');
+      const playPause = host?.shadowRoot?.querySelector(
+        '.play-pause-btn',
+      ) as HTMLButtonElement | null;
+      playPause?.click();
+    }, CHUNK_STREAM);
+    const results = await new AxeBuilder({ page }).include('[data-speedreader-overlay]').analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test('axe-core is clean in center-alignment-paused state (A11y MED #5)', async ({ page }) => {
+    // Center alignment uses display: block on .word-run (no grid). Verify
+    // the reverted-layout state passes axe — color/contrast on the
+    // .focus span should still meet AA against the modal background.
+    await page.goto('about:blank');
+    await page.addScriptTag({ path: BUNDLE_PATH });
+    await page.evaluate((words) => {
+      type OverlayMod = {
+        createOverlay: (o: Record<string, unknown>) => { mount(): void };
+      };
+      type RsvpMod = { createRsvpEngine: (o: Record<string, unknown>) => unknown };
+      const overlayMod = (window as unknown as { __speedreader_overlay__: OverlayMod })
+        .__speedreader_overlay__;
+      const rsvpMod = (window as unknown as { __speedreader_rsvp__: RsvpMod }).__speedreader_rsvp__;
+      const overlay = overlayMod.createOverlay({
+        doc: document,
+        words,
+        initialSettings: { theme: 'light', wpm: 300, fontSize: 20, alignment: 'center' },
+        subscribeSettings: () => () => undefined,
+        engineFactory: rsvpMod.createRsvpEngine,
+      });
+      overlay.mount();
+      const host = document.querySelector('[data-speedreader-overlay]');
+      const playPause = host?.shadowRoot?.querySelector(
+        '.play-pause-btn',
+      ) as HTMLButtonElement | null;
+      playPause?.click();
+    }, ARTICLE_WORDS);
+    const results = await new AxeBuilder({ page }).include('[data-speedreader-overlay]').analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test('axe-core is clean in playing-state with hidden scrubber (A11y MED #5)', async ({ page }) => {
+    // During playback the scrubber-area is visibility:hidden — it MUST
+    // not surface in the AT rotor (visibility:hidden removes from
+    // accessible tree). Axe should be clean: the hidden region's labels
+    // do not create unreachable-name violations because the entire
+    // subtree is excluded.
+    await page.goto('about:blank');
+    await page.addScriptTag({ path: BUNDLE_PATH });
+    await page.evaluate((words) => {
+      type OverlayMod = {
+        createOverlay: (o: Record<string, unknown>) => { mount(): void };
+      };
+      type RsvpMod = { createRsvpEngine: (o: Record<string, unknown>) => unknown };
+      const overlayMod = (window as unknown as { __speedreader_overlay__: OverlayMod })
+        .__speedreader_overlay__;
+      const rsvpMod = (window as unknown as { __speedreader_rsvp__: RsvpMod }).__speedreader_rsvp__;
+      const overlay = overlayMod.createOverlay({
+        doc: document,
+        words,
+        initialSettings: { theme: 'light', wpm: 300, fontSize: 20, alignment: 'orp' },
+        subscribeSettings: () => () => undefined,
+        engineFactory: rsvpMod.createRsvpEngine,
+      });
+      overlay.mount();
+      // Engine starts playing by default; the auto-hide recompute runs
+      // synchronously inside mount() so the scrubber-area is already in
+      // its hidden state when we scan.
+    }, ARTICLE_WORDS);
+    // Sanity-check scrubber is in hidden state before axe.
+    const hidden = await page.evaluate(() => {
+      const host = document.querySelector('[data-speedreader-overlay]');
+      const area = host?.shadowRoot?.querySelector('.scrubber-area') as HTMLElement | null;
+      return area?.dataset.hidden ?? null;
+    });
+    expect(hidden).toBe('true');
+    const results = await new AxeBuilder({ page }).include('[data-speedreader-overlay]').analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test('touch-primary viewport — chunk-mode .word-run siblings render inline, do NOT overlap (architect H1 SHIP BLOCKER)', async ({
+    browser,
+  }) => {
+    // Re-creates the multi-run-overlap regression: the touch-primary
+    // (pointer: coarse) and (hover: none) media block previously OVERRODE
+    // .word-region with `display: grid; place-items: center`, causing
+    // multiple .word-run siblings inside a chunk to stack on top of each
+    // other inside a single grid cell. The fix restores flex+wrap inside
+    // the touch-primary block. We verify by measuring bounding-box x +
+    // width on the two runs: run 0 must end (x + width) at or before run
+    // 1's start x (inline flow), with NO overlap.
+    const context = await browser.newContext({
+      viewport: { width: 375, height: 667 },
+      hasTouch: true,
+      isMobile: true,
+    });
+    const mobilePage = await context.newPage();
+    await mobilePage.goto('about:blank');
+    await mobilePage.addScriptTag({ path: BUNDLE_PATH });
+    const CHUNK_STREAM = ['The', 'quick', 'brown', 'fox.', 'Stop.'];
+    const measurements = await mobilePage.evaluate((words) => {
+      type OverlayMod = {
+        createOverlay: (o: Record<string, unknown>) => { mount(): void };
+      };
+      type RsvpMod = { createRsvpEngine: (o: Record<string, unknown>) => unknown };
+      const overlayMod = (window as unknown as { __speedreader_overlay__: OverlayMod })
+        .__speedreader_overlay__;
+      const rsvpMod = (window as unknown as { __speedreader_rsvp__: RsvpMod }).__speedreader_rsvp__;
+      const overlay = overlayMod.createOverlay({
+        doc: document,
+        words,
+        initialSettings: { theme: 'light', wpm: 60, fontSize: 20, chunkSize: 2 },
+        subscribeSettings: () => () => undefined,
+        engineFactory: rsvpMod.createRsvpEngine,
+      });
+      overlay.mount();
+      const host = document.querySelector('[data-speedreader-overlay]');
+      const region = host?.shadowRoot?.querySelector('.word-region');
+      const runs = region?.querySelectorAll('.word-run') ?? [];
+      const rects: { x: number; width: number }[] = [];
+      runs.forEach((run) => {
+        const r = (run as HTMLElement).getBoundingClientRect();
+        rects.push({ x: r.x, width: r.width });
+      });
+      // Also check the resolved layout to confirm we're in flex, not grid.
+      const computed = region ? getComputedStyle(region as HTMLElement) : null;
+      return {
+        runCount: runs.length,
+        rects,
+        display: computed?.display ?? '',
+      };
+    }, CHUNK_STREAM);
+    // 2 runs from chunkSize=2.
+    expect(measurements.runCount).toBe(2);
+    // Resolved layout under touch-primary media query MUST be flex (the
+    // SHIP BLOCKER fix); a regression to grid would surface here.
+    expect(measurements.display).toBe('flex');
+    // Non-overlapping: run[0] ends before or exactly at run[1] starts.
+    // The space between runs comes from the base rule's `gap: 0 0.4ch`
+    // which makes run[0].x + run[0].width <= run[1].x in inline flow.
+    const [r0, r1] = measurements.rects;
+    expect(r0.x + r0.width).toBeLessThanOrEqual(r1.x + 0.5);
+    // And both runs have non-zero width (would be a degenerate guard if
+    // a regression collapsed them).
+    expect(r0.width).toBeGreaterThan(0);
+    expect(r1.width).toBeGreaterThan(0);
+    await context.close();
   });
 });


### PR DESCRIPTION
# #52 overlay polish bundle — alignment wire-up + chunk-mode ORP + scrubber auto-hide

Closes #52. Bundles three previously-deferred polish concerns into a single PR per coordinator scope-reduction directive.

## Scope summary

Three concerns shipped together (A, C, D from the issue body); concerns B (context-preview sentence predicate unification) and E (overlay flicker bugs) deferred to separate follow-up issues — see "Follow-ups recommended" below.

| Part | Concern | Primary files | LOC delta |
|---|---|---|---|
| A | ORP alignment setting wire-up (was dead — schema slot existed since V3, overlay never read it) | `src/core/overlay/{constants,types,overlay,styles}.ts`, `src/chrome/content/index.ts` | +~75 |
| C | ORP per-word rendering within multi-word chunks (#51 Q3 deferred — `splitWordAtFocus` was being applied to the joined chunk text) | `src/core/overlay/{word,overlay,styles,constants}.ts` | +~75 |
| D | Scrubber auto-hide on playing + reveal on hover/focus/scrub (#47 deferred + #206) | `src/core/overlay/{overlay,styles}.ts` | +~110 |
| Tests | TDD-first: 3 new unit suites + 1 new e2e suite + updated `word.test.ts` | `src/core/overlay/__tests__/{alignment-wire,chunk-orp,scrubber-autohide,word}.test.ts`, `tests/e2e/overlay-polish.spec.ts` | +~460 |

Net: 22 new tests across vitest + 4 new playwright cases. All 1261 vitest + 32 playwright tests green.

## Decisions

- **Q-A1 — OVERLAY_ATTR.ALIGNMENT vs inline literal:** added `OVERLAY_ATTR.ALIGNMENT = 'data-alignment'` constant. Matches the centralization rationale in `constants.ts` ("DOM builders + stylesheet rules share a single source"). Test selectors and styles both consume the constant.
- **Q-A2 — center-mode CSS:** `display: block` on `.word-run` reverts the orp 3-column grid; the outer `.word-region { display: flex; justify-content: center; align-items: baseline }` continues to centre. No `text-align: center + display: block` magic — the flex parent does the centring uniformly across both modes. Simpler than flex-on-run.
- **Q-C1 — ORP within chunk:** Option 2 (per-word independent). Each word run gets its own grid in orp mode so each word's focus character aligns at its OWN centre column — cross-word column alignment in chunk mode would visually misalign the words against each other since chunks are read as units, not per-word fixations.
- **Q-C2 — render path:** new `renderChunk(region, chunkText, chunkWords)` in `word.ts`. Renamed internal helper `buildWordRun` shared by `renderWord` and `renderChunk` so the per-word DOM shape is structurally identical (one source of truth for the `:host([data-alignment="orp"]) .word-run` grid). Extending `renderWord` to handle `string | string[]` would have muddled its contract.
- **Q-D1 — lift updateScrubber or add sibling:** kept `updateScrubber` as a closure; added `recomputeScrubberVisibility` closure (separate concern from time-label refresh). Brief recommended lifting `updateScrubber` onto the returned overlay handle, but mutation-testing showed no verify gate needed external access. Surgical-changes rule (rules/think-before-coding precedence): smaller diff wins absent a concrete caller.
- **Q-D2 — hover-leave debounce:** 0ms (instant). Predictable, matches brief recommendation; no flicker observed during e2e because the 200ms CSS transition smooths the visual flip even on rapid mouseover.
- **Q-D3 — prefers-reduced-motion:** `@media (prefers-reduced-motion: reduce) { .scrubber-area { transition: none !important } }`. The visibility/opacity flip still happens, just instantly. Same pattern as the existing backdrop/modal block.

## Implementation notes

- **`renderWord` shape changed.** Previously emitted three loose spans; now emits one `.word-run` wrapper containing three spans. This is the SAME structural shape as each per-word run inside `renderChunk`, so the `:host([data-alignment="orp"]) .word-run` grid applies uniformly in both single-word and chunk modes. Existing `word.test.ts` updated to assert on the new shape; existing `chunk-render.test.ts` continues to pass because its assertions are on `textContent` and `aria-live` semantics, both preserved.
- **`.word-region` got `display: flex; flex-wrap: wrap; justify-content: center`.** Required so multiple `.word-run` wrappers inside a chunk flow inline on one line; the space text-nodes between runs collapse naturally inside flex. Wrap added so long chunks on narrow viewports don't overflow. The pre-existing `text-align: center` kept for legacy/tests that write `textContent` directly.
- **Scrubber visibility state.** Inline-styled (`opacity / visibility / pointer-events`) so the JS state machine can be observed deterministically in jsdom via `dataset.hidden`. CSS `transition: opacity 200ms ease-out, visibility 200ms ease-out` on `.scrubber-area` smooths the flip in real browsers. `display:none` was explicitly avoided per the FIX-5 comment in `styles.ts` — display:none would collapse the margin slot and reflow the word region's vertical centre on every toggle.
- **`recomputeScrubberVisibility` invocation points.** Called from `reflectEngineState` (covers togglePlayPause + swapToFull + start/done), `engine.start()` initial render, `beginScrubSession` start (mid-scrub override), the debounce-timer fire (scrub-session end), and the four hover/focus listeners.

## Mutation-hypothesis table

| Mutation | Caught by |
|---|---|
| `host.setAttribute('data-alignment', …)` deleted at mount | `alignment-wire.test.ts` `mount with alignment="orp" writes data-alignment="orp" on host` |
| `subscribeSettings` alignment branch deleted | `alignment-wire.test.ts` `subscribeSettings push from orp → center updates host attribute` |
| Default flipped to `'center'` | `alignment-wire.test.ts` `mount with alignment omitted defaults to "orp"` |
| `host.setAttribute` written on `modal` instead of `host` | `alignment-wire.test.ts` queries `[data-speedreader-overlay]` host element — modal-written attribute fails the selector |
| `OVERLAY_CSS` ORP grid rule dropped or `1fr auto 1fr` mutated | `alignment-wire.test.ts` `stylesheet scopes a word-run grid under :host([data-alignment="orp"])` |
| `renderChunk` swapped to `renderWord(region, ev.text)` (regression to pre-#52) | `chunk-orp.test.ts` `chunk-mode emission renders one .focus per word in the chunk` (would see 1 instead of 2) — also caught by e2e PART C |
| `renderChunk` builds N runs but each carries 0 focus spans (e.g. forgot to call `splitWordAtFocus`) | `chunk-orp.test.ts` `each word-run contains exactly one .focus span (per-word ORP)` |
| Space text-nodes between runs omitted (renders `"Thequick"` instead of `"The quick"`) | `chunk-orp.test.ts` `word-runs are separated by space text nodes` + `joined textContent preserves the visible chunk string` |
| Run wrapper class name mutated (`.run` instead of `.word-run`) | `chunk-orp.test.ts` `renders N .word-run children` |
| Scrubber stays visible during playing (auto-hide regression) | `scrubber-autohide.test.ts` `engine playing + no hover + no focus → scrubber hidden` |
| `display:none` used instead of `opacity/visibility/pointer-events` | `scrubber-autohide.test.ts` `scrubber uses opacity/visibility (NOT display:none) to prevent layout reflow` |
| Hover override missing (mouseenter does nothing) | `scrubber-autohide.test.ts` `engine playing + hover → scrubber visible` |
| Focus override missing (focusin doesn't keep bar visible — would lose focus when bar hides) | `scrubber-autohide.test.ts` `engine playing + scrubber focus → scrubber visible (focus retention)` |
| Mid-scrub hide regression (`scrubInProgress` not consulted) | `scrubber-autohide.test.ts` `engine playing + mid-scrub … scrubber stays visible even on mouseleave` |
| Done-state hide regression (engine terminal state should show bar) | `scrubber-autohide.test.ts` `engine done → scrubber visible (terminal state)` |
| CSS transition dropped (visual flicker on hide/show) | `scrubber-autohide.test.ts` `OVERLAY_CSS includes opacity transition on .scrubber-area` |
| `prefers-reduced-motion` override missing | `scrubber-autohide.test.ts` `prefers-reduced-motion disables the scrubber-area transition` |
| `chrome/content/index.ts` not forwarding `settings.alignment` to overlay | Manual smoke — caught at the chrome-glue boundary; could be extended with a `content/__tests__/alignment-wire.test.ts` mirror if reviewers want it |

## Self-weaknesses

- **Chrome-glue test coverage for alignment forwarding is light.** I extended `src/chrome/content/index.ts` to pass `settings.alignment` into both `initialSettings` and the `subscribeSettings` listener bridge, but did NOT write a chrome-side `alignment-wire.test.ts` mirror like the chunk-size / font wire tests in the same folder. The forwarding is mechanically obvious (one new line into a literal-shaped object) but a real `subscribeSettings` push test from the chrome side would close the gap. Recommend ring-review surface this as a possible test-gap MED.
- **Focus visibility is async in real browsers (focus event timing).** The vitest test simulates focusin via `dispatchEvent`. Real-browser focus may interleave with the visibility transition (200ms) such that a user tabbing into a hidden scrubber sees the slider receive focus before the bar finishes fading in. Acceptable per spec but worth a manual smoke. The axe-core e2e test mounts in paused state so it sidesteps this race.
- **`.word-region` flex layout is new shape.** Previously `block + text-align: center`. The new flex layout was needed for multi-run chunk mode but it CHANGES the layout for single-word mode too. Visual smoke on a real article (#51 chunk-mode regression) is recommended even though all 1261 unit tests pass — flex+wrap behaviour on extreme font sizes (12px, 96px) wasn't measured here.
- **Safari upstream divergence.** Safari uses `text-align: end / start` on the before/after column children (matches my implementation). However Safari's CSS doesn't reset to `display: flex` on `.word-region` — they keep block layout because chunk mode runs through Safari's own per-word fade-in renderer, not our `renderChunk`. The Chrome implementation chose flex specifically to support multi-run chunks; this is documented in styles.ts as a Chrome-side deviation. Per `[[parity-is-floor-not-ceiling]]`.
- **`updateScrubber` was NOT lifted onto the overlay handle** despite the brief recommending it. Mutation testing showed no verify gate required external access; smaller diff was preferred. If a future caller needs to pull a snapshot of scrubber state, the lift is a small follow-up.
- **No test asserts the CSS transition is honored in a real browser** (only that the rule exists in OVERLAY_CSS). jsdom doesn't compute transitions; a Playwright timing test would be flaky. Trade-off accepted.

## CI output tails (all green from worktree)

```
$ npm run lint
> eslint . --max-warnings=0
(clean — 0 errors, 0 warnings)

$ npm run format:check
Checking formatting...
All matched files use Prettier code style!

$ npm test
 Test Files  83 passed (83)
      Tests  1261 passed (1261)
   Duration  3.51s

$ npm run build
✓ built in 229ms

$ npx tsc --noEmit
(clean — 0 errors)

$ npm run build:e2e-bundle
dist-e2e/core-overlay-bundle.js  44.24 kB │ gzip: 14.82 kB
✓ built in 63ms

$ npm run build:e2e-ext
✓ built in 219ms

$ npm run test:e2e
  11 skipped
  32 passed (30.0s)
```

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 1261 / 1261 pass
- [x] `npm run build` — clean dist
- [x] `npm run build:e2e-bundle && npm run build:e2e-ext` — clean
- [x] `npm run test:e2e` — 32 / 32 pass (11 skipped from unrelated suites)
- [x] `tests/e2e/overlay-polish.spec.ts` — 4 / 4 pass (PART A live-switch, PART C chunk per-word ORP, PART D scrubber hide/reveal, axe-core clean)
- [x] ~Manual smoke (a) alignment switch on options page changes layout live~ — **automated** in `tests/e2e/overlay-polish.spec.ts` (PART A live-switch test) + new `src/chrome/content/__tests__/alignment-wire.test.ts` (chrome-glue forwarding)
- [x] ~Manual smoke (b) chunkSize=2 shows two distinct ORP highlights per emission~ — **automated** in `tests/e2e/overlay-polish.spec.ts` (PART C strengthened with per-word ORP char positioning assertions)
- [x] ~Manual smoke (c) scrubber fades on play / reveals on hover/focus/pause~ — **automated** in `tests/e2e/overlay-polish.spec.ts` (PART D hide/reveal test) + `scrubber-autohide.test.ts` 11+ unit tests covering all state transitions including rapid play/pause thrash
- [x] ~Manual smoke (d) `prefers-reduced-motion: reduce` makes fade instant~ — **covered by unit** `scrubber-autohide.test.ts` asserts the transition rule absence under the media query

### Test plan execution log

Unit suite: 1272 passed, 0 failed.
E2e suite: 36 passed, 11 skipped (pre-existing unrelated suites), 0 failed.
Axe-core: 4 scans green (paused-orp + chunk-paused + center-paused + playing-hidden-scrubber).
Touch-primary chunk layout: e2e regression test asserts non-overlapping `.word-run` siblings under `pointer:coarse` viewport.
Lint / format:check / tsc / build / build:e2e-bundle / build:e2e-ext: all clean.

## Follow-ups recommended

- **PART B — context-preview sentence predicate unification.** Deferred from issue body; needs UX decision on whether the preview region should mirror the chunk-mode boundary semantics or stay sentence-bounded. Recommend separate issue.
- **PART E — overlay flicker/stability bugs.** No specific repro in the issue body; recommend opening a "needs repro" issue and gathering user reports before scoping fix work.
- **Chrome-glue alignment-wire test mirror** under `src/chrome/content/__tests__/alignment-wire.test.ts` (matches existing `chunk-size-wire.test.ts` + `font-wire.test.ts` patterns).
- **Lift `updateScrubber` onto the overlay handle** when a real external caller surfaces (low priority; nothing currently needs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

