### PR TITLE
feat(overlay): Hi-Fi mockup parity — modal-header chrome + tweaks popover

### DIFF
--- a/src/core/overlay/__tests__/tweaks-panel.test.ts
+++ b/src/core/overlay/__tests__/tweaks-panel.test.ts
@@ -1,0 +1,424 @@
+/**
+ * tweaks-panel.test.ts — Step 3 of the Hi-Fi overhaul.
+ *
+ * Covers the in-overlay Tweaks popover wired to the modal-header ⚙
+ * button: open/close, focus management, click-outside dismissal,
+ * Escape routing (panel-close-first, then overlay-close), theme
+ * picker invocation, and stub-section disabled rendering.
+ *
+ * The OUTER overlay focus-trap is exercised by focus-trap.test.ts and
+ * mount-focus.test.ts; this file adds a regression guard ensuring those
+ * paths continue to work alongside the new panel-scoped inner trap.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createOverlay } from '../overlay';
+import type { OverlayOptions, OverlaySettings, SettingsSubscriber } from '../types';
+import { createRsvpEngine } from '../../rsvp-engine';
+import { OVERLAY_CLASS } from '../constants';
+import { THEME_IDS, type ThemeId } from '../../theme';
+
+const STREAM = ['hello', 'world', 'speed', 'reader'];
+
+function defaultOpts(overrides: Partial<OverlayOptions> = {}): OverlayOptions {
+  return {
+    doc: document,
+    words: STREAM.slice(),
+    initialSettings: { theme: 'system', wpm: 300, fontSize: 20 },
+    subscribeSettings: () => () => undefined,
+    engineFactory: createRsvpEngine,
+    ...overrides,
+  };
+}
+
+function getShadow(): ShadowRoot {
+  const host = document.body.querySelector('[data-speedreader-overlay]');
+  if (!(host instanceof HTMLElement) || !host.shadowRoot) {
+    throw new Error('overlay host missing or no shadow root');
+  }
+  return host.shadowRoot;
+}
+
+function getSettingsBtn(shadow: ShadowRoot): HTMLButtonElement {
+  const btn = shadow.querySelector<HTMLButtonElement>(`.${OVERLAY_CLASS.SETTINGS_BTN}`);
+  if (!btn) throw new Error('overlay shadow: missing .settings-btn');
+  return btn;
+}
+
+function getPanel(shadow: ShadowRoot): HTMLElement {
+  const panel = shadow.querySelector<HTMLElement>(`.${OVERLAY_CLASS.TWEAKS_PANEL}`);
+  if (!panel) throw new Error('overlay shadow: missing .tweaks-panel');
+  return panel;
+}
+
+function getThemeButtons(shadow: ShadowRoot): HTMLButtonElement[] {
+  return Array.from(
+    shadow.querySelectorAll<HTMLButtonElement>(
+      `.${OVERLAY_CLASS.TWEAKS_PANEL} .${OVERLAY_CLASS.TWEAKS_SEG_BTN}[data-theme-id]`,
+    ),
+  );
+}
+
+describe('createOverlay — Tweaks popover (#step-3)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+  });
+
+  test('panel is hidden on initial mount; settingsBtn aria-expanded is "false"', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const shadow = getShadow();
+    expect(getPanel(shadow).hidden).toBe(true);
+    expect(getSettingsBtn(shadow).getAttribute('aria-expanded')).toBe('false');
+    overlay.unmount();
+  });
+
+  test('clicking ⚙ opens the panel: hidden=false, aria-expanded="true", focus moves to first theme button', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const shadow = getShadow();
+    getSettingsBtn(shadow).click();
+    expect(getPanel(shadow).hidden).toBe(false);
+    expect(getSettingsBtn(shadow).getAttribute('aria-expanded')).toBe('true');
+    const first = getThemeButtons(shadow)[0];
+    expect(shadow.activeElement).toBe(first);
+    overlay.unmount();
+  });
+
+  test('clicking ⚙ again closes the panel; focus returns to ⚙', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const shadow = getShadow();
+    const settingsBtn = getSettingsBtn(shadow);
+    settingsBtn.click();
+    settingsBtn.click();
+    expect(getPanel(shadow).hidden).toBe(true);
+    expect(settingsBtn.getAttribute('aria-expanded')).toBe('false');
+    expect(shadow.activeElement).toBe(settingsBtn);
+    overlay.unmount();
+  });
+
+  test('Escape while panel open closes ONLY the panel; overlay remains mounted; focus returns to ⚙', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const shadow = getShadow();
+    const settingsBtn = getSettingsBtn(shadow);
+    settingsBtn.click();
+    expect(getPanel(shadow).hidden).toBe(false);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(overlay.status).toBe('mounted');
+    expect(getPanel(shadow).hidden).toBe(true);
+    expect(shadow.activeElement).toBe(settingsBtn);
+    overlay.unmount();
+  });
+
+  test('Escape while panel closed closes the overlay (regression guard)', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(overlay.status).toBe('unmounted');
+  });
+
+  test('pointerdown outside the panel (on the backdrop) closes the panel', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const shadow = getShadow();
+    getSettingsBtn(shadow).click();
+    expect(getPanel(shadow).hidden).toBe(false);
+    const backdrop = shadow.querySelector<HTMLElement>(`.${OVERLAY_CLASS.BACKDROP}`);
+    if (!backdrop) throw new Error('shadow: missing .backdrop');
+    // pointerdown covers mouse + touch + pen; the production listener is
+    // pointerdown so touch-primary users can also dismiss
+    // (security-adversary FIX #4).
+    backdrop.dispatchEvent(new Event('pointerdown', { bubbles: true, composed: true }));
+    expect(getPanel(shadow).hidden).toBe(true);
+    overlay.unmount();
+  });
+
+  test('clicking a theme button invokes onThemeChange and flips .active synchronously', () => {
+    const onThemeChange = vi.fn();
+    const overlay = createOverlay(defaultOpts({ onThemeChange }));
+    overlay.mount();
+    const shadow = getShadow();
+    getSettingsBtn(shadow).click();
+    const buttons = getThemeButtons(shadow);
+    const darkBtn = buttons.find((b) => b.dataset.themeId === 'dark');
+    if (!darkBtn) throw new Error('missing dark theme button');
+    darkBtn.click();
+    expect(onThemeChange).toHaveBeenCalledTimes(1);
+    expect(onThemeChange).toHaveBeenCalledWith('dark');
+    expect(darkBtn.classList.contains(OVERLAY_CLASS.TWEAKS_SEG_BTN_ACTIVE)).toBe(true);
+    expect(darkBtn.getAttribute('aria-pressed')).toBe('true');
+    // Other buttons must drop the active state.
+    const others = buttons.filter((b) => b !== darkBtn);
+    for (const b of others) {
+      expect(b.classList.contains(OVERLAY_CLASS.TWEAKS_SEG_BTN_ACTIVE)).toBe(false);
+      expect(b.getAttribute('aria-pressed')).toBe('false');
+    }
+    overlay.unmount();
+  });
+
+  test('the System theme button invokes onThemeChange with "system"', () => {
+    const onThemeChange = vi.fn();
+    const overlay = createOverlay(
+      defaultOpts({
+        onThemeChange,
+        initialSettings: { theme: 'light', wpm: 300, fontSize: 20 },
+      }),
+    );
+    overlay.mount();
+    const shadow = getShadow();
+    getSettingsBtn(shadow).click();
+    const systemBtn = getThemeButtons(shadow).find((b) => b.dataset.themeId === 'system');
+    if (!systemBtn) throw new Error('missing system button');
+    systemBtn.click();
+    expect(onThemeChange).toHaveBeenCalledWith('system');
+    overlay.unmount();
+  });
+
+  test('active theme on mount matches initialSettings.theme', () => {
+    const overlay = createOverlay(
+      defaultOpts({ initialSettings: { theme: 'sepia', wpm: 300, fontSize: 20 } }),
+    );
+    overlay.mount();
+    const shadow = getShadow();
+    const active = getThemeButtons(shadow).find((b) =>
+      b.classList.contains(OVERLAY_CLASS.TWEAKS_SEG_BTN_ACTIVE),
+    );
+    expect(active?.dataset.themeId).toBe('sepia');
+    overlay.unmount();
+  });
+
+  test('stub sections (Focus style / Accent / Modal dim) render with disabled controls', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const shadow = getShadow();
+    const panel = getPanel(shadow);
+    // Three stub sections + the theme section = 4 .tweaks-section nodes.
+    const sections = panel.querySelectorAll(`.${OVERLAY_CLASS.TWEAKS_SECTION}`);
+    expect(sections.length).toBe(4);
+    // Disabled buttons in focus-style section.
+    const stubButtons = panel.querySelectorAll<HTMLButtonElement>(
+      `.${OVERLAY_CLASS.TWEAKS_SEG_BTN}[disabled]`,
+    );
+    // Two focus-style stubs + the accent swatch (also a button) — three disabled buttons total.
+    // The accent swatch uses a distinct class; check it separately.
+    expect(stubButtons.length).toBeGreaterThanOrEqual(2);
+    const accentSwatch = panel.querySelector<HTMLButtonElement>(
+      `.${OVERLAY_CLASS.TWEAKS_ACCENT_SWATCH}`,
+    );
+    expect(accentSwatch?.disabled).toBe(true);
+    const dimRange = panel.querySelector<HTMLInputElement>(`.${OVERLAY_CLASS.TWEAKS_DIM_RANGE}`);
+    expect(dimRange?.disabled).toBe(true);
+    expect(dimRange?.type).toBe('range');
+    overlay.unmount();
+  });
+
+  test('Disclosure pattern — panel does NOT carry role="dialog"/aria-haspopup', () => {
+    // Switched from dialog→Disclosure (ARIA-APG) per a11y-extension-
+    // designer findings #2/#6: dialog implied modality the panel does
+    // not provide, and the prior inner focus trap was escapable via
+    // Shift+Tab from the ⚙ button. The Disclosure pattern uses only
+    // aria-expanded + aria-controls on the trigger; no role on the panel.
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const shadow = getShadow();
+    const panel = getPanel(shadow);
+    expect(panel.getAttribute('role')).toBeNull();
+    expect(getSettingsBtn(shadow).getAttribute('aria-haspopup')).toBeNull();
+    overlay.unmount();
+  });
+
+  test('theme buttons exist for every ThemeId plus a System sentinel', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const shadow = getShadow();
+    const ids = getThemeButtons(shadow).map((b) => b.dataset.themeId);
+    for (const t of THEME_IDS) {
+      expect(ids).toContain(t);
+    }
+    expect(ids).toContain('system');
+    overlay.unmount();
+  });
+
+  /*
+   * Ring-review post-fix coverage (test-gap adversary findings #1/#2/#4/#5
+   * + security-adversary #1/#5). The earlier tests verified callback
+   * invocation + visual class flip but did NOT pin the click's full
+   * side-effect surface (applyTheme on the modal, runtime validation of
+   * dataset.themeId, ARIA contract, outer-trap exclusion of the hidden
+   * panel, unmount-while-open safety). A future refactor dropping any
+   * of those side effects would have silently passed the original suite.
+   */
+  test('clicking a theme button calls applyTheme — modal --surface flips synchronously', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const shadow = getShadow();
+    const modal = shadow.querySelector<HTMLElement>(`.${OVERLAY_CLASS.MODAL}`);
+    if (!modal) throw new Error('shadow: missing .modal');
+    getSettingsBtn(shadow).click();
+    const darkBtn = getThemeButtons(shadow).find((b) => b.dataset.themeId === 'dark');
+    if (!darkBtn) throw new Error('panel: missing dark theme button');
+    darkBtn.click();
+    // applyTheme writes --surface inline on the modal. Dark surface
+    // (#292a2d) is verifiable; we just check the value is dark-non-default.
+    expect(modal.style.getPropertyValue('--surface')).toBe('#292a2d');
+    overlay.unmount();
+  });
+
+  test('theme button click with onThemeChange omitted still applies theme locally (session-only contract)', () => {
+    const overlay = createOverlay(defaultOpts()); // onThemeChange undefined
+    overlay.mount();
+    const shadow = getShadow();
+    const modal = shadow.querySelector<HTMLElement>(`.${OVERLAY_CLASS.MODAL}`);
+    if (!modal) throw new Error('shadow: missing .modal');
+    getSettingsBtn(shadow).click();
+    const darkBtn = getThemeButtons(shadow).find((b) => b.dataset.themeId === 'dark');
+    if (!darkBtn) throw new Error('panel: missing dark theme button');
+    darkBtn.click();
+    expect(modal.style.getPropertyValue('--surface')).toBe('#292a2d');
+    expect(darkBtn.classList.contains(OVERLAY_CLASS.TWEAKS_SEG_BTN_ACTIVE)).toBe(true);
+    overlay.unmount();
+  });
+
+  test('settingsBtn carries aria-controls; panel labelled by tweaks-heading (Disclosure)', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const shadow = getShadow();
+    const panel = getPanel(shadow);
+    const settingsBtn = getSettingsBtn(shadow);
+    // ARIA-APG Disclosure: no role on panel, only the trigger carries the
+    // expanded-state contract. The panel still names itself via the
+    // heading id for AT users that surface the panel content.
+    expect(settingsBtn.getAttribute('aria-controls')).toBe(panel.id);
+    expect(panel.getAttribute('aria-labelledby')).toBe('sr-tweaks-heading');
+    const heading = panel.querySelector<HTMLElement>(`.${OVERLAY_CLASS.TWEAKS_HEADING}`);
+    expect(heading?.id).toBe('sr-tweaks-heading');
+    overlay.unmount();
+  });
+
+  test('dataset.themeId injected with a non-allowlisted value is a no-op (defense-in-depth)', () => {
+    const onThemeChange = vi.fn();
+    const overlay = createOverlay(defaultOpts({ onThemeChange }));
+    overlay.mount();
+    const shadow = getShadow();
+    const modal = shadow.querySelector<HTMLElement>(`.${OVERLAY_CLASS.MODAL}`);
+    if (!modal) throw new Error('shadow: missing .modal');
+    const beforeSurface = modal.style.getPropertyValue('--surface');
+    getSettingsBtn(shadow).click();
+    const lightBtn = getThemeButtons(shadow).find((b) => b.dataset.themeId === 'light');
+    if (!lightBtn) throw new Error('panel: missing light theme button');
+    // Attacker-style injection — open shadow lets a sibling content script
+    // mutate dataset before clicking. Validator must reject.
+    lightBtn.dataset.themeId = 'evil-injected-theme';
+    lightBtn.click();
+    expect(onThemeChange).not.toHaveBeenCalled();
+    expect(modal.style.getPropertyValue('--surface')).toBe(beforeSurface);
+    overlay.unmount();
+  });
+
+  test('outer focus trap excludes focusables inside the hidden tweaks panel', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const shadow = getShadow();
+    expect(getPanel(shadow).hidden).toBe(true);
+    // installFocusTrap filters hidden subtrees via isInHiddenSubtree.
+    // Programmatic focus-bounce from the top sentinel must NOT land
+    // inside the hidden panel — that was the focus-thrash vector flagged
+    // by security-adversary #1.
+    const sentinels = shadow.querySelectorAll<HTMLElement>(`.${OVERLAY_CLASS.TRAP_SENTINEL}`);
+    const [outerTop] = Array.from(sentinels);
+    outerTop.focus();
+    outerTop.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+    const active = shadow.activeElement;
+    expect(active).not.toBeNull();
+    expect(getPanel(shadow).contains(active as Node)).toBe(false);
+    overlay.unmount();
+  });
+
+  test('panel has no inner trap sentinels — Disclosure pattern relies on outer trap', () => {
+    // Removed when switching from dialog→Disclosure. The outer focus
+    // trap's hidden-subtree filter excludes panel buttons while
+    // collapsed; when expanded, Tab flows naturally through panel
+    // buttons within the modal's existing trap. No inner sentinels.
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const shadow = getShadow();
+    const panel = getPanel(shadow);
+    expect(panel.querySelectorAll('.tweaks-trap-sentinel').length).toBe(0);
+    overlay.unmount();
+  });
+
+  test('theme switch writes a polite live-region announcement (WCAG 4.1.3)', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const shadow = getShadow();
+    const ariaLive = shadow.querySelector<HTMLElement>(`.${OVERLAY_CLASS.ARIA_LIVE}`);
+    if (!ariaLive) throw new Error('shadow: missing .aria-live');
+    getSettingsBtn(shadow).click();
+    const darkBtn = getThemeButtons(shadow).find((b) => b.dataset.themeId === 'dark');
+    if (!darkBtn) throw new Error('panel: missing dark theme button');
+    darkBtn.click();
+    expect(ariaLive.textContent).toBe('Theme: Dark');
+    overlay.unmount();
+  });
+
+  test('sanitizeHostname strips bidi controls + caps to 60 chars', async () => {
+    // Direct unit test on the exported helper — stubbing doc.location
+    // on a real Document object invalidates jsdom's EventTarget
+    // plumbing, so we test the sanitizer in isolation and rely on its
+    // contract being preserved at the call site in createOverlay.
+    const { sanitizeHostname } = await import('../overlay');
+    // Bidi RTL override (U+202E) between letters spoofs the visual order.
+    expect(sanitizeHostname('paypa‮l.com')).toBe('paypal.com');
+    // Embedding marks (U+202A-U+202E), isolates (U+2066-U+2069), LRM/RLM.
+    expect(sanitizeHostname('‎example.com⁩')).toBe('example.com');
+    // C0/C1 control bytes.
+    expect(sanitizeHostname('hostname.com')).toBe('hostname.com');
+    // 60-char cap.
+    expect(sanitizeHostname('a'.repeat(120) + '.com').length).toBe(60);
+    // Clean hostnames pass through unchanged.
+    expect(sanitizeHostname('en.wikipedia.org')).toBe('en.wikipedia.org');
+  });
+
+  test('unmount while panel is open is safe — no throw, listeners torn down', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const shadow = getShadow();
+    getSettingsBtn(shadow).click();
+    expect(getPanel(shadow).hidden).toBe(false);
+    expect(() => overlay.unmount()).not.toThrow();
+    // After unmount, the host is gone; firing a pointerdown on the now-
+    // detached shadow must not throw or otherwise re-enter overlay code.
+    expect(() => {
+      shadow.dispatchEvent(new Event('pointerdown', { bubbles: true, composed: true }));
+    }).not.toThrow();
+  });
+
+  test('subscribeSettings echo flips the active theme button without a panel click', () => {
+    const ref: { current: SettingsSubscriber | null } = { current: null };
+    const overlay = createOverlay(
+      defaultOpts({
+        subscribeSettings: (cb) => {
+          ref.current = cb;
+          return () => {
+            ref.current = null;
+          };
+        },
+      }),
+    );
+    overlay.mount();
+    const shadow = getShadow();
+    const next: OverlaySettings = { theme: 'nord' as ThemeId, wpm: 300, fontSize: 20 };
+    ref.current?.(next);
+    const active = getThemeButtons(shadow).find((b) =>
+      b.classList.contains(OVERLAY_CLASS.TWEAKS_SEG_BTN_ACTIVE),
+    );
+    expect(active?.dataset.themeId).toBe('nord');
+    overlay.unmount();
+  });
+});

--- a/src/core/overlay/constants.ts
+++ b/src/core/overlay/constants.ts
@@ -58,6 +58,34 @@ export const OVERLAY_CLASS = Object.freeze({
    * degrades gracefully rather than rendering invisible text).
    */
   OPENDYSLEXIC: 'opendyslexic',
+  /**
+   * Mockup-fidelity top chrome — modal-header bar with mini-logo + name +
+   * hostname on the left and icon-button actions group on the right.
+   * Hosts the close button (which used to be absolute-positioned top-right)
+   * plus stub bookmark + settings buttons.
+   */
+  MODAL_HEADER: 'modal-header',
+  MODAL_TITLE: 'modal-title',
+  MINI_LOGO: 'mini-logo',
+  MODAL_SOURCE: 'modal-source',
+  MODAL_ACTIONS: 'modal-actions',
+  BOOKMARK_BTN: 'bookmark-btn',
+  SETTINGS_BTN: 'settings-btn',
+  /**
+   * Tweaks popover panel (#step-3) — anchored to the modal header's
+   * settings button, hidden by default, opened by clicking the ⚙
+   * affordance. Hosts theme picker now; focus-style / accent / dim
+   * stubs render disabled and wire up in later steps.
+   */
+  TWEAKS_PANEL: 'tweaks-panel',
+  TWEAKS_HEADING: 'tweaks-heading',
+  TWEAKS_SECTION: 'tweaks-section',
+  TWEAKS_SECTION_LABEL: 'tweaks-section-label',
+  TWEAKS_SEG: 'tweaks-seg',
+  TWEAKS_SEG_BTN: 'tweaks-seg-btn',
+  TWEAKS_SEG_BTN_ACTIVE: 'active',
+  TWEAKS_ACCENT_SWATCH: 'tweaks-accent-swatch',
+  TWEAKS_DIM_RANGE: 'tweaks-dim-range',
 });
 
 /** DOM ids referenced by ARIA relationships (e.g., aria-labelledby). */
@@ -94,9 +122,10 @@ export const OVERLAY_TEXT = Object.freeze({
   CLOSE_GLYPH: 'X',
   CLOSE_LABEL: 'Close reader',
 
-  /** Play/pause button labels + glyphs. */
-  PLAY_GLYPH: '▶ Play',
-  PAUSE_GLYPH: '⏸ Pause',
+  /** Play/pause button labels + glyphs. Mockup uses glyph-only inside the
+   * circular primary button; aria-label carries the full action for AT. */
+  PLAY_GLYPH: '▶',
+  PAUSE_GLYPH: '⏸',
   PLAY_LABEL: 'Play reading',
   PAUSE_LABEL: 'Pause reading',
 
@@ -186,5 +215,45 @@ export const OVERLAY_TEXT = Object.freeze({
    */
   scrubberValueText(elapsedSec: number, remainingSec: number): string {
     return `${OVERLAY_TEXT.formatTime(elapsedSec)} elapsed, ${OVERLAY_TEXT.formatTime(remainingSec)} remaining`;
+  },
+
+  /** Mockup top chrome — brand mini-logo letters + product name. */
+  MINI_LOGO_TEXT: 'SR',
+  PRODUCT_NAME: 'SpeedReader',
+  /** Joiner between product name and hostname: " · gutenberg.org". */
+  SOURCE_SEPARATOR: ' · ',
+
+  /** Stub action buttons — handlers wired in subsequent commits. */
+  BOOKMARK_GLYPH: '☆',
+  BOOKMARK_LABEL: 'Bookmark this article',
+  SETTINGS_GLYPH: '⚙',
+  SETTINGS_LABEL: 'Reader settings',
+
+  /** Tweaks popover (#step-3). */
+  TWEAKS_HEADING: 'Tweaks',
+  TWEAKS_THEME_LABEL: 'Theme',
+  TWEAKS_FOCUS_STYLE_LABEL: 'Focus style',
+  TWEAKS_ACCENT_LABEL: 'Accent',
+  TWEAKS_DIM_LABEL: 'Modal dim',
+  TWEAKS_SYSTEM_LABEL: 'System',
+  TWEAKS_FOCUS_LINE_LABEL: 'Line',
+  TWEAKS_FOCUS_BOLD_LABEL: 'Bold',
+  /**
+   * Theme picker accessible-name template. Visible button text is the
+   * theme id capitalized; AT users hear the explicit "Light theme" form
+   * so the button purpose is unambiguous outside the section grouping.
+   */
+  themeButtonLabel(name: string): string {
+    return `${name} theme`;
+  },
+
+  /**
+   * Polite live-region announcement after a theme switch (WCAG 4.1.3).
+   * The visible button state flip alone leaves AT users without
+   * confirmation that the theme actually applied across the chrome.
+   */
+  themeAnnouncement(id: string): string {
+    const pretty = id === 'system' ? 'System' : id.charAt(0).toUpperCase() + id.slice(1);
+    return `Theme: ${pretty}`;
   },
 });

--- a/src/core/overlay/focus-trap.ts
+++ b/src/core/overlay/focus-trap.ts
@@ -12,11 +12,30 @@
 const FOCUSABLE_SELECTOR =
   'button:not([disabled]), [href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not(.trap-sentinel)';
 
+/**
+ * Walk up to the container checking for a `hidden` ancestor. We can't use a
+ * `:not([hidden] *)` CSS selector here because the `hidden` attribute on a
+ * tweaks panel toggles imperatively at runtime — the matcher must re-evaluate
+ * on every Tab-wrap, not on a static-selector snapshot. Walking ancestors is
+ * O(depth) per focusable but the focusable list is tiny (≤ ~12 entries in
+ * the worst case) and Tab events are user-driven, so the cost is invisible.
+ */
+function isInHiddenSubtree(el: HTMLElement, container: HTMLElement): boolean {
+  let cur: HTMLElement | null = el;
+  while (cur && cur !== container) {
+    if (cur.hidden) return true;
+    cur = cur.parentElement;
+  }
+  return false;
+}
+
 export function installFocusTrap(container: HTMLElement): () => void {
   const doc = container.ownerDocument;
   const priorActive = doc.activeElement as HTMLElement | null;
   const focusables = (): HTMLElement[] =>
-    Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+    Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+      (el) => !isInHiddenSubtree(el, container),
+    );
   const sentinels = container.querySelectorAll<HTMLElement>('.trap-sentinel');
   if (sentinels.length !== 2) {
     throw new Error('installFocusTrap: container must contain exactly two .trap-sentinel elements');

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -1,4 +1,4 @@
-import { applyTheme } from '../theme';
+import { applyTheme, THEME_IDS } from '../theme';
 import type { ThemeId } from '../theme';
 import { OVERLAY_CSS } from './styles';
 import { OVERLAY_ATTR, OVERLAY_CLASS, OVERLAY_ID, OVERLAY_TEXT } from './constants';
@@ -108,6 +108,23 @@ const HOST_ATTR = OVERLAY_ATTR.HOST;
  * are accepted — anything else throws. The single legitimate caller is
  * `chrome.runtime.getURL()` for the bundled WAR font path.
  */
+/**
+ * Strip bidi-control + C0/C1 controls from a hostname and cap visible
+ * length. Inputs flow from `document.location.hostname` — attacker-
+ * reachable through any page the content script attaches to. Bidi
+ * marks (RTL override, isolates) flip surrounding announcement order
+ * and enable visual brand spoofing; C0/C1 controls disrupt screen
+ * reader output. Cap at 60 chars so a long hostname does not dominate
+ * the modal chrome (a11y + security review finding #7).
+ */
+export function sanitizeHostname(hostname: string): string {
+  // C0 (0000-001F), DEL+C1 (007F-009F), bidi LRM/RLM (200E-200F),
+  // embedding/override (202A-202E), isolates (2066-2069).
+  // eslint-disable-next-line no-control-regex
+  const UNSAFE = /[\u0000-\u001F\u007F-\u009F\u200E\u200F\u202A-\u202E\u2066-\u2069]/g;
+  return hostname.replace(UNSAFE, '').slice(0, 60);
+}
+
 function buildOpenDyslexicFontFace(url: string): string {
   if (!/^chrome-extension:\/\/[a-zA-Z0-9_-]+\/[^"<>\s]+$/.test(url)) {
     throw new Error(`buildOpenDyslexicFontFace: untrusted URL ${url}`);
@@ -128,6 +145,10 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
   let unsubscribeSettings: (() => void) | null = null;
   let uninstallTrap: (() => void) | null = null;
   let onKeydown: ((e: KeyboardEvent) => void) | null = null;
+  // #step-3 — symmetric teardown for the shadow-root pointerdown listener
+  // installed for the panel's click-outside ergonomics. Every other shadow
+  // listener add/remove pairs explicitly; this matches that pattern.
+  let uninstallTweaksPointerDown: (() => void) | null = null;
   // #26 — live OS theme listener teardown. Attached during mount when
   // matchMedia is available; the same closure is invoked by
   // `subscribeSettings` to swap behaviour when the user toggles the
@@ -172,6 +193,9 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     scrubber: HTMLInputElement;
     scrubberElapsed: HTMLElement;
     scrubberRemaining: HTMLElement;
+    settingsBtn: HTMLButtonElement;
+    tweaksPanel: HTMLElement;
+    themeButtons: HTMLButtonElement[];
   } {
     const doc = opts.doc;
 
@@ -232,11 +256,186 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     topSentinel.className = OVERLAY_CLASS.TRAP_SENTINEL;
     topSentinel.tabIndex = 0;
 
+    // Modal header bar (mockup ".modal-header"). Houses the mini-logo + name
+    // + hostname on the left and the actions group (bookmark, settings, close)
+    // on the right. Hostname is derived from doc.location at mount; if
+    // unavailable, the source span is omitted entirely so the header reads
+    // "SpeedReader" alone.
+    const modalHeader = doc.createElement('div');
+    modalHeader.className = OVERLAY_CLASS.MODAL_HEADER;
+
+    const modalTitle = doc.createElement('div');
+    modalTitle.className = OVERLAY_CLASS.MODAL_TITLE;
+
+    const miniLogo = doc.createElement('div');
+    miniLogo.className = OVERLAY_CLASS.MINI_LOGO;
+    miniLogo.textContent = OVERLAY_TEXT.MINI_LOGO_TEXT;
+    miniLogo.setAttribute('aria-hidden', 'true');
+
+    const titleText = doc.createElement('span');
+    titleText.textContent = OVERLAY_TEXT.PRODUCT_NAME;
+
+    modalTitle.append(miniLogo, titleText);
+
+    // Hostname suffix — read from doc.location, sanitized for AT-safe
+    // announcement and rendered with a length cap. Bidi-control marks
+    // (RTL override, isolates) would flip the surrounding announcement
+    // order and enable brand spoofing; C0/C1 controls disrupt screen
+    // reader output. Strip both, then cap visible length so a very long
+    // hostname doesn't dominate the chrome bar (a11y + security review
+    // finding #7). Falsy / about:blank / data: URIs skip the separator
+    // entirely so the header degrades cleanly.
+    const hostname = doc.location?.hostname ?? '';
+    const safeHost = sanitizeHostname(hostname);
+    if (safeHost) {
+      const sourceSpan = doc.createElement('span');
+      sourceSpan.className = OVERLAY_CLASS.MODAL_SOURCE;
+      sourceSpan.textContent = `${OVERLAY_TEXT.SOURCE_SEPARATOR}${safeHost}`;
+      modalTitle.appendChild(sourceSpan);
+    }
+
+    const modalActions = doc.createElement('div');
+    modalActions.className = OVERLAY_CLASS.MODAL_ACTIONS;
+
+    // Bookmark + settings stubs — render now so the visual chrome matches
+    // the Hi-Fi mockup. Click handlers wired in follow-up commits (bookmark
+    // → reading-history, settings → tweaks panel). For Step 2 they are
+    // no-op buttons with proper aria-labels so AT users still discover them.
+    const bookmarkBtn = doc.createElement('button');
+    bookmarkBtn.className = OVERLAY_CLASS.BOOKMARK_BTN;
+    bookmarkBtn.type = 'button';
+    bookmarkBtn.textContent = OVERLAY_TEXT.BOOKMARK_GLYPH;
+    bookmarkBtn.setAttribute('aria-label', OVERLAY_TEXT.BOOKMARK_LABEL);
+
+    const settingsBtn = doc.createElement('button');
+    settingsBtn.className = OVERLAY_CLASS.SETTINGS_BTN;
+    settingsBtn.type = 'button';
+    settingsBtn.textContent = OVERLAY_TEXT.SETTINGS_GLYPH;
+    settingsBtn.setAttribute('aria-label', OVERLAY_TEXT.SETTINGS_LABEL);
+
     const closeBtn = doc.createElement('button');
     closeBtn.className = OVERLAY_CLASS.CLOSE_BTN;
     closeBtn.type = 'button';
     closeBtn.setAttribute('aria-label', OVERLAY_TEXT.CLOSE_LABEL);
     closeBtn.textContent = OVERLAY_TEXT.CLOSE_GLYPH;
+
+    modalActions.append(bookmarkBtn, settingsBtn, closeBtn);
+    modalHeader.append(modalTitle, modalActions);
+
+    // Tweaks popover (#step-3) — Disclosure pattern (ARIA-APG). Settings
+    // button toggles `aria-expanded` + `aria-controls`; the panel itself
+    // carries no role/aria-label. Tab traversal flows through the panel
+    // as part of the modal's existing focus trap (outer-trap's hidden-
+    // subtree filter skips the panel when collapsed). This replaces an
+    // earlier `role="dialog"` + inner-trap implementation; the dialog
+    // role implied modality the panel does not provide, and the inner
+    // trap was escapable via Shift+Tab from the ⚙ button (a11y-extension-
+    // designer findings #2/#6).
+    const tweaksPanel = doc.createElement('div');
+    tweaksPanel.className = OVERLAY_CLASS.TWEAKS_PANEL;
+    tweaksPanel.id = 'sr-tweaks-panel';
+    tweaksPanel.setAttribute('aria-labelledby', 'sr-tweaks-heading');
+    tweaksPanel.hidden = true;
+
+    settingsBtn.setAttribute('aria-expanded', 'false');
+    settingsBtn.setAttribute('aria-controls', tweaksPanel.id);
+
+    const tweaksHeading = doc.createElement('h3');
+    tweaksHeading.className = OVERLAY_CLASS.TWEAKS_HEADING;
+    tweaksHeading.id = 'sr-tweaks-heading';
+    tweaksHeading.textContent = OVERLAY_TEXT.TWEAKS_HEADING;
+
+    // Theme section — segmented row of buttons (one per ThemeId + a
+    // System sentinel). The Active state is communicated via .active
+    // class + aria-pressed="true"; clicking invokes onThemeChange and
+    // flips the class synchronously so the user sees instant feedback
+    // even when the host hasn't wired the callback.
+    const themeSection = doc.createElement('div');
+    themeSection.className = OVERLAY_CLASS.TWEAKS_SECTION;
+
+    const themeLabel = doc.createElement('div');
+    themeLabel.className = OVERLAY_CLASS.TWEAKS_SECTION_LABEL;
+    themeLabel.textContent = OVERLAY_TEXT.TWEAKS_THEME_LABEL;
+    themeLabel.id = 'sr-tweaks-theme-label';
+
+    const themeSeg = doc.createElement('div');
+    themeSeg.className = OVERLAY_CLASS.TWEAKS_SEG;
+    themeSeg.setAttribute('role', 'group');
+    themeSeg.setAttribute('aria-labelledby', themeLabel.id);
+
+    const themeButtons: HTMLButtonElement[] = [];
+    const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
+    const themeChoices: ReadonlyArray<{ id: ThemeId | 'system'; label: string }> = [
+      ...THEME_IDS.map((id) => ({ id, label: capitalize(id) })),
+      { id: 'system' as const, label: OVERLAY_TEXT.TWEAKS_SYSTEM_LABEL },
+    ];
+    for (const choice of themeChoices) {
+      const btn = doc.createElement('button');
+      btn.type = 'button';
+      btn.className = OVERLAY_CLASS.TWEAKS_SEG_BTN;
+      btn.textContent = choice.label;
+      btn.dataset.themeId = choice.id;
+      btn.setAttribute('aria-label', OVERLAY_TEXT.themeButtonLabel(choice.label));
+      btn.setAttribute('aria-pressed', 'false');
+      themeSeg.appendChild(btn);
+      themeButtons.push(btn);
+    }
+    themeSection.append(themeLabel, themeSeg);
+
+    // Stub sections (Focus style / Accent / Modal dim) — render disabled
+    // so the panel layout matches the mockup. Wired in later steps.
+    const focusSection = doc.createElement('div');
+    focusSection.className = OVERLAY_CLASS.TWEAKS_SECTION;
+    const focusLabel = doc.createElement('div');
+    focusLabel.className = OVERLAY_CLASS.TWEAKS_SECTION_LABEL;
+    focusLabel.textContent = OVERLAY_TEXT.TWEAKS_FOCUS_STYLE_LABEL;
+    focusLabel.id = 'sr-tweaks-focus-label';
+    const focusSeg = doc.createElement('div');
+    focusSeg.className = OVERLAY_CLASS.TWEAKS_SEG;
+    focusSeg.setAttribute('role', 'group');
+    focusSeg.setAttribute('aria-labelledby', focusLabel.id);
+    for (const stubLabel of [
+      OVERLAY_TEXT.TWEAKS_FOCUS_LINE_LABEL,
+      OVERLAY_TEXT.TWEAKS_FOCUS_BOLD_LABEL,
+    ]) {
+      const stubBtn = doc.createElement('button');
+      stubBtn.type = 'button';
+      stubBtn.className = OVERLAY_CLASS.TWEAKS_SEG_BTN;
+      stubBtn.textContent = stubLabel;
+      stubBtn.disabled = true;
+      focusSeg.appendChild(stubBtn);
+    }
+    focusSection.append(focusLabel, focusSeg);
+
+    const accentSection = doc.createElement('div');
+    accentSection.className = OVERLAY_CLASS.TWEAKS_SECTION;
+    const accentLabel = doc.createElement('div');
+    accentLabel.className = OVERLAY_CLASS.TWEAKS_SECTION_LABEL;
+    accentLabel.textContent = OVERLAY_TEXT.TWEAKS_ACCENT_LABEL;
+    const accentSwatch = doc.createElement('button');
+    accentSwatch.type = 'button';
+    accentSwatch.className = OVERLAY_CLASS.TWEAKS_ACCENT_SWATCH;
+    accentSwatch.setAttribute('aria-label', OVERLAY_TEXT.TWEAKS_ACCENT_LABEL);
+    accentSwatch.disabled = true;
+    accentSection.append(accentLabel, accentSwatch);
+
+    const dimSection = doc.createElement('div');
+    dimSection.className = OVERLAY_CLASS.TWEAKS_SECTION;
+    const dimLabel = doc.createElement('div');
+    dimLabel.className = OVERLAY_CLASS.TWEAKS_SECTION_LABEL;
+    dimLabel.textContent = OVERLAY_TEXT.TWEAKS_DIM_LABEL;
+    dimLabel.id = 'sr-tweaks-dim-label';
+    const dimRange = doc.createElement('input');
+    dimRange.type = 'range';
+    dimRange.min = '0';
+    dimRange.max = '100';
+    dimRange.value = '50';
+    dimRange.className = OVERLAY_CLASS.TWEAKS_DIM_RANGE;
+    dimRange.disabled = true;
+    dimRange.setAttribute('aria-labelledby', dimLabel.id);
+    dimSection.append(dimLabel, dimRange);
+
+    tweaksPanel.append(tweaksHeading, themeSection, focusSection, accentSection, dimSection);
 
     const word = doc.createElement('div');
     word.className = OVERLAY_CLASS.WORD_REGION;
@@ -379,9 +578,14 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     bottomSentinel.className = OVERLAY_CLASS.TRAP_SENTINEL;
     bottomSentinel.tabIndex = 0;
 
-    const children: Node[] = [topSentinel, closeBtn, header];
+    // Mockup append order: top-sentinel → modal-header (logo + actions
+    // including close-btn) → scope-header (article-meta) → optional
+    // subtitle → word → preview → aria-live → scrubber → footer →
+    // bottom-sentinel. close-btn is now nested inside modalHeader.actions
+    // so it is NOT a direct modal child.
+    const children: Node[] = [topSentinel, modalHeader, header];
     if (subtitle) children.push(subtitle);
-    children.push(word, preview, ariaLive, scrubberArea, footer, bottomSentinel);
+    children.push(word, preview, ariaLive, scrubberArea, footer, tweaksPanel, bottomSentinel);
     modal.append(...children);
     backdrop.appendChild(modal);
     shadow.appendChild(backdrop);
@@ -404,6 +608,9 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       scrubber,
       scrubberElapsed,
       scrubberRemaining,
+      settingsBtn,
+      tweaksPanel,
+      themeButtons,
     };
   }
 
@@ -459,6 +666,9 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       scrubber,
       scrubberElapsed,
       scrubberRemaining,
+      settingsBtn,
+      tweaksPanel,
+      themeButtons,
     } = buildShadowTree(shadow, scopeView);
     const resolvedTheme = resolveTheme(opts.initialSettings.theme, view);
     applyTheme(resolvedTheme, modal);
@@ -500,6 +710,18 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       uninstallSystemThemeListener = null;
     };
     if (currentTheme === 'system') installSystemThemeListener();
+
+    // #step-3 — flip the .active class + aria-pressed on the Tweaks
+    // theme buttons. Declared up here so the subscribeSettings echo path
+    // below can call it without a temporal-dead-zone hazard if a host
+    // implementation fires the listener synchronously.
+    const syncThemeButtons = (active: ThemeId | 'system'): void => {
+      for (const btn of themeButtons) {
+        const isActive = btn.dataset.themeId === active;
+        btn.classList.toggle(OVERLAY_CLASS.TWEAKS_SEG_BTN_ACTIVE, isActive);
+        btn.setAttribute('aria-pressed', String(isActive));
+      }
+    };
 
     // Local WPM is the source of truth for engine cadence while mounted.
     // Persisted settings updates push in via `subscribeSettings`; the
@@ -570,11 +792,20 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     applyFont(currentFont);
 
     unsubscribeSettings = opts.subscribeSettings((s) => {
-      const resolved = resolveTheme(s.theme, view);
-      applyTheme(resolved, modal);
-      currentTheme = s.theme;
-      if (s.theme === 'system') installSystemThemeListener();
-      else removeSystemThemeListener();
+      // Theme-side work runs only on a real change. The existing
+      // wpm/fontSize/font/chunkSize/alignment branches below all guard
+      // on `next !== current` to avoid CSS invalidation under hot-cadence
+      // settings echoes (WPM slider drag); theme matches that pattern
+      // (perf-adversary finding #2). applyTheme is idempotent so this is
+      // a perf guard, not a correctness fix.
+      if (s.theme !== currentTheme) {
+        const resolved = resolveTheme(s.theme, view);
+        applyTheme(resolved, modal);
+        currentTheme = s.theme;
+        if (s.theme === 'system') installSystemThemeListener();
+        else removeSystemThemeListener();
+        syncThemeButtons(s.theme);
+      }
       if (s.wpm !== currentWpm) {
         currentWpm = s.wpm;
         engine?.setWpm(s.wpm);
@@ -1057,6 +1288,96 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
 
     swapBtn?.addEventListener('click', swapToFull);
 
+    // ===== Tweaks popover (#step-3) =====
+    // Click wiring lands here. syncThemeButtons is defined as a function
+    // declaration above the subscribeSettings block so the echo path can
+    // call it without a TDZ hazard.
+    syncThemeButtons(opts.initialSettings.theme);
+    // Defense-in-depth: dataset is attacker-reachable on an open shadow
+    // root, so validate against the allowlist before flowing into
+    // applyTheme / persistence callback (security-adversary finding #5).
+    const ALLOWED_THEME_IDS = new Set<string>([...THEME_IDS, 'system']);
+    for (const btn of themeButtons) {
+      btn.addEventListener('click', () => {
+        const raw = btn.dataset.themeId;
+        if (!raw || !ALLOWED_THEME_IDS.has(raw)) return;
+        const id = raw as ThemeId | 'system';
+        syncThemeButtons(id);
+        currentTheme = id;
+        // Apply locally for instant feedback. The subscribeSettings echo
+        // (if any) will run applyTheme again with the same resolved value;
+        // applyTheme is idempotent so a duplicate write is harmless.
+        applyTheme(resolveTheme(id, view), modal);
+        if (id === 'system') installSystemThemeListener();
+        else removeSystemThemeListener();
+        opts.onThemeChange?.(id);
+        // WCAG 4.1.3 Status Messages — confirm the theme switch via the
+        // polite live region. AT users hear "Theme: Sepia" so they know
+        // their click had a non-trivial side effect beyond the button
+        // state flip (a11y-extension-designer finding #4). Clear-then-set
+        // forces re-announcement when the same theme is clicked twice.
+        ariaLive.textContent = '';
+        ariaLive.textContent = OVERLAY_TEXT.themeAnnouncement(id);
+      });
+    }
+
+    const isTweaksOpen = (): boolean => !tweaksPanel.hidden;
+    // Disclosure pattern (ARIA-APG) — no inner focus trap. The outer modal
+    // trap's `isInHiddenSubtree` filter excludes the panel's controls
+    // while hidden; when open, Tab flows naturally through panel buttons
+    // alongside the rest of the modal's focusables. The settings button +
+    // panel form a labeled relationship via aria-controls + aria-expanded.
+    const openTweaks = (): void => {
+      if (!tweaksPanel.hidden) return;
+      tweaksPanel.hidden = false;
+      settingsBtn.setAttribute('aria-expanded', 'true');
+      // Move focus into the panel so kbd users land on the first theme
+      // button on open (matches mouse-user expectation of "I clicked
+      // settings, the next thing I do happens in the panel"). The first
+      // theme button is the first focusable inside the panel.
+      const firstFocusable = tweaksPanel.querySelector<HTMLElement>(
+        'button:not([disabled]), input:not([disabled])',
+      );
+      firstFocusable?.focus();
+    };
+    const closeTweaks = (returnFocus: boolean): void => {
+      if (tweaksPanel.hidden) return;
+      tweaksPanel.hidden = true;
+      settingsBtn.setAttribute('aria-expanded', 'false');
+      if (returnFocus) settingsBtn.focus();
+    };
+    settingsBtn.addEventListener('click', (e) => {
+      // Stop propagation so the click doesn't trip the click-outside
+      // listener below in the same event tick.
+      e.stopPropagation();
+      if (isTweaksOpen()) closeTweaks(true);
+      else openTweaks();
+    });
+
+    // Click-outside — any pointerdown inside the modal or backdrop that
+    // is NOT inside the panel AND not on the settings button closes the
+    // panel. Bound on the shadow root so we catch events before they
+    // reach the document; we use `pointerdown` (covers mouse, touch, pen)
+    // so touch-primary users can also dismiss — synthesized mousedown is
+    // suppressed on some gesture paths in iOS Safari + recent Chromium
+    // (security-adversary finding #4).
+    const onShadowPointerDown = (e: Event): void => {
+      if (!isTweaksOpen()) return;
+      const target = e.target;
+      if (!(target instanceof Node)) return;
+      if (tweaksPanel.contains(target)) return;
+      if (settingsBtn.contains(target)) return;
+      closeTweaks(true);
+    };
+    shadow.addEventListener('pointerdown', onShadowPointerDown, true);
+    // Captured into the outer closure for symmetric teardown in unmount()
+    // — every other shadow listener pairs add+remove explicitly so a
+    // mount/unmount cycle does not accumulate handlers
+    // (perf-adversary finding #4 + security-adversary finding #3).
+    uninstallTweaksPointerDown = () => {
+      shadow.removeEventListener('pointerdown', onShadowPointerDown, true);
+    };
+
     uninstallTrap = installFocusTrap(modal);
     // installFocusTrap auto-focuses the first DOM-order focusable (the
     // close button at top-right). Override to land on play/pause per
@@ -1267,6 +1588,13 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
       if (e.key === 'Escape') {
         e.preventDefault();
+        // #step-3 — when the Tweaks popover is open, Escape closes ONLY
+        // the panel and returns focus to the settings button. Existing
+        // overlay-close behaviour applies when the panel is closed.
+        if (isTweaksOpen()) {
+          closeTweaks(true);
+          return;
+        }
         close();
         return;
       }
@@ -1323,6 +1651,11 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       clearTimeout(scrubDebounceTimer);
       scrubDebounceTimer = null;
     }
+    // #step-3 — drop the shadow pointerdown listener before the outer
+    // trap so the click-outside handler can't fire against a detached
+    // shadow during teardown.
+    uninstallTweaksPointerDown?.();
+    uninstallTweaksPointerDown = null;
     uninstallTrap?.();
     uninstallTrap = null;
     if (onKeydown) opts.doc.removeEventListener('keydown', onKeydown, true);

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -1,8 +1,23 @@
 /**
  * Overlay stylesheet, served via adoptedStyleSheets on the open shadow
- * root. Container query primer lives in the #35 spec; this MVP floor
- * uses fluid clamp() that satisfies WCAG 1.4.10 / 1.4.4 at 320px and
- * 200% zoom without dedicated tier blocks. Tiers land in a follow-up.
+ * root. Reskinned to match the approved Hi-Fi mockup
+ * (docs/design source: SpeedReader-standalone Hi-Fi). The DOM structure
+ * is unchanged; existing class names from `constants.ts` remain the
+ * single source of truth so the 24-file overlay test suite stays green.
+ *
+ * Visual deltas vs prior styling (mockup-derived):
+ *   - Modal: 620px max, rounded 16px corners, surface bg, accent border
+ *   - Typography: Roboto / Roboto-Mono with system fallbacks
+ *   - Close button: 30px circular icon-btn (was 44px outlined square)
+ *   - Word region: 54px mono ORP word, accent focus letter
+ *   - Context preview: 13px serif, `.now` highlight inline
+ *   - Progress scrubber: thin (4px) accent rail with circular thumb
+ *   - Controls: circular ctrl-btns, primary play (48px accent)
+ *   - WPM: slider styled to match mockup's pill chip
+ *
+ * Ancillary tokens (--surface-2, --text-muted, --border, etc.) are
+ * derived from the 5 theme tokens via color-mix so the existing
+ * applyTheme() contract stays the contract.
  *
  * forced-colors block uses system tokens per #35 spec section 6.
  * prefers-reduced-motion disables chrome transitions only (RSVP cadence
@@ -15,47 +30,68 @@ export const OVERLAY_CSS = `
   inset: 0;
   z-index: 2147483647;
   display: block;
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-family: 'Roboto', 'Google Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+
+  /* Theme-invariant tokens (do not depend on applyTheme writes). */
+  --brand-red: #d93025;
+  --shadow-1: 0 1px 2px rgba(0,0,0,.10), 0 1px 3px 1px rgba(0,0,0,.06);
+  --shadow-3: 0 4px 8px 3px rgba(0,0,0,.18), 0 1px 3px rgba(0,0,0,.32);
+  --radius: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --font-ui: 'Roboto', 'Google Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-mono: 'Roboto Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  --font-reader: 'Source Serif 4', 'Source Serif Pro', Georgia, serif;
 }
 
 .backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.78);
+  background: rgba(0, 0, 0, 0.45);
   display: grid;
   place-items: center;
-  padding: 24px;
+  padding: 40px;
 }
 
 .modal {
+  /* applyTheme() writes --bg/--surface/--text/--accent/--accent-soft onto
+   * THIS element. The ancillary palette (--surface-2/-3, --text-muted,
+   * --border, etc.) is derived here from those writes via color-mix so a
+   * theme flip cascades through every descendant in one update. Keep
+   * derivations on .modal (NOT :host) so the cascade has the post-applyTheme
+   * values to mix against. */
+  --surface-2: color-mix(in oklab, var(--surface, #ffffff) 96%, var(--text, #202124));
+  --surface-3: color-mix(in oklab, var(--surface, #ffffff) 92%, var(--text, #202124));
+  --text-2: color-mix(in oklab, var(--text, #202124) 85%, var(--surface, #ffffff));
+  /* --text-muted at 60/40 mix lands ~4.0–4.2:1 on light/paper/cream
+   * surfaces — below WCAG 1.4.3 (4.5:1 for &lt;18px non-bold). 75/25 lands
+   * ~5.5:1 across themes and preserves the muted feel
+   * (a11y-extension-designer finding #1). */
+  --text-muted: color-mix(in oklab, var(--text, #202124) 75%, var(--surface, #ffffff));
+  --text-faint: color-mix(in oklab, var(--text, #202124) 40%, var(--surface, #ffffff));
+  --border: color-mix(in oklab, var(--text, #202124) 18%, var(--surface, #ffffff));
+  --border-strong: color-mix(in oklab, var(--text, #202124) 35%, var(--surface, #ffffff));
+  --accent-hover: color-mix(in oklab, var(--accent, #1a73e8) 88%, black);
+
   background: var(--surface, #ffffff);
-  color: var(--text, #111111);
-  border-radius: 12px;
-  padding: clamp(24px, 6cqi, 64px);
-  max-inline-size: min(72ch, 1100px);
-  inline-size: 100%;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  color: var(--text, #202124);
+  border-radius: var(--radius-xl);
+  padding: 0;
+  inline-size: 620px;
+  max-inline-size: calc(100% - 40px);
+  box-shadow: var(--shadow-3);
+  border: 1px solid var(--border);
   position: relative;
+  overflow: hidden;
   container-type: inline-size;
   container-name: rsvp;
+  font-family: var(--font-ui);
 }
 
-/* Font picker (#28) — Safari-parity 5-font set. Family stacks mirror
- * SpeedReader/SpeedReaderExtension/Resources/rsvp/overlay.css. Scoped to
- * the reading surface only (word + context-preview); UI chrome stays in
- * the system font so button labels read consistently across picker
- * selections. The 'system' ID applies no class — the default .modal
- * family stack at :host above is already system-ui. */
+/* Font picker (#28) — Safari-parity 5-font set scoped to reading surface. */
 .modal.opendyslexic .word-region,
 .modal.opendyslexic .context-current,
 .modal.opendyslexic .context-preview {
-  /* Fallback chain ordered for dyslexia readability — generic system-ui
-   * only as last resort. Atkinson Hyperlegible (Braille Institute,
-   * downloadable / ships on some platforms), Comic Sans MS (research-
-   * cited dyslexia-friendly letter disambiguation; preinstalled on
-   * Windows + macOS), and Trebuchet MS (also research-cited; preinstalled
-   * cross-platform) keep the user on a dyslexia-friendly face when the
-   * bundled OpenDyslexic WOFF2 fails to load. See #190. */
   font-family:
     'OpenDyslexic', 'Atkinson Hyperlegible', 'Comic Sans MS',
     'Trebuchet MS', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
@@ -64,9 +100,6 @@ export const OVERLAY_CSS = `
 .modal.newYork .word-region,
 .modal.newYork .context-current,
 .modal.newYork .context-preview {
-  /* macOS/iOS ship 'New York' (Apple system serif); Chromium on other
-   * platforms falls back to Iowan Old Style → Georgia → generic serif so
-   * the user still sees a comfortable serif face. */
   font-family: 'New York', 'Iowan Old Style', Georgia, serif;
 }
 
@@ -79,305 +112,182 @@ export const OVERLAY_CSS = `
 .modal.menlo .word-region,
 .modal.menlo .context-current,
 .modal.menlo .context-preview {
-  /* Apple-bundled monospace; the fallback chain covers Windows
-   * ('Courier New') and Linux (generic monospace). */
   font-family: Menlo, 'Courier New', monospace;
 }
 
-.close-btn {
-  position: absolute;
-  top: 16px;
-  right: 16px;
+/* ===== Modal header bar — mockup ".modal-header" =====
+ * Top chrome row with mini-logo + product name + hostname on left,
+ * action icons on right. Sits above .scope-header (which carries the
+ * article-meta info). */
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px 10px 18px;
+  border-block-end: 1px solid var(--border);
+  background: var(--surface-2);
+  margin-block-end: 2px;
+}
+
+.modal-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font: 500 13px / 1.2 var(--font-ui);
+  color: var(--text);
+  min-inline-size: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mini-logo {
+  inline-size: 22px;
+  block-size: 22px;
+  border-radius: 6px;
+  background: var(--brand-red);
+  color: #ffffff;
+  display: grid;
+  place-items: center;
+  font: 700 9px / 1 var(--font-mono);
+  flex-shrink: 0;
+  letter-spacing: 0.05em;
+}
+
+.modal-source {
+  color: var(--text-muted);
+  font-weight: 400;
+  font-size: 12px;
+}
+
+.modal-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+/* ===== Close + bookmark + settings — shared icon-btn baseline =====
+ * In-header icon buttons. WCAG 2.5.5 target-size honored at 44px. */
+.close-btn,
+.bookmark-btn,
+.settings-btn {
   width: 44px;
   height: 44px;
-  border: 2px solid var(--text, #111111);
-  border-radius: 8px;
+  min-width: 44px;
+  min-height: 44px;
+  border-radius: 50%;
+  border: none;
   background: transparent;
-  color: var(--text, #111111);
-  font: 700 20px / 1 system-ui, sans-serif;
+  color: var(--text-muted);
+  font: 600 14px / 1 var(--font-ui);
   cursor: pointer;
+  display: grid;
+  place-items: center;
+  padding: 0;
+}
+
+.bookmark-btn,
+.settings-btn {
+  font-size: 16px;
 }
 
 .close-btn:hover {
-  background: var(--accent-soft, rgba(37, 99, 235, 0.12));
-  color: var(--text, #111111);
+  background: var(--accent-soft, #e8f0fe);
+  color: var(--text, #202124);
 }
 
-.close-btn:focus-visible {
-  outline: 3px solid var(--accent, #2563eb);
+.bookmark-btn:hover,
+.settings-btn:hover {
+  background: var(--accent-soft, #e8f0fe);
+  color: var(--text);
+}
+
+.close-btn:focus-visible,
+.bookmark-btn:focus-visible,
+.settings-btn:focus-visible {
+  outline: 2px solid var(--accent, #1a73e8);
   outline-offset: 2px;
 }
 
-.footer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 16px;
-  padding-block-start: clamp(16px, 4cqi, 32px);
-}
-
-.play-pause-btn {
-  min-width: 96px;
-  min-height: 44px;
-  padding: 8px 20px;
-  border: 2px solid var(--text, #111111);
-  border-radius: 8px;
-  background: var(--accent, #2563eb);
-  color: var(--bg, #ffffff);
-  font: 700 16px / 1 system-ui, sans-serif;
-  cursor: pointer;
-}
-
-.play-pause-btn:hover {
-  background: var(--accent-soft, rgba(37, 99, 235, 0.12));
-  color: var(--text, #111111);
-}
-
-.play-pause-btn:focus-visible {
-  outline: 3px solid var(--text, #111111);
-  outline-offset: 2px;
-}
-
-.play-pause-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
+/* ===== Scope header — repurposed as ".article-meta" row =====
+ * Mockup shows: bold title • author • word-count pill, 12px muted.
+ * We carry just the header text in current DOM (h2 with full title or
+ * scoped descriptor). Close icon now lives inside .modal-header, so the
+ * right padding here is symmetric. */
 .scope-header {
   margin: 0;
-  padding-inline-end: 56px; /* leave room for top-right close button */
-  font-size: clamp(0.95rem, 1.6cqi + 0.5rem, 1.25rem);
-  font-weight: 700;
-  line-height: 1.3;
-  letter-spacing: 0.02em;
+  padding: 14px 24px 0;
+  font: 500 14px / 1.3 var(--font-ui);
+  color: var(--text);
+  letter-spacing: 0;
 }
 
 .scope-subtitle {
-  margin: 6px 0 0;
-  font-size: clamp(0.8rem, 1.2cqi + 0.4rem, 1rem);
+  margin: 4px 24px 0;
+  padding: 0;
+  font: 400 11px / 1.4 var(--font-ui);
   font-style: italic;
-  color: var(--text, #111111);
-  opacity: 0.85;
+  color: var(--text-muted);
 }
 
-.scope-swap-btn {
-  min-height: 44px;
-  padding: 8px 16px;
-  border: 2px solid var(--text, #111111);
-  border-radius: 8px;
-  background: transparent;
-  color: var(--text, #111111);
-  font: 600 14px / 1 system-ui, sans-serif;
-  cursor: pointer;
-}
-
-.scope-swap-btn:hover {
-  background: var(--accent-soft, rgba(37, 99, 235, 0.12));
-  color: var(--text, #111111);
-}
-
-.scope-swap-btn:focus-visible {
-  outline: 3px solid var(--accent, #2563eb);
-  outline-offset: 2px;
-}
-
-/* Font-size stepper buttons (#29). Visual treatment mirrors
- * .scope-swap-btn (outline style, accent on hover) and tap-target
- * dimensions mirror .close-btn so the WCAG 2.5.5 minimum holds across
- * the control bar. */
-.font-dec-btn,
-.font-inc-btn {
-  min-width: 44px;
-  min-height: 44px;
-  padding: 8px 12px;
-  border: 2px solid var(--text, #111111);
-  border-radius: 8px;
-  background: transparent;
-  color: var(--text, #111111);
-  font: 700 16px / 1 system-ui, sans-serif;
-  cursor: pointer;
-}
-
-.font-dec-btn:hover,
-.font-inc-btn:hover {
-  background: var(--accent-soft, rgba(37, 99, 235, 0.12));
-  color: var(--text, #111111);
-}
-
-.font-dec-btn:focus-visible,
-.font-inc-btn:focus-visible {
-  outline: 3px solid var(--accent, #2563eb);
-  outline-offset: 2px;
-}
-
-.font-dec-btn:disabled,
-.font-inc-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-/* Prev / next sentence buttons (#23). Same outline / accent treatment as
- * the font stepper; ≥44×44 px so WCAG 2.5.5 holds across the control bar. */
-.prev-sentence-btn,
-.next-sentence-btn {
-  min-width: 44px;
-  min-height: 44px;
-  padding: 8px 12px;
-  border: 2px solid var(--text, #111111);
-  border-radius: 8px;
-  background: transparent;
-  color: var(--text, #111111);
-  font: 700 18px / 1 system-ui, sans-serif;
-  cursor: pointer;
-}
-
-.prev-sentence-btn:hover,
-.next-sentence-btn:hover {
-  background: var(--accent-soft, rgba(37, 99, 235, 0.12));
-  color: var(--text, #111111);
-}
-
-.prev-sentence-btn:focus-visible,
-.next-sentence-btn:focus-visible {
-  outline: 3px solid var(--accent, #2563eb);
-  outline-offset: 2px;
-}
-
-/* WPM slider (#24). The native <input type="range"> default thumb is well
- * below the WCAG 2.5.5 target-size minimum (24px on Chromium, ~18px on
- * WebKit). The base styles below give the slider element a 44px hitbox
- * (touch-primary block bumps to 48px). Track + thumb keep system defaults
- * inside that hitbox so we don't fight the cross-browser thumb shape. */
-.wpm-slider,
-.scrubber-slider {
-  min-height: 44px;
-  /* The default range thumb is small; the larger inline-size gives the
-   * user enough travel for a 100→600 step=10 sweep. */
-  inline-size: clamp(120px, 22cqi, 240px);
-  accent-color: var(--accent, #2563eb);
-  cursor: pointer;
-}
-
-.wpm-slider:focus-visible,
-.scrubber-slider:focus-visible {
-  outline: 3px solid var(--accent, #2563eb);
-  outline-offset: 4px;
-}
-
-/* Progress scrubber (#47). Layout is a labels row above a full-width
- * native range input. The slider reuses the WPM slider base rules above
- * (shared min-height/track/thumb); only width differs — the scrubber is
- * a full-width position control, where the WPM slider is a side control.
- * Labels use tabular-nums to prevent layout jitter as digits change.
- *
- * FIX-5 (ring-review architect MED #2) — auto-hide guidance for #52:
- * .scrubber-area's #52 polish (auto-hide on playing, reveal on hover /
- * focus / tap) MUST use visibility:hidden OR opacity:0 +
- * pointer-events:none — NEVER display:none. The latter collapses the
- * margin-block-start slot below and reflows the word region every time
- * the scrubber toggles, producing visible jitter that fights the RSVP
- * cadence. Visibility / opacity keeps the layout slot reserved so the
- * word region's vertical center stays stable. */
-.scrubber-area {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin-block-start: clamp(12px, 3cqi, 24px);
-  inline-size: 100%;
-  max-inline-size: 60ch;
-  margin-inline: auto;
-  /* #52 PART D — auto-hide transition. Overlay JS toggles opacity +
-   * visibility + pointer-events inline; the 200ms ease-out transition
-   * here smooths the flip so the bar fades in/out rather than blinking.
-   * Visibility is transitioned alongside opacity so the bar becomes
-   * non-interactive at the right moment (visibility:hidden takes effect
-   * at the END of the transition for fade-out; the simultaneous
-   * pointer-events:none ensures input is blocked the instant hide
-   * begins). prefers-reduced-motion (below) drops the transition entirely
-   * so the flip is instant for users who opt out of motion. */
-  transition: opacity 200ms ease-out, visibility 200ms ease-out;
-}
-
-.scrubber-labels {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font: 600 12px / 1 system-ui, sans-serif;
-  font-variant-numeric: tabular-nums;
-  color: var(--text, #111111);
-  opacity: 0.85;
-}
-
-.scrubber-slider {
-  /* Override the WPM slider's bounded inline-size — the scrubber is a
-   * full-width position control. */
-  inline-size: 100%;
-}
-
-.wpm-readout {
-  /* tabular-nums prevents the readout width from jittering as the digit
-   * count changes during a drag (100 → 99 → 100 etc.). */
-  font: 600 14px / 1 system-ui, sans-serif;
-  font-variant-numeric: tabular-nums;
-  color: var(--text, #111111);
-  min-inline-size: 6ch;
-  text-align: start;
-}
-
+/* ===== Word region — mockup ".rsvp-stage > .rsvp-word" =====
+ * Generous vertical padding gives the ORP word breathing room. The
+ * accent focus-tick marks above and below the word are rendered as
+ * CSS pseudo-elements anchored to the region's vertical center — no
+ * DOM nodes required, so the existing word-run rendering pipeline
+ * (single-word + chunk + ORP grid) is unaffected. */
 .word-region {
-  /*
-   * Flex layout (#52 PART C) so multiple .word-run wrappers inside a
-   * chunk flow on one line separated by the space text nodes
-   * renderChunk injects. text-align: center is kept for legacy single-
-   * span content (e.g. tests that write textContent directly); the
-   * justify-content: center below is what actually centers the
-   * .word-run children produced by renderWord / renderChunk.
-   *
-   * Wrap so a long chunk on a narrow viewport breaks gracefully rather
-   * than overflowing the modal — flex-wrap keeps the modal width as the
-   * hard cap.
-   */
   text-align: center;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   align-items: baseline;
   gap: 0 0.4ch;
-  /*
-   * When the in-modal A−/A+ stepper (#29) sets --rsvp-font-size as an
-   * inline custom property, this font-size resolves to the user-chosen
-   * value (clamped to FONT_SIZE_MIN..MAX in JS). When the custom
-   * property is absent (e.g. caller hasn't wired the stepper yet) the
-   * fluid clamp() fallback satisfies WCAG 1.4.10 / 1.4.4 at 320px and
-   * 200% zoom per the responsive-overlay spec.
-   */
-  font-size: var(--rsvp-font-size, clamp(2rem, 5.5cqi + 1rem, 5.5rem));
+  padding: 36px 24px 20px;
+  font-family: var(--font-mono);
+  font-size: var(--rsvp-font-size, clamp(40px, 8.5cqi + 0.5rem, 54px));
+  font-weight: 500;
+  letter-spacing: 0.01em;
   line-height: 1.15;
   font-variant-numeric: tabular-nums;
-  padding-block: clamp(32px, 8cqi, 96px);
+  color: var(--text);
+  min-block-size: 110px;
+  user-select: none;
+  position: relative;
+}
+
+.word-region::before,
+.word-region::after {
+  content: '';
+  position: absolute;
+  inset-inline-start: 50%;
+  transform: translateX(-50%);
+  width: 1.5px;
+  background: var(--accent, #1a73e8);
+  opacity: 0.85;
+  border-radius: 1px;
+  pointer-events: none;
+}
+
+.word-region::before {
+  top: 18px;
+  height: 14px;
+}
+
+.word-region::after {
+  bottom: 6px;
+  height: 14px;
 }
 
 .word-region .focus {
-  color: var(--accent, #2563eb);
+  color: var(--accent, #1a73e8);
+  font-weight: 600;
 }
 
-/* Word alignment (#52 PART A). Each word — single-word emission AND each
- * word inside a chunk — is wrapped in a .word-run span. The
- * data-alignment host attribute drives the per-run layout:
- *
- *   - "orp" (default, Safari upstream): 3-column grid where before /
- *     focus / after sit in columns of width 1fr / auto / 1fr. The focus
- *     character anchors at the same horizontal position across successive
- *     runs so the eye doesn't micro-saccade between words. Matches the
- *     Safari spec at docs/superpowers/specs/2026-04-04-orp-alignment-design.md.
- *   - "center": inline layout (display: block on the run reverts the grid
- *     and lets the centered .word-region parent center the inline
- *     before/focus/after spans naturally).
- *
- * In chunk mode (chunkSize ≥ 2), multiple .word-run wrappers sit inside
- * .word-region separated by space text nodes; the grid layout per-run
- * keeps each word independently ORP-aligned (the chunk is read as a
- * unit; cross-word column alignment is NOT a goal). */
+/* ORP alignment (#52) — preserved from prior implementation. */
 :host([data-alignment="orp"]) .word-run {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
@@ -385,25 +295,44 @@ export const OVERLAY_CSS = `
 }
 
 :host([data-alignment="orp"]) .word-run > span:first-child {
-  /* before — right-aligned so text flows TOWARD the focus column. */
   text-align: end;
 }
 
 :host([data-alignment="orp"]) .word-run > span:last-child {
-  /* after — left-aligned so text flows AWAY from the focus column. */
   text-align: start;
 }
 
 :host([data-alignment="center"]) .word-run {
-  /* Revert the grid; inline before/focus/after spans flow naturally
-   * inside the centered .word-region parent. */
   display: block;
 }
 
+/* ===== Context preview — mockup ".rsvp-context" =====
+ * 13px serif, muted, with the current word inline-highlighted via
+ * .context-current → mockup's ".now" treatment (accent-soft bg pill). */
+.context-preview {
+  margin: 0;
+  padding: 0 32px 16px;
+  font: 400 13px / 1.5 var(--font-reader);
+  color: var(--text-muted);
+  text-align: center;
+  min-block-size: 24px;
+}
+
+.context-preview[hidden] { display: none; }
+
+.context-current {
+  color: var(--text);
+  background: var(--accent-soft, #e8f0fe);
+  padding: 0 4px;
+  border-radius: 3px;
+  font-weight: 500;
+}
+
+/* ===== Aria-live region (visually hidden but available to AT). ===== */
 .aria-live {
   position: absolute;
-  width: 1px;
-  height: 1px;
+  inline-size: 1px;
+  block-size: 1px;
   margin: -1px;
   padding: 0;
   overflow: hidden;
@@ -412,47 +341,210 @@ export const OVERLAY_CSS = `
   border: 0;
 }
 
-.context-preview {
-  margin-block-start: clamp(12px, 3cqi, 24px);
-  font-size: clamp(0.85rem, 1.2cqi + 0.4rem, 1.05rem);
-  line-height: 1.5;
-  color: var(--text, #111111);
-  opacity: 0.85;
-  max-inline-size: 60ch;
-  margin-inline: auto;
-  text-align: center;
-}
-
-.context-preview[hidden] { display: none; }
-
-.context-current {
-  font-weight: 700;
-  /* Subtle accent so the eye lands on the current word in the sentence. */
-  color: var(--accent, #2563eb);
-}
-
+/* ===== Trap sentinels — focus trap boundaries. ===== */
 .trap-sentinel {
   position: absolute;
-  width: 1px;
-  height: 1px;
+  inline-size: 1px;
+  block-size: 1px;
   opacity: 0;
   pointer-events: none;
 }
 
-/* Reading-position resume toast (#48). Non-blocking polite status
- * region pinned to the top of the modal. role="status" carries the
- * polite announcement; the visual style is a subdued chip so the eye
- * lands on the word region, not the toast. */
-.resume-toast {
-  margin-block-end: clamp(8px, 2cqi, 16px);
-  padding: clamp(8px, 1.5cqi + 4px, 14px) clamp(12px, 2cqi + 6px, 20px);
-  border-radius: 8px;
-  background: var(--surface-alt, rgba(0, 0, 0, 0.06));
-  color: var(--text, #111111);
-  font-size: clamp(0.85rem, 1cqi + 0.4rem, 1rem);
+/* ===== Scrubber — mockup ".rsvp-progress" =====
+ * 4px accent rail spanning the modal with elapsed/-remaining labels
+ * on either side. The native <input range> retains its accessibility
+ * surface; the visual track is styled via accent-color. */
+.scrubber-area {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 24px 0;
+  /* #52 PART D — auto-hide fade preserved. */
+  transition: opacity 200ms ease-out, visibility 200ms ease-out;
+}
+
+.scrubber-labels {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font: 500 11px / 1 var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+}
+
+.scrubber-slider {
+  inline-size: 100%;
+  block-size: 22px; /* hit-target while visual track stays 4px */
+  accent-color: var(--accent, #1a73e8);
+  cursor: pointer;
+  margin: 0;
+}
+
+.scrubber-slider:focus-visible {
+  outline: 2px solid var(--accent, #1a73e8);
+  outline-offset: 4px;
+}
+
+/* ===== Footer — mockup ".rsvp-controls" =====
+ * Horizontal row: scope-swap • font ± • prev • play (primary) • next •
+ * WPM slider • WPM readout. The play-pause-btn gets the primary
+ * circular treatment; the other transport buttons share .ctrl-btn-ish
+ * styling via their existing classes. */
+.footer {
   display: flex;
   flex-wrap: wrap;
-  gap: clamp(8px, 1.5cqi, 16px);
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 18px 14px;
+  border-block-start: 1px solid var(--border);
+  background: var(--surface-2);
+  margin-block-start: 8px;
+}
+
+/* Shared circular icon-btn baseline used by transport + font + scope swap.
+ * Sized to WCAG 2.2 AA target-size floor (44px) — mockup's 38px visual
+ * fits centered inside the larger hit-target via padding. */
+.scope-swap-btn,
+.font-dec-btn,
+.font-inc-btn,
+.prev-sentence-btn,
+.next-sentence-btn {
+  min-width: 44px;
+  min-height: 44px;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  color: var(--text-2);
+  font: 500 14px / 1 var(--font-ui);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+}
+
+.scope-swap-btn {
+  /* Scope-swap shows text "← Full article" — let it expand horizontally. */
+  width: auto;
+  min-width: 44px;
+  padding: 0 14px;
+  border-radius: 22px;
+}
+
+.scope-swap-btn:hover {
+  background: var(--accent-soft, #e8f0fe);
+  color: var(--text, #202124);
+}
+
+.prev-sentence-btn:hover,
+.next-sentence-btn:hover,
+.font-dec-btn:hover,
+.font-inc-btn:hover {
+  background: var(--accent-soft, #e8f0fe);
+  color: var(--text, #202124);
+}
+
+.scope-swap-btn:focus-visible,
+.font-dec-btn:focus-visible,
+.font-inc-btn:focus-visible,
+.prev-sentence-btn:focus-visible,
+.next-sentence-btn:focus-visible {
+  outline: 2px solid var(--accent, #1a73e8);
+  outline-offset: 2px;
+}
+
+.font-dec-btn:disabled,
+.font-inc-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.prev-sentence-btn,
+.next-sentence-btn {
+  font-size: 16px;
+  inline-size: 38px;
+  block-size: 38px;
+  padding: 0;
+}
+
+/* Primary play/pause — mockup's circular accent button. WCAG floor honored
+ * by sizing to 48×48 (above the 44px target-size minimum). */
+.play-pause-btn {
+  width: 48px;
+  height: 48px;
+  min-width: 48px;
+  min-height: 48px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--accent, #1a73e8);
+  color: #ffffff;
+  font: 600 14px / 1 var(--font-ui);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  box-shadow: var(--shadow-1);
+  /* The button's textContent is "▶ Play" / "⏸ Pause" from OVERLAY_TEXT.
+   * The aria-label carries the full action for AT. */
+  white-space: nowrap;
+  overflow: hidden;
+  font-size: 16px;
+}
+
+.play-pause-btn:hover {
+  background: var(--accent-soft, #e8f0fe);
+  color: var(--text, #202124);
+}
+
+.play-pause-btn:focus-visible {
+  outline: 3px solid var(--accent, #1a73e8);
+  outline-offset: 3px;
+}
+
+.play-pause-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* WPM slider + readout — styled as a pill chip pair.
+ * Hit-target ≥44px per WCAG 2.2 AA. */
+.wpm-slider {
+  min-height: 44px;
+  inline-size: clamp(100px, 18cqi, 180px);
+  accent-color: var(--accent, #1a73e8);
+  cursor: pointer;
+}
+
+.wpm-slider:focus-visible {
+  outline: 2px solid var(--accent, #1a73e8);
+  outline-offset: 4px;
+}
+
+.wpm-readout {
+  font: 600 12px / 1 var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+  padding: 4px 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  min-inline-size: 5ch;
+  text-align: center;
+}
+
+/* ===== Resume toast (#48) — Hi-Fi chip styling. ===== */
+.resume-toast {
+  margin: 4px 24px 0;
+  padding: 8px 14px;
+  border-radius: var(--radius);
+  background: var(--accent-soft, #e8f0fe);
+  color: var(--text);
+  font: 400 12px / 1.4 var(--font-ui);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
   align-items: center;
   justify-content: center;
 }
@@ -461,88 +553,200 @@ export const OVERLAY_CSS = `
   background: transparent;
   border: 0;
   padding: 0;
-  color: var(--accent, #2563eb);
+  color: var(--accent, #1a73e8);
   text-decoration: underline;
   cursor: pointer;
   font: inherit;
 }
 
 .resume-toast-start-over:focus-visible {
-  outline: 2px solid var(--accent, #2563eb);
+  outline: 2px solid var(--accent, #1a73e8);
   outline-offset: 2px;
 }
 
+/* ===== Tweaks popover (#step-3) =====
+ * Absolute-positioned panel anchored to the modal top-right, dropping
+ * below the modal-header settings button. Hidden by default via the
+ * hidden attribute. Segmented row uses the .tweaks-seg-btn shared
+ * baseline; .active swaps the surface to accent-soft + accent text
+ * for the pressed-state affordance.
+ */
+.tweaks-panel[hidden] { display: none; }
+
+.tweaks-panel {
+  position: absolute;
+  inset-block-start: 56px;
+  inset-inline-end: 12px;
+  inline-size: 280px;
+  max-inline-size: calc(100% - 24px);
+  background: var(--surface, #ffffff);
+  color: var(--text, #202124);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-3);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 2;
+}
+
+.tweaks-panel .tweaks-heading {
+  margin: 0;
+  font: 600 13px / 1.2 var(--font-ui);
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+
+.tweaks-panel .tweaks-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.tweaks-panel .tweaks-section-label {
+  font: 500 11px / 1.2 var(--font-ui);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.tweaks-panel .tweaks-seg {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.tweaks-panel .tweaks-seg-btn {
+  /* Honors WCAG 2.5.5 target-size floor (44px), matching the rest of
+   * the overlay's tap-target discipline rather than the mockup's 32px
+   * (a11y-extension-designer finding #5). */
+  min-block-size: 44px;
+  min-inline-size: 44px;
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  color: var(--text);
+  font: 500 12px / 1.2 var(--font-ui);
+  cursor: pointer;
+}
+
+.tweaks-panel .tweaks-seg-btn:hover:not([disabled]) {
+  background: var(--accent-soft, #e8f0fe);
+  border-color: var(--accent, #1a73e8);
+}
+
+.tweaks-panel .tweaks-seg-btn.active {
+  background: var(--accent-soft, #e8f0fe);
+  border-color: var(--accent, #1a73e8);
+  color: var(--accent, #1a73e8);
+}
+
+.tweaks-panel .tweaks-seg-btn:focus-visible {
+  outline: 2px solid var(--accent, #1a73e8);
+  outline-offset: 2px;
+}
+
+.tweaks-panel .tweaks-seg-btn[disabled],
+.tweaks-panel .tweaks-accent-swatch[disabled],
+.tweaks-panel .tweaks-dim-range[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.tweaks-panel .tweaks-accent-swatch {
+  inline-size: 24px;
+  block-size: 24px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--accent, #1a73e8);
+  padding: 0;
+}
+
+.tweaks-panel .tweaks-dim-range {
+  inline-size: 100%;
+}
+
+.tweaks-trap-sentinel {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ===== Forced colors ===== */
 @media (forced-colors: active) {
-  .modal { background: Canvas; color: CanvasText; }
-  .close-btn { border-color: ButtonText; color: ButtonText; }
+  .modal { background: Canvas; color: CanvasText; border-color: CanvasText; }
+  .close-btn { color: ButtonText; background: ButtonFace; }
   .close-btn:focus-visible { outline-color: Highlight; }
   .word-region .focus { color: Highlight; }
-  .play-pause-btn {
-    background: ButtonFace;
-    color: ButtonText;
-    border-color: ButtonText;
-  }
+  .play-pause-btn { background: ButtonFace; color: ButtonText; border: 1px solid ButtonText; }
   .play-pause-btn:focus-visible { outline-color: Highlight; }
   .scope-header { color: CanvasText; }
-  .scope-subtitle { color: CanvasText; opacity: 1; }
-  .scope-swap-btn {
-    background: ButtonFace;
-    color: ButtonText;
-    border-color: ButtonText;
-  }
-  .scope-swap-btn:focus-visible { outline-color: Highlight; }
+  .scope-subtitle { color: CanvasText; }
+  .scope-swap-btn,
   .font-dec-btn,
-  .font-inc-btn {
-    background: ButtonFace;
-    color: ButtonText;
-    border-color: ButtonText;
-  }
-  .font-dec-btn:focus-visible,
-  .font-inc-btn:focus-visible { outline-color: Highlight; }
+  .font-inc-btn,
   .prev-sentence-btn,
   .next-sentence-btn {
-    background: ButtonFace;
     color: ButtonText;
-    border-color: ButtonText;
+    background: ButtonFace;
+    border: 1px solid ButtonText;
   }
+  .scope-swap-btn:focus-visible,
+  .font-dec-btn:focus-visible,
+  .font-inc-btn:focus-visible,
   .prev-sentence-btn:focus-visible,
   .next-sentence-btn:focus-visible { outline-color: Highlight; }
-  .wpm-slider:focus-visible { outline-color: Highlight; }
-  .wpm-readout { color: CanvasText; }
+  .wpm-slider:focus-visible,
   .scrubber-slider:focus-visible { outline-color: Highlight; }
-  .scrubber-labels { color: CanvasText; opacity: 1; }
-  .context-preview { color: CanvasText; opacity: 1; }
-  .context-current { color: Highlight; }
+  .wpm-readout { color: CanvasText; border-color: CanvasText; background: Canvas; }
+  .scrubber-labels { color: CanvasText; }
+  .context-preview { color: CanvasText; }
+  .context-current { color: Highlight; background: Canvas; }
   .resume-toast { background: Canvas; color: CanvasText; border: 1px solid CanvasText; }
   .resume-toast-start-over { color: LinkText; }
   .resume-toast-start-over:focus-visible { outline-color: Highlight; }
+
+  /* Step 2 modal-header + Step 3 tweaks-panel surfaces under
+   * forced-colors. Without these overrides the new classes resolve to
+   * the theme's hardcoded hex values and defeat the user's OS
+   * high-contrast preference (a11y-extension-designer finding #3). */
+  .modal-header { background: Canvas; border-color: CanvasText; }
+  .modal-title { color: CanvasText; }
+  .modal-source { color: CanvasText; }
+  .mini-logo { background: ButtonFace; color: ButtonText; border: 1px solid ButtonText; }
+  .bookmark-btn,
+  .settings-btn { color: ButtonText; background: ButtonFace; }
+  .bookmark-btn:focus-visible,
+  .settings-btn:focus-visible { outline-color: Highlight; }
+
+  .tweaks-panel { background: Canvas; color: CanvasText; border: 1px solid CanvasText; }
+  .tweaks-panel .tweaks-heading,
+  .tweaks-panel .tweaks-section-label { color: CanvasText; }
+  .tweaks-panel .tweaks-seg-btn {
+    background: ButtonFace;
+    color: ButtonText;
+    border-color: ButtonText;
+  }
+  .tweaks-panel .tweaks-seg-btn.active {
+    background: Highlight;
+    color: HighlightText;
+  }
+  .tweaks-panel .tweaks-seg-btn:focus-visible { outline-color: Highlight; }
+  .tweaks-accent-swatch { background: ButtonFace; border: 1px solid ButtonText; }
+  .tweaks-dim-range:focus-visible { outline-color: Highlight; }
 }
 
+/* ===== Reduced motion ===== */
 @media (prefers-reduced-motion: reduce) {
   .backdrop, .modal { transition: none !important; animation: none !important; }
-  /* #52 PART D — drop the auto-hide fade for users who opt out of motion.
-   * The visibility / opacity flip still happens (the bar still hides on
-   * play, shows on pause/hover/focus), just instantly. */
   .scrubber-area { transition: none !important; }
 }
 
-/*
- * Touch-primary viewports (#36). The combined query targets devices whose
- * primary input is touch (phones, most tablets) without catching hybrid
- * laptops that report \`pointer: coarse\` on their touchscreen alongside
- * a precise mouse — \`hover: none\` further narrows to "no precise hover
- * available," which is the WCAG-aligned touch-primary signal.
- *
- * - Tap targets bumped to 48 CSS px (WCAG 2.2 AA target-size minimum is
- *   44; the extra 4 px is thumb-comfort headroom and gives a single
- *   knob to tune without re-auditing the minimum).
- * - Footer bottom-anchored within the modal and padded by
- *   \`env(safe-area-inset-bottom)\` so the control bar stays
- *   thumb-reachable on devices with a home indicator.
- * - Backdrop padding shrinks to give the modal more inline space at
- *   handset widths; the modal itself fills the viewport vertically so
- *   the footer can dock at the bottom.
- */
+/* ===== Touch-primary (#36) ===== */
 @media (pointer: coarse) and (hover: none) {
   .backdrop {
     padding: 0;
@@ -551,73 +755,58 @@ export const OVERLAY_CSS = `
   .modal {
     border-radius: 0;
     min-block-size: 100%;
+    inline-size: 100%;
+    max-inline-size: 100%;
     display: flex;
     flex-direction: column;
   }
   .close-btn {
     width: 48px;
     height: 48px;
+    min-width: 48px;
+    min-height: 48px;
   }
   .word-region {
     flex: 1 1 auto;
-    /* #52 PART C / architect H1 — preserve the flex+wrap layout from the
-     * base .word-region rule so chunk-mode (chunkSize >= 2) renders its
-     * multiple .word-run siblings inline on one line. The previous
-     * "display: grid; place-items: center" here OVERRODE the base flex
-     * layout, causing multi-run chunks to stack/overlap inside a single
-     * grid cell on touch-primary viewports. The base rule's
-     * "justify-content: center; align-items: baseline" already centers
-     * the runs horizontally; we only override align-items to "center" here
-     * so the runs are vertically centred within the now-larger touch
-     * .word-region flex slot. */
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
-    /* Tap target hint for assistive tech / a11y devtools — the click
-     * handler is wired in JS. */
     cursor: pointer;
   }
   .footer {
     padding-block-end: max(16px, env(safe-area-inset-bottom));
     padding-inline: 16px;
+    flex-wrap: wrap;
+    row-gap: 10px;
   }
   .play-pause-btn {
-    min-width: 128px;
-    min-height: 48px;
-    padding: 12px 24px;
+    width: 56px;
+    height: 56px;
+    min-width: 56px;
+    min-height: 56px;
+    font-size: 20px;
   }
-  .scope-swap-btn {
-    min-height: 48px;
-    padding: 12px 20px;
-  }
+  .scope-swap-btn,
   .font-dec-btn,
-  .font-inc-btn {
-    min-width: 48px;
-    min-height: 48px;
-    padding: 12px 16px;
-  }
+  .font-inc-btn,
   .prev-sentence-btn,
   .next-sentence-btn {
     min-width: 48px;
     min-height: 48px;
-    padding: 12px 16px;
+    width: 48px;
+    height: 48px;
+  }
+  .scope-swap-btn {
+    width: auto;
+    padding: 0 16px;
   }
   .wpm-slider {
     min-height: 48px;
-    inline-size: clamp(160px, 30cqi, 320px);
+    inline-size: clamp(140px, 26cqi, 280px);
   }
   .scrubber-slider {
-    min-height: 48px;
-    /* Stays full-width; the WPM slider gets a wider bounded range above. */
-    inline-size: 100%;
-  }
-  .footer {
-    /* On handsets the control bar can wrap onto two lines without losing
-     * the bottom safe-area inset. Centered alignment keeps the layout
-     * symmetric whether or not the slider wraps. */
-    flex-wrap: wrap;
-    row-gap: 12px;
+    block-size: 32px;
   }
 }
 `;

--- a/src/core/overlay/types.ts
+++ b/src/core/overlay/types.ts
@@ -176,6 +176,17 @@ export interface OverlayOptions {
    */
   onWpmChange?: (next: number) => void;
   /**
+   * Called when the user picks a theme from the in-overlay Tweaks
+   * panel (#step-3). The overlay also calls `applyTheme()` locally so
+   * the user gets instant feedback; consumers are expected to persist
+   * the value (the chrome glue routes this to
+   * `chrome.storage.sync.saveSettings({ theme })`). Omitting the
+   * callback disables persistence — the overlay still flips the theme
+   * for the session. The `'system'` sentinel passes through unchanged
+   * so callers can store the user's auto-detect preference.
+   */
+  onThemeChange?: (next: ThemeId | 'system') => void;
+  /**
    * Resume toast (#48). When provided AND the mount actually resumes
    * (i.e. `initialIndex` is a positive in-range integer), the overlay
    * renders a non-blocking `role="status"` toast inside the shadow root

--- a/tests/e2e/touch-smoke.spec.ts
+++ b/tests/e2e/touch-smoke.spec.ts
@@ -76,7 +76,21 @@ test.describe('Touch-primary smoke (#36 / PR #149)', () => {
     const buttonSizes = await host.evaluate((el) => {
       const root = (el as HTMLElement).shadowRoot;
       if (!root) throw new Error('no shadowRoot');
-      const buttons = Array.from(root.querySelectorAll<HTMLButtonElement>('button'));
+      // Skip buttons inside a [hidden] ancestor (e.g. the tweaks popover
+      // panel before the user clicks ⚙). getBoundingClientRect returns 0×0
+      // on hidden subtrees — they're not user-reachable tap targets until
+      // the panel is opened, so the 44 px floor doesn't apply yet.
+      const isInHiddenSubtree = (n: HTMLElement, container: HTMLElement): boolean => {
+        let cur: HTMLElement | null = n;
+        while (cur && cur !== container) {
+          if (cur.hidden) return true;
+          cur = cur.parentElement;
+        }
+        return false;
+      };
+      const buttons = Array.from(root.querySelectorAll<HTMLButtonElement>('button')).filter(
+        (b) => !isInHiddenSubtree(b, el as HTMLElement),
+      );
       return buttons.map((b) => {
         const r = b.getBoundingClientRect();
         return { ariaLabel: b.getAttribute('aria-label') ?? '', w: r.width, h: r.height };


### PR DESCRIPTION
## Summary

Brings the in-page RSVP overlay in line with the approved standalone Hi-Fi mockup. Single batched commit across three logical steps in the same surface area (phase-1, pre-V1.0 per project workflow).

- **Step 1 — CSS reskin.** Roboto + mono + serif stack; 620 px rounded modal; 54 px ORP word + accent focus letter + focus-tick pseudo-elements; thin scrubber rail; primary play (48 px accent circle); WPM readout pill chip; ancillary tokens (`--surface-2/-3`, `--text-muted`/`-faint`, `--border`, `--accent-hover`) derived from the 5 base theme tokens via `color-mix(in oklab, ...)` on `.modal` so theme flips cascade.
- **Step 2 — Modal header chrome.** New `.modal-header` bar with `SR` mini-logo + product name + sanitized hostname + actions group (bookmark / settings / close). Close moves into the actions group; `sanitizeHostname()` strips C0/C1 + bidi controls + caps to 60 chars.
- **Step 3 — Tweaks popover.** Settings toggle opens in-overlay popover with theme picker (segmented row for each `ThemeId` + `'system'`) and disabled stubs for Focus style / Accent / Modal dim. ARIA-APG **Disclosure pattern** (no `role="dialog"` — non-modal popover semantics + avoids trap-escape). Click-outside via `pointerdown` capture. New optional `onThemeChange?` callback on `OverlayOptions` (host wires to `saveSettings` in a follow-up). Polite live-region announcement on theme switch (WCAG 4.1.3).

## Review trail

Built by `chrome-extension-engineer`, then run through the antagonistic ring + architect + a11y reviewers per `feedback_architect_a11y_after_ring`:
- **Security / perf / scope / test-gap adversaries** — convergent + step-3 findings all addressed: shadow-listener symmetric teardown, `dataset.themeId` allowlist guard, `pointerdown` over `mousedown` for touch, `subscribeSettings` theme branch guarded, +CRIT/HIGH/MED test-gap coverage added.
- **`extension-architect`** — no findings above LOW (clean boundary, optional callback contract back-compat, focus-trap layering correct, no SW/CS changes).
- **`a11y-extension-designer`** — all 3 HIGH + 2 MED + 1 LOW fixes applied:
  - `--text-muted` 60% to 75% mix (WCAG 1.4.3 4.5:1 on light/paper/cream)
  - Inner focus-trap removed; Disclosure pattern (WCAG 2.1.2 + ARIA-APG)
  - Forced-colors block extended to cover all new classes
  - Live-region announcement on theme switch (4.1.3)
  - Tweaks segmented buttons 32px to 44px (2.5.5)
  - Hostname sanitization

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 1294/1294 (+22 new in `tweaks-panel.test.ts`)
- [x] `tsc --noEmit` (via `npm run build`) — clean
- [x] `npm run build` — clean
- [x] `npm run format:check` — clean
- [x] Manual smoke on `chrome://extensions` + Wikipedia article — overlay renders with mockup chrome (header bar, focus ticks, primary play circle); settings opens Tweaks panel; theme picker flips theme instantly
- [ ] Manual smoke: forced-colors mode (Windows High Contrast / macOS Increase Contrast) — visual confirmation that new classes resolve via system tokens
- [ ] Manual smoke: 320 px viewport — overlay still readable at WCAG 1.4.10 floor
- [ ] Playwright e2e run on CI (axe-core scan must stay green)

## Follow-ups (NOT in this PR)

- Step 4 — bookmark wire to reading-history (#49)
- Step 5 — plus/minus 5s skip buttons + engine method
- Step 6 — WPM stepper (minus num plus) replacing slider
- Step 7 — footer keyboard-shortcut hint row + "Esc to exit"
- `onThemeChange` wire in `src/chrome/content/index.ts` alongside `onWpmChange` pattern (architect LOW #1)
- Move `sr-tweaks-*` IDs into `OVERLAY_ID` for consistency (architect LOW #2)

Generated with [Claude Code](https://claude.com/claude-code)
