### PR TITLE
feat(overlay): WPM stepper (− num +) — Hi-Fi parity Step 6 (#213)

### DIFF
--- a/src/chrome/content/__tests__/wpm-wire.test.ts
+++ b/src/chrome/content/__tests__/wpm-wire.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
 import { OVERLAY_CLASS } from '../../../core/overlay/constants';
+import { WPM_STEP } from '../../../core/settings/bounds';
 
 /**
- * WPM wire test (ring review #21 / test-gap H1 — slider-side counterpart
- * to `font-size-wire.test.ts`).
+ * WPM wire test (ring review #21 / test-gap H1 — stepper-side counterpart
+ * to `font-size-wire.test.ts`; #213 swapped the prior slider for a
+ * [−] [num] [wpm] [+] stepper).
  *
  * The overlay's `onWpmChange` callback is wired in `content/index.ts` to
  * `saveSettings({ wpm: next })` (debounced 300 ms). Before this file,
@@ -16,9 +18,10 @@ import { OVERLAY_CLASS } from '../../../core/overlay/constants';
  * load-bearing assertion: revert the persist call to `() => undefined`
  * and the suite must go red.
  *
- * Per Fix 1 (ring #21), the SLIDER persists on `change` events only,
- * not `input`. ArrowUp/Down updates engine cadence without persisting
- * (Fix 2). Both behaviors are exercised below.
+ * Stepper contract: every − / + click commits one discrete WPM_STEP delta
+ * to the engine AND fires onWpmChange (the stepper IS the persistence
+ * surface, just like the prior slider was). ArrowUp/Down updates engine
+ * cadence without persisting (Fix 2 — issue #24 contract preserved).
  */
 
 const SETTINGS_KEY = 'speedreader.settings';
@@ -75,13 +78,23 @@ function installChromeMock(): { mock: ChromeMock; getListener: () => Listener } 
   };
 }
 
-function getSlider(): HTMLInputElement {
+function getShadow(): ShadowRoot {
   const host = document.body.querySelector('[data-speedreader-overlay]');
   if (!(host instanceof HTMLElement) || !host.shadowRoot) {
     throw new Error('overlay host missing or no shadow root');
   }
-  const el = host.shadowRoot.querySelector<HTMLInputElement>(`.${OVERLAY_CLASS.WPM_SLIDER}`);
-  if (!el) throw new Error('overlay shadow: missing wpm-slider');
+  return host.shadowRoot;
+}
+
+function getStepperInc(): HTMLButtonElement {
+  const el = getShadow().querySelector<HTMLButtonElement>(`.${OVERLAY_CLASS.WPM_STEPPER_INC}`);
+  if (!el) throw new Error('overlay shadow: missing wpm-stepper-inc');
+  return el;
+}
+
+function getStepperNum(): HTMLElement {
+  const el = getShadow().querySelector<HTMLElement>(`.${OVERLAY_CLASS.WPM_STEPPER_NUM}`);
+  if (!el) throw new Error('overlay shadow: missing wpm-stepper-num');
   return el;
 }
 
@@ -110,14 +123,17 @@ describe('content script wpm wire (ring #21 / test-gap H1)', () => {
     vi.resetModules();
   });
 
-  test('a single slider commit writes wpm via debounced chrome.storage.sync.set', async () => {
+  test('a single + click writes wpm via debounced chrome.storage.sync.set', async () => {
     const { mock, getListener } = installChromeMock();
     await mountOverlay(getListener);
     const baselineSetCalls = mock.storage.sync.set.mock.calls.length;
 
-    const slider = getSlider();
-    slider.value = '420';
-    slider.dispatchEvent(new Event('change', { bubbles: true }));
+    // Capture the readout BEFORE the click so we can assert the delta
+    // landed at exactly WPM_STEP (catches an off-by-N regression in
+    // the click handler — mutation guard #2 from the dispatch brief).
+    const before = Number(getStepperNum().textContent);
+    getStepperInc().click();
+    expect(Number(getStepperNum().textContent)).toBe(before + WPM_STEP);
 
     // No flush before the debounce trailing edge.
     expect(mock.storage.sync.set.mock.calls.length).toBe(baselineSetCalls);
@@ -128,44 +144,64 @@ describe('content script wpm wire (ring #21 / test-gap H1)', () => {
     const newCalls = mock.storage.sync.set.mock.calls.slice(baselineSetCalls);
     expect(newCalls.length).toBe(1);
     const written = newCalls[0]?.[0] as { [k: string]: { wpm: number } } | undefined;
-    expect(written?.[SETTINGS_KEY]).toEqual(expect.objectContaining({ wpm: 420 }));
+    expect(written?.[SETTINGS_KEY]).toEqual(expect.objectContaining({ wpm: before + WPM_STEP }));
   });
 
-  test('many input ticks during drag write NOTHING; only the final change commits', async () => {
-    // Ring #21 BLOCKER: pre-fix code dispatched on `input` which fires
-    // ~60×/sec during drag, hammering chrome.storage.sync.set well past
-    // the 120 writes/min quota. Post-fix, drag ticks are UI-only.
+  test('a single − click writes wpm via debounced chrome.storage.sync.set', async () => {
     const { mock, getListener } = installChromeMock();
     await mountOverlay(getListener);
     const baselineSetCalls = mock.storage.sync.set.mock.calls.length;
 
-    const slider = getSlider();
-    for (let v = 310; v <= 500; v += 10) {
-      slider.value = String(v);
-      slider.dispatchEvent(new Event('input', { bubbles: true }));
-      await vi.advanceTimersByTimeAsync(5);
-    }
-    // Past the debounce window, but no `change` yet — zero new writes.
-    await vi.advanceTimersByTimeAsync(400);
-    await vi.runAllTimersAsync();
-    expect(mock.storage.sync.set.mock.calls.length).toBe(baselineSetCalls);
+    const before = Number(getStepperNum().textContent);
+    const dec = getShadow().querySelector<HTMLButtonElement>(`.${OVERLAY_CLASS.WPM_STEPPER_DEC}`);
+    if (!dec) throw new Error('missing wpm-stepper-dec');
+    dec.click();
+    expect(Number(getStepperNum().textContent)).toBe(before - WPM_STEP);
 
-    // Release the drag.
-    slider.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(mock.storage.sync.set.mock.calls.length).toBe(baselineSetCalls);
     await vi.advanceTimersByTimeAsync(300);
     await vi.runAllTimersAsync();
 
     const newCalls = mock.storage.sync.set.mock.calls.slice(baselineSetCalls);
     expect(newCalls.length).toBe(1);
     const written = newCalls[0]?.[0] as { [k: string]: { wpm: number } } | undefined;
-    expect(written?.[SETTINGS_KEY]).toEqual(expect.objectContaining({ wpm: 500 }));
+    expect(written?.[SETTINGS_KEY]).toEqual(expect.objectContaining({ wpm: before - WPM_STEP }));
   });
 
-  test('ArrowUp keyboard shortcut does NOT persist (issue #24 names slider as persistence surface)', async () => {
-    // Fix 2 (ring #21): ArrowUp/Down updates engine cadence for the
-    // session without rewriting the saved default. Any storage.sync.set
-    // here would mean the keyboard shortcut silently re-acquired the
-    // persisting behaviour the slider drag fix removed.
+  test('multiple stepper clicks within the debounce window collapse to a single set', async () => {
+    // The 300 ms saveSettings debounce coalesces rapid clicks — the
+    // final written value reflects the last click's WPM, not each
+    // intermediate step. This protects chrome.storage.sync's 120
+    // writes/min quota the way the prior drag-then-change pattern did.
+    const { mock, getListener } = installChromeMock();
+    await mountOverlay(getListener);
+    const baselineSetCalls = mock.storage.sync.set.mock.calls.length;
+
+    const before = Number(getStepperNum().textContent);
+    const inc = getStepperInc();
+    inc.click();
+    await vi.advanceTimersByTimeAsync(50);
+    inc.click();
+    await vi.advanceTimersByTimeAsync(50);
+    inc.click();
+
+    // Past the debounce window with no further activity → one flush.
+    await vi.advanceTimersByTimeAsync(400);
+    await vi.runAllTimersAsync();
+
+    const newCalls = mock.storage.sync.set.mock.calls.slice(baselineSetCalls);
+    expect(newCalls.length).toBe(1);
+    const written = newCalls[0]?.[0] as { [k: string]: { wpm: number } } | undefined;
+    expect(written?.[SETTINGS_KEY]).toEqual(
+      expect.objectContaining({ wpm: before + 3 * WPM_STEP }),
+    );
+  });
+
+  test('ArrowUp keyboard shortcut does NOT persist (issue #24 contract preserved through #213)', async () => {
+    // ArrowUp/Down updates engine cadence for the session without
+    // rewriting the saved default. Any storage.sync.set here would mean
+    // the keyboard shortcut silently re-acquired persisting behaviour
+    // — the stepper IS the persistence surface, not the keyboard.
     const { mock, getListener } = installChromeMock();
     await mountOverlay(getListener);
     const baselineSetCalls = mock.storage.sync.set.mock.calls.length;
@@ -179,7 +215,7 @@ describe('content script wpm wire (ring #21 / test-gap H1)', () => {
     expect(mock.storage.sync.set.mock.calls.length).toBe(baselineSetCalls);
   });
 
-  test('mutation guard — without onWpmChange persisting, no set fires after a slider commit', async () => {
+  test('mutation guard — without onWpmChange persisting, no set fires after a stepper click', async () => {
     // If a contributor reverts the `onWpmChange: (next) => saveSettings(...)`
     // call site in `content/index.ts` to a no-op, this test fails: the
     // baseline-vs-post-commit count stays equal, and the `>` assertion
@@ -188,9 +224,7 @@ describe('content script wpm wire (ring #21 / test-gap H1)', () => {
     await mountOverlay(getListener);
     const baselineSetCalls = mock.storage.sync.set.mock.calls.length;
 
-    const slider = getSlider();
-    slider.value = '410';
-    slider.dispatchEvent(new Event('change', { bubbles: true }));
+    getStepperInc().click();
     await vi.advanceTimersByTimeAsync(300);
     await vi.runAllTimersAsync();
 

--- a/src/core/overlay/__tests__/control-bar.test.ts
+++ b/src/core/overlay/__tests__/control-bar.test.ts
@@ -1,13 +1,16 @@
 /**
- * control-bar.test.ts — issue #21 (with #16 / #23 / #24 scope)
+ * control-bar.test.ts — issue #21 (with #16 / #23 / #24 / #213 scope)
  *
  * Persistent control-bar chrome:
  *  - prev-sentence button (⏮) — clicks call engine.seekToSentence('prev')
  *  - next-sentence button (⏭) — clicks call engine.seekToSentence('next')
- *  - WPM slider (<input type="range" min=100 max=600 step=10>) — input events
- *    update engine cadence, snap/clamp at bounds, fire onWpmChange
- *  - WPM readout — text node ("300 wpm") that syncs with the slider,
- *    keyboard ArrowUp/Down, and subscribeSettings emissions
+ *  - WPM stepper (#213) — `[−] [num] [wpm] [+]` pill. Each button click
+ *    commits a single WPM_STEP discrete change to the engine and fires
+ *    onWpmChange. The numeric span carries the live value and exposes
+ *    `role="spinbutton"` with aria-valuemin / aria-valuemax / aria-valuenow.
+ *    Buttons are `disabled` at WPM_MIN / WPM_MAX (and visually distinguishable).
+ *  - Keyboard ArrowUp/Down: still updates engine cadence (non-persisting)
+ *    via the global hotkey wired in mount().
  *
  * The close button, play/pause, font-size stepper and ArrowLeft/Right /
  * ArrowUp/Down keyboard shortcuts are covered by their own specs
@@ -64,15 +67,21 @@ function getNextBtn(): HTMLButtonElement {
   return btn;
 }
 
-function getSlider(): HTMLInputElement {
-  const el = getShadow().querySelector<HTMLInputElement>(`.${OVERLAY_CLASS.WPM_SLIDER}`);
-  if (!el) throw new Error('overlay shadow: missing wpm-slider');
+function getStepperDec(): HTMLButtonElement {
+  const el = getShadow().querySelector<HTMLButtonElement>(`.${OVERLAY_CLASS.WPM_STEPPER_DEC}`);
+  if (!el) throw new Error('overlay shadow: missing wpm-stepper-dec');
   return el;
 }
 
-function getReadout(): HTMLElement {
-  const el = getShadow().querySelector<HTMLElement>(`.${OVERLAY_CLASS.WPM_READOUT}`);
-  if (!el) throw new Error('overlay shadow: missing wpm-readout');
+function getStepperInc(): HTMLButtonElement {
+  const el = getShadow().querySelector<HTMLButtonElement>(`.${OVERLAY_CLASS.WPM_STEPPER_INC}`);
+  if (!el) throw new Error('overlay shadow: missing wpm-stepper-inc');
+  return el;
+}
+
+function getStepperNum(): HTMLElement {
+  const el = getShadow().querySelector<HTMLElement>(`.${OVERLAY_CLASS.WPM_STEPPER_NUM}`);
+  if (!el) throw new Error('overlay shadow: missing wpm-stepper-num');
   return el;
 }
 
@@ -134,7 +143,7 @@ describe('createOverlay — prev/next sentence buttons (#23)', () => {
   });
 });
 
-describe('createOverlay — WPM slider + readout (#24, #16)', () => {
+describe('createOverlay — WPM stepper (#213, supersedes #24 slider)', () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -143,110 +152,176 @@ describe('createOverlay — WPM slider + readout (#24, #16)', () => {
     document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
   });
 
-  test('renders slider with bounds [100, 600] and step 10 (issue #16)', () => {
+  test('renders [−] [num] [wpm] [+] stepper shape with accessible labels', () => {
     const holder: Holder = { engine: null };
     const overlay = createOverlay(defaultOpts(holder));
     overlay.mount();
-    const slider = getSlider();
-    expect(slider.type).toBe('range');
-    expect(slider.min).toBe(String(WPM_MIN));
-    expect(slider.max).toBe(String(WPM_MAX));
-    expect(slider.step).toBe(String(WPM_STEP));
-    expect(slider.getAttribute('aria-label')).toMatch(/reading speed/i);
+    const dec = getStepperDec();
+    const inc = getStepperInc();
+    const num = getStepperNum();
+    expect(dec.tagName).toBe('BUTTON');
+    expect(dec.type).toBe('button');
+    expect(dec.getAttribute('aria-label')).toBe('Decrease reading speed');
+    expect(inc.tagName).toBe('BUTTON');
+    expect(inc.type).toBe('button');
+    expect(inc.getAttribute('aria-label')).toBe('Increase reading speed');
+    // Visible glyphs match the mockup.
+    expect(dec.textContent).toBe('−');
+    expect(inc.textContent).toBe('+');
+    // Number span is the spinbutton with bounds wired up.
+    expect(num.getAttribute('role')).toBe('spinbutton');
+    expect(num.getAttribute('aria-valuemin')).toBe(String(WPM_MIN));
+    expect(num.getAttribute('aria-valuemax')).toBe(String(WPM_MAX));
+    expect(num.getAttribute('aria-label')).toMatch(/reading speed/i);
     overlay.unmount();
   });
 
-  test('slider initial value reflects initialSettings.wpm', () => {
-    const holder: Holder = { engine: null };
-    const overlay = createOverlay(
-      defaultOpts(holder, { initialSettings: { theme: 'system', wpm: 450, fontSize: 20 } }),
-    );
-    overlay.mount();
-    expect(getSlider().value).toBe('450');
-    overlay.unmount();
-  });
-
-  test('readout shows current WPM value at mount', () => {
+  test('numeric span shows initial WPM and exposes aria-valuenow', () => {
     const holder: Holder = { engine: null };
     const overlay = createOverlay(
       defaultOpts(holder, { initialSettings: { theme: 'system', wpm: 350, fontSize: 20 } }),
     );
     overlay.mount();
-    expect(getReadout().textContent).toMatch(/350/);
-    expect(getReadout().textContent).toMatch(/wpm/i);
+    const num = getStepperNum();
+    expect(num.textContent).toBe('350');
+    expect(num.getAttribute('aria-valuenow')).toBe('350');
     overlay.unmount();
   });
 
-  test('slider input event updates readout but does NOT touch engine (drag UI-only, ring #21)', () => {
-    // Per ring review #21: `input` fires ~60×/sec during drag. Each engine
-    // setWpm clears + reschedules the pending word, stalling the RSVP
-    // stream while the user drags. UI sync only on `input`; engine commit
-    // on `change`.
+  test('unit-label "wpm" renders next to the number (Hi-Fi parity)', () => {
     const holder: Holder = { engine: null };
     const overlay = createOverlay(defaultOpts(holder));
     overlay.mount();
-    const slider = getSlider();
-    const setWpmSpy = vi.spyOn(engineOf(holder), 'setWpm');
-
-    slider.value = '420';
-    slider.dispatchEvent(new Event('input', { bubbles: true }));
-
-    expect(setWpmSpy).not.toHaveBeenCalled();
-    expect(getReadout().textContent).toMatch(/420/);
-    expect(slider.value).toBe('420');
+    const lbl = getShadow().querySelector<HTMLElement>(`.${OVERLAY_CLASS.WPM_STEPPER_LBL}`);
+    expect(lbl?.textContent).toBe('wpm');
+    expect(lbl?.getAttribute('aria-hidden')).toBe('true');
     overlay.unmount();
   });
 
-  test('slider change event commits to engine WPM and readout', () => {
-    const holder: Holder = { engine: null };
-    const overlay = createOverlay(defaultOpts(holder));
-    overlay.mount();
-    const slider = getSlider();
-    const setWpmSpy = vi.spyOn(engineOf(holder), 'setWpm');
-
-    slider.value = '420';
-    slider.dispatchEvent(new Event('change', { bubbles: true }));
-
-    expect(setWpmSpy).toHaveBeenCalledWith(420);
-    expect(getReadout().textContent).toMatch(/420/);
-    overlay.unmount();
-  });
-
-  test('slider change invokes onWpmChange for persistence', () => {
+  test('− click decrements by WPM_STEP, commits to engine and onWpmChange', () => {
     const holder: Holder = { engine: null };
     const onWpmChange = vi.fn<(n: number) => void>();
-    const overlay = createOverlay(defaultOpts(holder, { onWpmChange }));
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20 },
+        onWpmChange,
+      }),
+    );
     overlay.mount();
-    const slider = getSlider();
-    slider.value = '500';
-    // Mimic a real drag: input ticks during drag, change on release.
-    slider.dispatchEvent(new Event('input', { bubbles: true }));
-    expect(onWpmChange).not.toHaveBeenCalled();
-    slider.dispatchEvent(new Event('change', { bubbles: true }));
-    expect(onWpmChange).toHaveBeenCalledWith(500);
+    const setWpmSpy = vi.spyOn(engineOf(holder), 'setWpm');
+
+    getStepperDec().click();
+
+    expect(setWpmSpy).toHaveBeenCalledTimes(1);
+    expect(setWpmSpy).toHaveBeenCalledWith(300 - WPM_STEP);
     expect(onWpmChange).toHaveBeenCalledTimes(1);
+    expect(onWpmChange).toHaveBeenCalledWith(300 - WPM_STEP);
+    expect(getStepperNum().textContent).toBe(String(300 - WPM_STEP));
+    expect(getStepperNum().getAttribute('aria-valuenow')).toBe(String(300 - WPM_STEP));
     overlay.unmount();
   });
 
-  test('keyboard ArrowUp updates slider value and readout (sync)', () => {
+  test('+ click increments by WPM_STEP, commits to engine and onWpmChange', () => {
+    const holder: Holder = { engine: null };
+    const onWpmChange = vi.fn<(n: number) => void>();
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20 },
+        onWpmChange,
+      }),
+    );
+    overlay.mount();
+    const setWpmSpy = vi.spyOn(engineOf(holder), 'setWpm');
+
+    getStepperInc().click();
+
+    expect(setWpmSpy).toHaveBeenCalledTimes(1);
+    expect(setWpmSpy).toHaveBeenCalledWith(300 + WPM_STEP);
+    expect(onWpmChange).toHaveBeenCalledTimes(1);
+    expect(onWpmChange).toHaveBeenCalledWith(300 + WPM_STEP);
+    expect(getStepperNum().textContent).toBe(String(300 + WPM_STEP));
+    overlay.unmount();
+  });
+
+  test('− is disabled at WPM_MIN (clamp + visible affordance)', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, { initialSettings: { theme: 'system', wpm: WPM_MIN, fontSize: 20 } }),
+    );
+    overlay.mount();
+    expect(getStepperDec().disabled).toBe(true);
+    expect(getStepperInc().disabled).toBe(false);
+    overlay.unmount();
+  });
+
+  test('+ is disabled at WPM_MAX (clamp + visible affordance)', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, { initialSettings: { theme: 'system', wpm: WPM_MAX, fontSize: 20 } }),
+    );
+    overlay.mount();
+    expect(getStepperInc().disabled).toBe(true);
+    expect(getStepperDec().disabled).toBe(false);
+    overlay.unmount();
+  });
+
+  test('disabled-at-bounds transitions live as the stepper is walked to MIN/MAX', () => {
+    // Step − repeatedly from WPM_MIN + WPM_STEP — after one click the
+    // value reaches WPM_MIN and the − button must flip disabled.
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialSettings: { theme: 'system', wpm: WPM_MIN + WPM_STEP, fontSize: 20 },
+      }),
+    );
+    overlay.mount();
+    expect(getStepperDec().disabled).toBe(false);
+    getStepperDec().click();
+    expect(getStepperNum().textContent).toBe(String(WPM_MIN));
+    expect(getStepperDec().disabled).toBe(true);
+    overlay.unmount();
+  });
+
+  test('− click at WPM_MIN does not fire onWpmChange (clamp short-circuit)', () => {
+    // applyWpm short-circuits when the clamped delta lands on currentWpm.
+    // The button is also disabled by syncWpmUi, but the contract should
+    // hold even for programmatic .click() calls that bypass disabled
+    // styling: no spurious engine.setWpm + no spurious persistence.
+    const holder: Holder = { engine: null };
+    const onWpmChange = vi.fn<(n: number) => void>();
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialSettings: { theme: 'system', wpm: WPM_MIN, fontSize: 20 },
+        onWpmChange,
+      }),
+    );
+    overlay.mount();
+    const setWpmSpy = vi.spyOn(engineOf(holder), 'setWpm');
+    getStepperDec().click();
+    expect(setWpmSpy).not.toHaveBeenCalled();
+    expect(onWpmChange).not.toHaveBeenCalled();
+    expect(getStepperNum().textContent).toBe(String(WPM_MIN));
+    overlay.unmount();
+  });
+
+  test('keyboard ArrowUp updates stepper readout (global hotkey, no regression)', () => {
     const holder: Holder = { engine: null };
     const overlay = createOverlay(
       defaultOpts(holder, { initialSettings: { theme: 'system', wpm: 300, fontSize: 20 } }),
     );
     overlay.mount();
-    expect(getSlider().value).toBe('300');
-    expect(getReadout().textContent).toMatch(/300/);
+    expect(getStepperNum().textContent).toBe('300');
 
     document.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true, cancelable: true }),
     );
 
-    expect(getSlider().value).toBe(String(300 + WPM_STEP));
-    expect(getReadout().textContent).toMatch(new RegExp(String(300 + WPM_STEP)));
+    expect(getStepperNum().textContent).toBe(String(300 + WPM_STEP));
+    expect(getStepperNum().getAttribute('aria-valuenow')).toBe(String(300 + WPM_STEP));
     overlay.unmount();
   });
 
-  test('keyboard ArrowDown updates slider value and readout (sync)', () => {
+  test('keyboard ArrowDown updates stepper readout (global hotkey, no regression)', () => {
     const holder: Holder = { engine: null };
     const overlay = createOverlay(
       defaultOpts(holder, { initialSettings: { theme: 'system', wpm: 300, fontSize: 20 } }),
@@ -255,16 +330,13 @@ describe('createOverlay — WPM slider + readout (#24, #16)', () => {
     document.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }),
     );
-    expect(getSlider().value).toBe(String(300 - WPM_STEP));
-    expect(getReadout().textContent).toMatch(new RegExp(String(300 - WPM_STEP)));
+    expect(getStepperNum().textContent).toBe(String(300 - WPM_STEP));
     overlay.unmount();
   });
 
-  test('keyboard ArrowUp/Down do NOT persist (main contract — slider is the persistence surface)', () => {
-    // Issue #24 names the slider as the persistence surface. ArrowUp /
-    // ArrowDown adjust engine cadence for the session without rewriting
-    // the saved default. Ring review #21 caught a silent flip to
-    // persisting; this test guards the contract.
+  test('keyboard ArrowUp/Down do NOT persist (issue #24 contract still holds)', () => {
+    // The − / + stepper IS the persistence surface; ArrowUp/Down keeps
+    // the session-only contract that's been in place since #24.
     const holder: Holder = { engine: null };
     const onWpmChange = vi.fn<(n: number) => void>();
     const overlay = createOverlay(defaultOpts(holder, { onWpmChange }));
@@ -293,7 +365,7 @@ describe('createOverlay — WPM slider + readout (#24, #16)', () => {
     overlay.unmount();
   });
 
-  test('subscribeSettings emission with new wpm updates slider and readout', () => {
+  test('subscribeSettings emission with new wpm updates stepper readout', () => {
     const holder: Holder = { engine: null };
     let notify: SettingsSubscriber = () => undefined;
     const overlay = createOverlay(
@@ -306,96 +378,77 @@ describe('createOverlay — WPM slider + readout (#24, #16)', () => {
       }),
     );
     overlay.mount();
-    expect(getSlider().value).toBe('300');
+    expect(getStepperNum().textContent).toBe('300');
 
     const next: OverlaySettings = { theme: 'system', wpm: 480, fontSize: 20 };
     notify(next);
 
-    expect(getSlider().value).toBe('480');
-    expect(getReadout().textContent).toMatch(/480/);
+    expect(getStepperNum().textContent).toBe('480');
+    expect(getStepperNum().getAttribute('aria-valuenow')).toBe('480');
     overlay.unmount();
   });
 
-  test('slider clamps to WPM_MIN if out-of-range value is set externally', () => {
-    // The native <input type="range"> normally clamps on its own, but the
-    // engine.setWpm path must also tolerate the (theoretical) escape — and
-    // the on-change handler MUST always feed a clamped value to the engine.
-    const holder: Holder = { engine: null };
-    const overlay = createOverlay(defaultOpts(holder));
-    overlay.mount();
-    const slider = getSlider();
-    const setWpmSpy = vi.spyOn(engineOf(holder), 'setWpm');
-
-    slider.value = '50'; // below WPM_MIN — browser would clamp to '100'
-    slider.dispatchEvent(new Event('change', { bubbles: true }));
-
-    const calls = setWpmSpy.mock.calls;
-    const calledWith = calls[calls.length - 1]?.[0];
-    expect(calledWith).toBeGreaterThanOrEqual(WPM_MIN);
-    expect(calledWith).toBeLessThanOrEqual(WPM_MAX);
-    overlay.unmount();
-  });
-
-  test('mutation guard — onWpmChange wire from slider change is load-bearing', () => {
+  test('mutation guard — onWpmChange wire from + click is load-bearing', () => {
     // Without the wire, the assertion below would never be true; if a
-    // contributor reverts the `opts.onWpmChange?.(clamped)` call inside the
-    // slider change handler to a no-op, this test fails.
+    // contributor reverts the `opts.onWpmChange?.(clamped)` call inside
+    // applyWpm (or flips persist:true to persist:false in the click
+    // handler) this test fails.
     const holder: Holder = { engine: null };
     const onWpmChange = vi.fn<(n: number) => void>();
-    const overlay = createOverlay(defaultOpts(holder, { onWpmChange }));
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialSettings: { theme: 'system', wpm: 400, fontSize: 20 },
+        onWpmChange,
+      }),
+    );
     overlay.mount();
-    const slider = getSlider();
-    slider.value = '410';
-    slider.dispatchEvent(new Event('change', { bubbles: true }));
+    getStepperInc().click();
     expect(onWpmChange).toHaveBeenCalledTimes(1);
-    expect(onWpmChange).toHaveBeenCalledWith(410);
+    expect(onWpmChange).toHaveBeenCalledWith(400 + WPM_STEP);
     overlay.unmount();
   });
 
-  test('slider drag stress — many input ticks call engine.setWpm zero times (ring #21 BLOCKER)', () => {
-    // Simulates a drag: dozens of `input` events while the user holds the
-    // slider, then a single `change` on release. Engine commit MUST happen
-    // once, not per tick — otherwise each tick clearPending()+scheduleNext()
-    // stalls the RSVP stream.
+  test('multiple − / + clicks walk the stepper in WPM_STEP increments', () => {
     const holder: Holder = { engine: null };
     const onWpmChange = vi.fn<(n: number) => void>();
-    const overlay = createOverlay(defaultOpts(holder, { onWpmChange }));
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20 },
+        onWpmChange,
+      }),
+    );
     overlay.mount();
-    const slider = getSlider();
-    const setWpmSpy = vi.spyOn(engineOf(holder), 'setWpm');
-
-    for (let v = 310; v <= 500; v += 10) {
-      slider.value = String(v);
-      slider.dispatchEvent(new Event('input', { bubbles: true }));
-    }
-    expect(setWpmSpy).not.toHaveBeenCalled();
-    expect(onWpmChange).not.toHaveBeenCalled();
-
-    slider.dispatchEvent(new Event('change', { bubbles: true }));
-    expect(setWpmSpy).toHaveBeenCalledTimes(1);
-    expect(setWpmSpy).toHaveBeenCalledWith(500);
-    expect(onWpmChange).toHaveBeenCalledTimes(1);
-    expect(onWpmChange).toHaveBeenCalledWith(500);
+    getStepperInc().click();
+    getStepperInc().click();
+    getStepperInc().click();
+    expect(getStepperNum().textContent).toBe(String(300 + 3 * WPM_STEP));
+    expect(onWpmChange).toHaveBeenCalledTimes(3);
+    expect(onWpmChange).toHaveBeenLastCalledWith(300 + 3 * WPM_STEP);
+    getStepperDec().click();
+    expect(getStepperNum().textContent).toBe(String(300 + 2 * WPM_STEP));
+    expect(onWpmChange).toHaveBeenCalledTimes(4);
+    expect(onWpmChange).toHaveBeenLastCalledWith(300 + 2 * WPM_STEP);
     overlay.unmount();
   });
 });
 
-describe('createOverlay — control-bar tap targets (#21)', () => {
-  test('CSS sheet ensures prev/next/slider/font/play-pause meet 44px target-size at base', () => {
+describe('createOverlay — control-bar tap targets (#21, #213)', () => {
+  test('CSS sheet ensures prev/next/stepper-buttons/font/play-pause meet 44px target-size at base', () => {
     // jsdom does not evaluate CSS — assert structural minimums in the
     // stylesheet bytes (mirrors touch-controls.test.ts pattern).
     expect(OVERLAY_CSS).toMatch(/\.prev-sentence-btn[\s\S]*?min-(width|height):\s*44px/);
     expect(OVERLAY_CSS).toMatch(/\.next-sentence-btn[\s\S]*?min-(width|height):\s*44px/);
-    // Slider thumb / track wrapped in a hitbox ≥ 44px tall.
-    expect(OVERLAY_CSS).toMatch(/\.wpm-slider[\s\S]*?min-height:\s*44px/);
+    // WPM stepper buttons (#213) — `.wpm-display button` rule wraps both
+    // − and + with a 44px floor even though the painted circle is 22px.
+    expect(OVERLAY_CSS).toMatch(/\.wpm-display button[\s\S]*?min-height:\s*44px/);
   });
 
-  test('CSS sheet bumps prev/next/slider to ≥48px on touch-primary viewports', () => {
+  test('CSS sheet bumps prev/next/stepper-buttons to ≥48px on touch-primary viewports', () => {
     const blockMatch = OVERLAY_CSS.match(/@media\s*\(pointer:\s*coarse\)[^{]*\{([\s\S]*?)\n\}/);
     expect(blockMatch, 'coarse-pointer media block must exist').toBeTruthy();
     const blockBody = blockMatch?.[1] ?? '';
     expect(blockBody).toMatch(/\.prev-sentence-btn[\s\S]*?min-height:\s*48px/);
     expect(blockBody).toMatch(/\.next-sentence-btn[\s\S]*?min-height:\s*48px/);
-    expect(blockBody).toMatch(/\.wpm-slider[\s\S]*?min-height:\s*48px/);
+    expect(blockBody).toMatch(/\.wpm-display button[\s\S]*?min-height:\s*48px/);
   });
 });

--- a/src/core/overlay/__tests__/control-bar.test.ts
+++ b/src/core/overlay/__tests__/control-bar.test.ts
@@ -4,11 +4,16 @@
  * Persistent control-bar chrome:
  *  - prev-sentence button (⏮) — clicks call engine.seekToSentence('prev')
  *  - next-sentence button (⏭) — clicks call engine.seekToSentence('next')
- *  - WPM stepper (#213) — `[−] [num] [wpm] [+]` pill. Each button click
- *    commits a single WPM_STEP discrete change to the engine and fires
- *    onWpmChange. The numeric span carries the live value and exposes
- *    `role="spinbutton"` with aria-valuemin / aria-valuemax / aria-valuenow.
- *    Buttons are `disabled` at WPM_MIN / WPM_MAX (and visually distinguishable).
+ *  - WPM stepper (#213, with PR #214 a11y revisions) — `[−] [num] [wpm] [+]`
+ *    pill. Each button click commits a single WPM_STEP discrete change to
+ *    the engine, fires onWpmChange, and writes a polite-live-region
+ *    announcement (#214 BLOCK 1). The numeric span is a pure display
+ *    element with a dynamic `aria-label` rewritten on every commit
+ *    (#214 BLOCK 2 — replaces the broken `role="spinbutton"` shape).
+ *    Buttons use `aria-disabled="true"` at WPM_MIN / WPM_MAX (#214 HOLD 1
+ *    — native `disabled` removes the element from the tab chain) with a
+ *    visible affordance via `--text-muted` + `cursor: not-allowed`
+ *    (#214 HOLD 2 — opacity 0.4 failed 1.4.11 non-text contrast).
  *  - Keyboard ArrowUp/Down: still updates engine cadence (non-persisting)
  *    via the global hotkey wired in mount().
  *
@@ -82,6 +87,12 @@ function getStepperInc(): HTMLButtonElement {
 function getStepperNum(): HTMLElement {
   const el = getShadow().querySelector<HTMLElement>(`.${OVERLAY_CLASS.WPM_STEPPER_NUM}`);
   if (!el) throw new Error('overlay shadow: missing wpm-stepper-num');
+  return el;
+}
+
+function getAriaLive(): HTMLElement {
+  const el = getShadow().querySelector<HTMLElement>(`.${OVERLAY_CLASS.ARIA_LIVE}`);
+  if (!el) throw new Error('overlay shadow: missing aria-live region');
   return el;
 }
 
@@ -168,15 +179,19 @@ describe('createOverlay — WPM stepper (#213, supersedes #24 slider)', () => {
     // Visible glyphs match the mockup.
     expect(dec.textContent).toBe('−');
     expect(inc.textContent).toBe('+');
-    // Number span is the spinbutton with bounds wired up.
-    expect(num.getAttribute('role')).toBe('spinbutton');
-    expect(num.getAttribute('aria-valuemin')).toBe(String(WPM_MIN));
-    expect(num.getAttribute('aria-valuemax')).toBe(String(WPM_MAX));
+    // #214 BLOCK 2 — number span is a pure display element. No `role`
+    // (spinbutton would lie to AT since the span isn't focusable / has
+    // no ArrowUp/Down handlers); no aria-valuemin/max/now. A dynamic
+    // `aria-label` carries the current value instead.
+    expect(num.getAttribute('role')).toBeNull();
+    expect(num.getAttribute('aria-valuemin')).toBeNull();
+    expect(num.getAttribute('aria-valuemax')).toBeNull();
+    expect(num.getAttribute('aria-valuenow')).toBeNull();
     expect(num.getAttribute('aria-label')).toMatch(/reading speed/i);
     overlay.unmount();
   });
 
-  test('numeric span shows initial WPM and exposes aria-valuenow', () => {
+  test('numeric span shows initial WPM and exposes it via dynamic aria-label', () => {
     const holder: Holder = { engine: null };
     const overlay = createOverlay(
       defaultOpts(holder, { initialSettings: { theme: 'system', wpm: 350, fontSize: 20 } }),
@@ -184,7 +199,8 @@ describe('createOverlay — WPM stepper (#213, supersedes #24 slider)', () => {
     overlay.mount();
     const num = getStepperNum();
     expect(num.textContent).toBe('350');
-    expect(num.getAttribute('aria-valuenow')).toBe('350');
+    // #214 BLOCK 2 — aria-label carries the value, not aria-valuenow.
+    expect(num.getAttribute('aria-label')).toBe('Reading speed, 350 words per minute');
     overlay.unmount();
   });
 
@@ -217,7 +233,9 @@ describe('createOverlay — WPM stepper (#213, supersedes #24 slider)', () => {
     expect(onWpmChange).toHaveBeenCalledTimes(1);
     expect(onWpmChange).toHaveBeenCalledWith(300 - WPM_STEP);
     expect(getStepperNum().textContent).toBe(String(300 - WPM_STEP));
-    expect(getStepperNum().getAttribute('aria-valuenow')).toBe(String(300 - WPM_STEP));
+    expect(getStepperNum().getAttribute('aria-label')).toBe(
+      `Reading speed, ${300 - WPM_STEP} words per minute`,
+    );
     overlay.unmount();
   });
 
@@ -243,31 +261,38 @@ describe('createOverlay — WPM stepper (#213, supersedes #24 slider)', () => {
     overlay.unmount();
   });
 
-  test('− is disabled at WPM_MIN (clamp + visible affordance)', () => {
+  test('− is aria-disabled at WPM_MIN, stays in tab chain (#214 HOLD 1)', () => {
     const holder: Holder = { engine: null };
     const overlay = createOverlay(
       defaultOpts(holder, { initialSettings: { theme: 'system', wpm: WPM_MIN, fontSize: 20 } }),
     );
     overlay.mount();
-    expect(getStepperDec().disabled).toBe(true);
-    expect(getStepperInc().disabled).toBe(false);
+    // #214 HOLD 1 — aria-disabled (not native `disabled`) so keyboard
+    // users tabbing right at MIN still land on the button. Native
+    // `disabled` would silently remove it from the tab chain.
+    expect(getStepperDec().getAttribute('aria-disabled')).toBe('true');
+    expect(getStepperInc().getAttribute('aria-disabled')).toBe('false');
+    // Belt-and-suspenders: native `disabled` MUST stay off so the
+    // button remains focusable.
+    expect(getStepperDec().disabled).toBe(false);
     overlay.unmount();
   });
 
-  test('+ is disabled at WPM_MAX (clamp + visible affordance)', () => {
+  test('+ is aria-disabled at WPM_MAX, stays in tab chain (#214 HOLD 1)', () => {
     const holder: Holder = { engine: null };
     const overlay = createOverlay(
       defaultOpts(holder, { initialSettings: { theme: 'system', wpm: WPM_MAX, fontSize: 20 } }),
     );
     overlay.mount();
-    expect(getStepperInc().disabled).toBe(true);
-    expect(getStepperDec().disabled).toBe(false);
+    expect(getStepperInc().getAttribute('aria-disabled')).toBe('true');
+    expect(getStepperDec().getAttribute('aria-disabled')).toBe('false');
+    expect(getStepperInc().disabled).toBe(false);
     overlay.unmount();
   });
 
-  test('disabled-at-bounds transitions live as the stepper is walked to MIN/MAX', () => {
-    // Step − repeatedly from WPM_MIN + WPM_STEP — after one click the
-    // value reaches WPM_MIN and the − button must flip disabled.
+  test('aria-disabled bounds transitions live as the stepper is walked to MIN/MAX', () => {
+    // Step − from WPM_MIN + WPM_STEP — after one click the value
+    // reaches WPM_MIN and the − button must flip aria-disabled='true'.
     const holder: Holder = { engine: null };
     const overlay = createOverlay(
       defaultOpts(holder, {
@@ -275,18 +300,19 @@ describe('createOverlay — WPM stepper (#213, supersedes #24 slider)', () => {
       }),
     );
     overlay.mount();
-    expect(getStepperDec().disabled).toBe(false);
+    expect(getStepperDec().getAttribute('aria-disabled')).toBe('false');
     getStepperDec().click();
     expect(getStepperNum().textContent).toBe(String(WPM_MIN));
-    expect(getStepperDec().disabled).toBe(true);
+    expect(getStepperDec().getAttribute('aria-disabled')).toBe('true');
     overlay.unmount();
   });
 
-  test('− click at WPM_MIN does not fire onWpmChange (clamp short-circuit)', () => {
-    // applyWpm short-circuits when the clamped delta lands on currentWpm.
-    // The button is also disabled by syncWpmUi, but the contract should
-    // hold even for programmatic .click() calls that bypass disabled
-    // styling: no spurious engine.setWpm + no spurious persistence.
+  test('− click at WPM_MIN does not fire onWpmChange (aria-disabled handler short-circuit)', () => {
+    // #214 HOLD 1 — the click handler now checks aria-disabled and
+    // early-returns BEFORE entering applyWpm. This protects against
+    // a refactor of applyWpm's clamp short-circuit + ensures programmatic
+    // .click() calls (which bypass any pointer-events styling) still
+    // no-op. The mutation guard below confirms this gate is load-bearing.
     const holder: Holder = { engine: null };
     const onWpmChange = vi.fn<(n: number) => void>();
     const overlay = createOverlay(
@@ -304,6 +330,33 @@ describe('createOverlay — WPM stepper (#213, supersedes #24 slider)', () => {
     overlay.unmount();
   });
 
+  test('mutation guard — aria-disabled handler gate is load-bearing (independent of applyWpm clamp)', () => {
+    // The handler-level early-return is belt-and-suspenders on top of
+    // applyWpm's `clamped === currentWpm` short-circuit. To discriminate
+    // the HANDLER gate from the applyWpm gate, force aria-disabled="true"
+    // on the + button at a mid-range WPM (where applyWpm would NOT
+    // short-circuit because clampedDelta !== currentWpm). If the handler
+    // gate is intact, the click no-ops. If a refactor removes it, the
+    // click reaches applyWpm and fires onWpmChange.
+    const holder: Holder = { engine: null };
+    const onWpmChange = vi.fn<(n: number) => void>();
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20 },
+        onWpmChange,
+      }),
+    );
+    overlay.mount();
+    // Force aria-disabled='true' at a non-bound value. syncWpmUi will
+    // overwrite this on the next legitimate state change, but we click
+    // BEFORE any sync runs.
+    getStepperInc().setAttribute('aria-disabled', 'true');
+    getStepperInc().click();
+    expect(onWpmChange).not.toHaveBeenCalled();
+    expect(getStepperNum().textContent).toBe('300');
+    overlay.unmount();
+  });
+
   test('keyboard ArrowUp updates stepper readout (global hotkey, no regression)', () => {
     const holder: Holder = { engine: null };
     const overlay = createOverlay(
@@ -317,7 +370,11 @@ describe('createOverlay — WPM stepper (#213, supersedes #24 slider)', () => {
     );
 
     expect(getStepperNum().textContent).toBe(String(300 + WPM_STEP));
-    expect(getStepperNum().getAttribute('aria-valuenow')).toBe(String(300 + WPM_STEP));
+    // #214 BLOCK 2 — value flows through aria-label (replaces the
+    // broken aria-valuenow on a non-spinbutton span).
+    expect(getStepperNum().getAttribute('aria-label')).toBe(
+      `Reading speed, ${300 + WPM_STEP} words per minute`,
+    );
     overlay.unmount();
   });
 
@@ -384,7 +441,7 @@ describe('createOverlay — WPM stepper (#213, supersedes #24 slider)', () => {
     notify(next);
 
     expect(getStepperNum().textContent).toBe('480');
-    expect(getStepperNum().getAttribute('aria-valuenow')).toBe('480');
+    expect(getStepperNum().getAttribute('aria-label')).toBe('Reading speed, 480 words per minute');
     overlay.unmount();
   });
 
@@ -428,6 +485,92 @@ describe('createOverlay — WPM stepper (#213, supersedes #24 slider)', () => {
     expect(getStepperNum().textContent).toBe(String(300 + 2 * WPM_STEP));
     expect(onWpmChange).toHaveBeenCalledTimes(4);
     expect(onWpmChange).toHaveBeenLastCalledWith(300 + 2 * WPM_STEP);
+    overlay.unmount();
+  });
+
+  // #214 a11y BLOCK 1 — polite-live-region announcements on stepper
+  // commits. Updating aria-valuenow on a non-focused sibling does NOT
+  // reliably trigger NVDA/JAWS/VoiceOver announcements; the .aria-live
+  // region is the existing, AT-tested channel for status updates.
+  test('+ click writes the new WPM value to the polite aria-live region', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, { initialSettings: { theme: 'system', wpm: 300, fontSize: 20 } }),
+    );
+    overlay.mount();
+    getStepperInc().click();
+    expect(getAriaLive().textContent).toBe(`${300 + WPM_STEP} wpm`);
+    overlay.unmount();
+  });
+
+  test('− click writes the new WPM value to the polite aria-live region', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, { initialSettings: { theme: 'system', wpm: 300, fontSize: 20 } }),
+    );
+    overlay.mount();
+    getStepperDec().click();
+    expect(getAriaLive().textContent).toBe(`${300 - WPM_STEP} wpm`);
+    overlay.unmount();
+  });
+
+  test('successive ± clicks each refresh the aria-live region with the latest value', () => {
+    // Polite live-region writes replace prior content (the region is
+    // aria-atomic=true); each commit's announcement must reflect the
+    // CURRENT value, not stack/concatenate.
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, { initialSettings: { theme: 'system', wpm: 300, fontSize: 20 } }),
+    );
+    overlay.mount();
+    getStepperInc().click();
+    expect(getAriaLive().textContent).toBe(`${300 + WPM_STEP} wpm`);
+    getStepperInc().click();
+    expect(getAriaLive().textContent).toBe(`${300 + 2 * WPM_STEP} wpm`);
+    getStepperDec().click();
+    expect(getAriaLive().textContent).toBe(`${300 + WPM_STEP} wpm`);
+    overlay.unmount();
+  });
+
+  test('keyboard ArrowUp/ArrowDown do NOT announce to aria-live (cadence probe stays quiet)', () => {
+    // #214 BLOCK 1 carve-out — only persist:true commits announce.
+    // ArrowUp/Down is the live-cadence probe path (persist:false);
+    // announcing on every keypress would be deafening. The aria-live
+    // region may carry other content (e.g., the current RSVP word when
+    // playing) — we only assert it does NOT carry the wpm announcement.
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, { initialSettings: { theme: 'system', wpm: 300, fontSize: 20 } }),
+    );
+    overlay.mount();
+    const ariaLiveBefore = getAriaLive().textContent;
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true, cancelable: true }),
+    );
+    // ArrowUp advanced the stepper to 310, but the wpm announcement
+    // must NOT have been written. The text is either unchanged from
+    // before (idle state) or whatever RSVP/other path writes — but it
+    // must NOT match the wpm-commit format.
+    expect(getAriaLive().textContent).not.toBe(`${300 + WPM_STEP} wpm`);
+    expect(getAriaLive().textContent).toBe(ariaLiveBefore);
+    overlay.unmount();
+  });
+
+  test('mutation guard — removing the live-region write makes BLOCK 1 regress detectable', () => {
+    // If a future refactor drops `ariaLive.textContent = ...` from the
+    // persist:true branch of applyWpm, this test fails because the
+    // region stays at its pre-click value. Confirms the announcement
+    // IS the load-bearing wire (not e.g. a side-effect of syncWpmUi).
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, { initialSettings: { theme: 'system', wpm: 300, fontSize: 20 } }),
+    );
+    overlay.mount();
+    const before = getAriaLive().textContent;
+    getStepperInc().click();
+    const after = getAriaLive().textContent;
+    expect(after).not.toBe(before);
+    expect(after).toBe(`${300 + WPM_STEP} wpm`);
     overlay.unmount();
   });
 });

--- a/src/core/overlay/constants.ts
+++ b/src/core/overlay/constants.ts
@@ -155,12 +155,28 @@ export const OVERLAY_TEXT = Object.freeze({
   NEXT_SENTENCE_LABEL: 'Next sentence',
 
   /**
-   * WPM stepper accessible label (#213 — was #24 slider label).
+   * Dynamic `aria-label` for the WPM display span (#214 a11y BLOCK 2).
    *
-   * Used as the `aria-label` on the numeric `role="spinbutton"` so screen
-   * readers announce the control purpose alongside the live value.
+   * Replaced the original static `WPM_SPINBUTTON_LABEL` + `role="spinbutton"`
+   * shape. ARIA APG requires spinbutton elements to be focusable + handle
+   * ArrowUp/Down/Home/End; the span had none of that, so AT users heard
+   * "spin button, 300" and got silence when arrowing. The span is now a
+   * pure display element whose `aria-label` is rewritten on every commit
+   * to carry the live value; the ± buttons own the increment affordance.
    */
-  WPM_SPINBUTTON_LABEL: 'Reading speed (words per minute)',
+  wpmDisplayLabel(wpm: number): string {
+    return `Reading speed, ${wpm} words per minute`;
+  },
+
+  /**
+   * Polite-live-region announcement fired on each user-initiated WPM
+   * commit (stepper ± click, NOT keyboard hotkey) — #214 a11y BLOCK 1.
+   * Terse on purpose: repeated announcements need to be cheap to hear,
+   * and the unit "wpm" matches the visible chip label.
+   */
+  wpmAnnouncement(wpm: number): string {
+    return `${wpm} wpm`;
+  },
 
   /** WPM stepper button accessible labels (#213). */
   WPM_DEC_LABEL: 'Decrease reading speed',

--- a/src/core/overlay/constants.ts
+++ b/src/core/overlay/constants.ts
@@ -38,8 +38,17 @@ export const OVERLAY_CLASS = Object.freeze({
   FONT_INC_BTN: 'font-inc-btn',
   PREV_SENTENCE_BTN: 'prev-sentence-btn',
   NEXT_SENTENCE_BTN: 'next-sentence-btn',
-  WPM_SLIDER: 'wpm-slider',
-  WPM_READOUT: 'wpm-readout',
+  /**
+   * WPM stepper (#213) — `[−] [num] [wpm] [+]` per the Hi-Fi mockup. The
+   * outer `.wpm-display` is a pill chip containing two buttons (decrement
+   * / increment), a numeric span, and a unit-label span. Replaces the
+   * prior `<input type="range">` slider + standalone readout.
+   */
+  WPM_STEPPER: 'wpm-display',
+  WPM_STEPPER_DEC: 'wpm-stepper-dec',
+  WPM_STEPPER_INC: 'wpm-stepper-inc',
+  WPM_STEPPER_NUM: 'wpm-stepper-num',
+  WPM_STEPPER_LBL: 'wpm-stepper-lbl',
   CONTEXT_PREVIEW: 'context-preview',
   CONTEXT_CURRENT: 'context-current',
   /** Reading-position resume toast (#48). */
@@ -145,13 +154,24 @@ export const OVERLAY_TEXT = Object.freeze({
   PREV_SENTENCE_LABEL: 'Previous sentence',
   NEXT_SENTENCE_LABEL: 'Next sentence',
 
-  /** WPM slider accessible label (#24). */
-  WPM_SLIDER_LABEL: 'Reading speed (words per minute)',
+  /**
+   * WPM stepper accessible label (#213 — was #24 slider label).
+   *
+   * Used as the `aria-label` on the numeric `role="spinbutton"` so screen
+   * readers announce the control purpose alongside the live value.
+   */
+  WPM_SPINBUTTON_LABEL: 'Reading speed (words per minute)',
 
-  /** WPM readout template — visible "300 wpm" text next to the slider. */
-  wpmReadout(wpm: number): string {
-    return `${wpm} wpm`;
-  },
+  /** WPM stepper button accessible labels (#213). */
+  WPM_DEC_LABEL: 'Decrease reading speed',
+  WPM_INC_LABEL: 'Increase reading speed',
+
+  /** WPM stepper button visible glyphs (#213). Match the Hi-Fi mockup. */
+  WPM_DEC_GLYPH: '−',
+  WPM_INC_GLYPH: '+',
+
+  /** WPM stepper unit-label text — visible "wpm" next to the number. */
+  WPM_UNIT_LABEL: 'wpm',
 
   /** Empty-selection fallback subtitle + polite live-region announcement. */
   EMPTY_SELECTION_FALLBACK: 'No selection detected. Reading full article instead.',

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -186,8 +186,9 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     fontIncBtn: HTMLButtonElement;
     prevSentenceBtn: HTMLButtonElement;
     nextSentenceBtn: HTMLButtonElement;
-    wpmSlider: HTMLInputElement;
-    wpmReadout: HTMLElement;
+    wpmStepperDec: HTMLButtonElement;
+    wpmStepperInc: HTMLButtonElement;
+    wpmStepperNum: HTMLElement;
     ariaLive: HTMLElement;
     preview: HTMLElement;
     scrubber: HTMLInputElement;
@@ -508,34 +509,65 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     nextSentenceBtn.setAttribute('aria-label', OVERLAY_TEXT.NEXT_SENTENCE_LABEL);
     footer.appendChild(nextSentenceBtn);
 
-    // WPM slider (#24) + readout. Bounds are [WPM_MIN, WPM_MAX] = [100, 600]
-    // (#16). Slider value is set in mount() from currentWpm so the initial
-    // position reflects initialSettings.wpm even when callers pass non-default
-    // values.
-    const wpmSlider = doc.createElement('input');
-    wpmSlider.className = OVERLAY_CLASS.WPM_SLIDER;
-    wpmSlider.type = 'range';
-    wpmSlider.min = String(WPM_MIN);
-    wpmSlider.max = String(WPM_MAX);
-    wpmSlider.step = String(WPM_STEP);
-    wpmSlider.setAttribute('aria-label', OVERLAY_TEXT.WPM_SLIDER_LABEL);
-    footer.appendChild(wpmSlider);
+    // WPM stepper (#213) — `[−] [num] [wpm] [+]` per the Hi-Fi mockup.
+    // Replaces the prior `<input type="range">` slider + standalone readout
+    // with a pill chip whose two end-buttons step by WPM_STEP and whose
+    // numeric span carries the live value. Bounds are [WPM_MIN, WPM_MAX] =
+    // [100, 600] (#16); step = WPM_STEP = 10 (`src/core/settings/bounds.ts`).
+    //
+    // A11y shape:
+    //   - Each button gets a verb-form `aria-label` ("Decrease/Increase
+    //     reading speed") and a visible glyph; default <button> semantics
+    //     mean Enter/Space activate without extra wiring.
+    //   - The numeric span is `role="spinbutton"` with aria-valuemin /
+    //     aria-valuemax / aria-valuenow so AT users hear the current WPM
+    //     announced when focus or value changes.
+    //   - The unit-label ("wpm") span is aria-hidden — the spinbutton
+    //     already announces "Reading speed (words per minute)".
+    //   - Buttons get the `disabled` attribute at MIN / MAX; styles.ts
+    //     gives the disabled state a visible affordance (opacity + cursor).
+    const wpmStepper = doc.createElement('div');
+    wpmStepper.className = OVERLAY_CLASS.WPM_STEPPER;
 
-    const wpmReadout = doc.createElement('span');
-    wpmReadout.className = OVERLAY_CLASS.WPM_READOUT;
-    // The slider already exposes its value via aria-label + role; the readout
-    // is a visual companion. aria-hidden avoids duplicate announcements.
-    wpmReadout.setAttribute('aria-hidden', 'true');
-    footer.appendChild(wpmReadout);
+    const wpmStepperDec = doc.createElement('button');
+    wpmStepperDec.className = OVERLAY_CLASS.WPM_STEPPER_DEC;
+    wpmStepperDec.type = 'button';
+    wpmStepperDec.textContent = OVERLAY_TEXT.WPM_DEC_GLYPH;
+    wpmStepperDec.setAttribute('aria-label', OVERLAY_TEXT.WPM_DEC_LABEL);
+
+    const wpmStepperNum = doc.createElement('span');
+    wpmStepperNum.className = OVERLAY_CLASS.WPM_STEPPER_NUM;
+    wpmStepperNum.setAttribute('role', 'spinbutton');
+    wpmStepperNum.setAttribute('aria-label', OVERLAY_TEXT.WPM_SPINBUTTON_LABEL);
+    wpmStepperNum.setAttribute('aria-valuemin', String(WPM_MIN));
+    wpmStepperNum.setAttribute('aria-valuemax', String(WPM_MAX));
+    // aria-valuenow is set in mount() via syncWpmUi(currentWpm).
+
+    const wpmStepperLbl = doc.createElement('span');
+    wpmStepperLbl.className = OVERLAY_CLASS.WPM_STEPPER_LBL;
+    wpmStepperLbl.textContent = OVERLAY_TEXT.WPM_UNIT_LABEL;
+    // The spinbutton's aria-label already conveys "words per minute"; the
+    // visible unit is decorative for sighted users.
+    wpmStepperLbl.setAttribute('aria-hidden', 'true');
+
+    const wpmStepperInc = doc.createElement('button');
+    wpmStepperInc.className = OVERLAY_CLASS.WPM_STEPPER_INC;
+    wpmStepperInc.type = 'button';
+    wpmStepperInc.textContent = OVERLAY_TEXT.WPM_INC_GLYPH;
+    wpmStepperInc.setAttribute('aria-label', OVERLAY_TEXT.WPM_INC_LABEL);
+
+    wpmStepper.append(wpmStepperDec, wpmStepperNum, wpmStepperLbl, wpmStepperInc);
+    footer.appendChild(wpmStepper);
 
     // Progress scrubber (#47). Mounted ABOVE the footer so visual order
     // reads: word → preview → scrubber → controls (matches Safari spec).
     // Q1 decision: above the existing control bar — the footer IS the
     // control bar in current Chrome architecture, so this is the natural
     // slot. Q2: visible from mount with pre-start labels (Safari spec
-    // implies always-visible). Q3: new .scrubber-slider class sharing
-    // base track/thumb rules with .wpm-slider via a selector list in
-    // styles.ts. Q4: aria-valuetext updates per-emission (matches
+    // implies always-visible). Q3: dedicated `.scrubber-slider` rule
+    // block in styles.ts (used to share a selector list with the now-
+    // removed `.wpm-slider`; #213 swapped that to a stepper and split
+    // the lists). Q4: aria-valuetext updates per-emission (matches
     // user-perceived granularity).
     const scrubberArea = doc.createElement('div');
     scrubberArea.className = OVERLAY_CLASS.SCRUBBER_AREA;
@@ -601,8 +633,9 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       fontIncBtn,
       prevSentenceBtn,
       nextSentenceBtn,
-      wpmSlider,
-      wpmReadout,
+      wpmStepperDec,
+      wpmStepperInc,
+      wpmStepperNum,
       ariaLive,
       preview,
       scrubber,
@@ -659,8 +692,9 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       fontIncBtn,
       prevSentenceBtn,
       nextSentenceBtn,
-      wpmSlider,
-      wpmReadout,
+      wpmStepperDec,
+      wpmStepperInc,
+      wpmStepperNum,
       ariaLive,
       preview,
       scrubber,
@@ -737,12 +771,17 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     // when alignment actually changed. Default `'orp'` matches schema.
     let currentAlignment: 'orp' | 'center' = opts.initialSettings.alignment ?? 'orp';
 
-    // Single point of truth for keeping the slider + readout in sync with
+    // Single point of truth for keeping the stepper UI in sync with
     // `currentWpm`. Called from mount-time init, the ArrowUp/Down keyboard
-    // handler, slider input, and subscribeSettings emissions.
+    // handler, the −/+ button click handlers, and subscribeSettings
+    // emissions. Updates the visible number, the spinbutton's
+    // aria-valuenow (so AT users hear the new value), and the
+    // disabled-at-bounds state on the two buttons (#213 a11y req).
     const syncWpmUi = (n: number): void => {
-      wpmSlider.value = String(n);
-      wpmReadout.textContent = OVERLAY_TEXT.wpmReadout(n);
+      wpmStepperNum.textContent = String(n);
+      wpmStepperNum.setAttribute('aria-valuenow', String(n));
+      wpmStepperDec.disabled = n <= WPM_MIN;
+      wpmStepperInc.disabled = n >= WPM_MAX;
     };
     syncWpmUi(currentWpm);
 
@@ -1443,37 +1482,19 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       engine?.seekToSentence('next');
     });
 
-    // WPM slider (#24). Split `input` vs `change`:
-    //   - `input` fires ~60×/sec during drag — UI-only update (slider
-    //     value, readout text, currentWpm cache). Calling engine.setWpm
-    //     on every tick would `clearPending()` + `scheduleNext()` per
-    //     tick, resetting the active word's remaining-time and stalling
-    //     the RSVP stream while the user drags (ring review #21).
-    //   - `change` fires on drag release / keyboard commit — push the
-    //     final value through applyWpm so engine cadence + persistence
-    //     happen once per discrete drag, not per tick.
-    wpmSlider.addEventListener('input', () => {
-      const raw = Number(wpmSlider.value);
-      const clamped = clampWpm(raw);
-      currentWpm = clamped;
-      wpmSlider.value = String(clamped);
-      wpmReadout.textContent = OVERLAY_TEXT.wpmReadout(clamped);
+    // WPM stepper (#213) — `[−] [num] [wpm] [+]`. Each click is a single
+    // discrete commit, so unlike the prior slider there is no drag-vs-
+    // release distinction to manage. Route both buttons through applyWpm
+    // with persist:true so engine cadence updates AND onWpmChange fires
+    // once per click. applyWpm short-circuits when clamping lands on
+    // currentWpm, which is exactly the desired behaviour at the bounds
+    // (the button is also disabled by syncWpmUi so a click can't fire
+    // via mouse, but a programmatic .click() would still no-op cleanly).
+    wpmStepperDec.addEventListener('click', () => {
+      applyWpm(currentWpm - WPM_STEP, { persist: true });
     });
-    wpmSlider.addEventListener('change', () => {
-      const raw = Number(wpmSlider.value);
-      const clamped = clampWpm(raw);
-      // Bypass applyWpm's currentWpm short-circuit: `input` has already
-      // moved currentWpm to the dragged value, so applyWpm would no-op
-      // and skip engine.setWpm + persistence. Call them directly here.
-      if (!engine) return;
-      engine.setWpm(clamped);
-      // Keep the UI source of truth aligned with the committed value
-      // (defensive — input handler already syncs).
-      if (currentWpm !== clamped) {
-        currentWpm = clamped;
-        syncWpmUi(clamped);
-      }
-      opts.onWpmChange?.(clamped);
+    wpmStepperInc.addEventListener('click', () => {
+      applyWpm(currentWpm + WPM_STEP, { persist: true });
     });
     // Progress scrubber interaction (#47). Spec: pause-on-scrub, stay
     // paused. mousedown/touchstart prime the engine into paused state

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -515,17 +515,37 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     // numeric span carries the live value. Bounds are [WPM_MIN, WPM_MAX] =
     // [100, 600] (#16); step = WPM_STEP = 10 (`src/core/settings/bounds.ts`).
     //
-    // A11y shape:
+    // A11y shape (revised for PR #214 a11y review — 2 BLOCKs + 2 HOLDs):
     //   - Each button gets a verb-form `aria-label` ("Decrease/Increase
     //     reading speed") and a visible glyph; default <button> semantics
     //     mean Enter/Space activate without extra wiring.
-    //   - The numeric span is `role="spinbutton"` with aria-valuemin /
-    //     aria-valuemax / aria-valuenow so AT users hear the current WPM
-    //     announced when focus or value changes.
-    //   - The unit-label ("wpm") span is aria-hidden — the spinbutton
-    //     already announces "Reading speed (words per minute)".
-    //   - Buttons get the `disabled` attribute at MIN / MAX; styles.ts
-    //     gives the disabled state a visible affordance (opacity + cursor).
+    //   - The numeric span is a PURE DISPLAY element (no `role`,
+    //     no aria-value*). Original shape used `role="spinbutton"` +
+    //     aria-valuenow, but ARIA APG requires spinbutton elements to
+    //     be focusable + handle ArrowUp/Down/Home/End. The span had none
+    //     of that, so AT users heard "spin button, 300" and got silence
+    //     when arrowing (WCAG 4.1.2 BLOCK). Instead, the span carries a
+    //     dynamic `aria-label` rewritten on each commit
+    //     (`OVERLAY_TEXT.wpmDisplayLabel(n)`); the buttons own the
+    //     increment affordance.
+    //   - On every user-initiated commit (− / + click), the new value
+    //     is also announced via the polite `.aria-live` region so AT
+    //     users hear feedback even without focus on the display element
+    //     (WCAG 4.1.3 Status Messages BLOCK — updating aria-valuenow on
+    //     a non-focused sibling does NOT reliably trigger NVDA/JAWS/
+    //     VoiceOver announcements). Keyboard ArrowUp/Down (persist:false)
+    //     intentionally does NOT announce — that path is live engine
+    //     cadence and per-tick announcements would be deafening.
+    //   - The unit-label ("wpm") span is aria-hidden — the display
+    //     element's aria-label already conveys "words per minute".
+    //   - Buttons use `aria-disabled="true"` at MIN / MAX rather than
+    //     native `disabled` (HOLD — native disabled removes the element
+    //     from the tab chain, hiding the affordance from keyboard users).
+    //     Click handlers short-circuit on `aria-disabled === 'true'` so
+    //     programmatic clicks still no-op. styles.ts uses
+    //     `[aria-disabled="true"]` selectors with `--text-muted` color
+    //     (clears WCAG 1.4.11 3:1 against `--surface`) + cursor:
+    //     not-allowed for the visual affordance.
     const wpmStepper = doc.createElement('div');
     wpmStepper.className = OVERLAY_CLASS.WPM_STEPPER;
 
@@ -537,11 +557,10 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
 
     const wpmStepperNum = doc.createElement('span');
     wpmStepperNum.className = OVERLAY_CLASS.WPM_STEPPER_NUM;
-    wpmStepperNum.setAttribute('role', 'spinbutton');
-    wpmStepperNum.setAttribute('aria-label', OVERLAY_TEXT.WPM_SPINBUTTON_LABEL);
-    wpmStepperNum.setAttribute('aria-valuemin', String(WPM_MIN));
-    wpmStepperNum.setAttribute('aria-valuemax', String(WPM_MAX));
-    // aria-valuenow is set in mount() via syncWpmUi(currentWpm).
+    // PR #214 a11y BLOCK 2 — `role="spinbutton"` + `aria-value*` removed.
+    // The display element's `aria-label` is set in mount() via
+    // syncWpmUi(currentWpm) and rewritten on every commit so AT users
+    // hear the current value when focus reaches the element.
 
     const wpmStepperLbl = doc.createElement('span');
     wpmStepperLbl.className = OVERLAY_CLASS.WPM_STEPPER_LBL;
@@ -774,14 +793,19 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     // Single point of truth for keeping the stepper UI in sync with
     // `currentWpm`. Called from mount-time init, the ArrowUp/Down keyboard
     // handler, the −/+ button click handlers, and subscribeSettings
-    // emissions. Updates the visible number, the spinbutton's
-    // aria-valuenow (so AT users hear the new value), and the
-    // disabled-at-bounds state on the two buttons (#213 a11y req).
+    // emissions. Updates the visible number, the display element's
+    // dynamic `aria-label` (#214 a11y BLOCK 2 — replaces the broken
+    // role="spinbutton"/aria-valuenow shape), and the aria-disabled
+    // bounds state on the two buttons (#214 a11y HOLD 1 — was native
+    // `disabled`, which removes the buttons from the tab chain).
     const syncWpmUi = (n: number): void => {
       wpmStepperNum.textContent = String(n);
-      wpmStepperNum.setAttribute('aria-valuenow', String(n));
-      wpmStepperDec.disabled = n <= WPM_MIN;
-      wpmStepperInc.disabled = n >= WPM_MAX;
+      wpmStepperNum.setAttribute('aria-label', OVERLAY_TEXT.wpmDisplayLabel(n));
+      // `aria-disabled` (not native disabled) — keyboard users tabbing
+      // at MIN/MAX still land on the button so the affordance is
+      // discoverable; click handlers short-circuit when this is 'true'.
+      wpmStepperDec.setAttribute('aria-disabled', n <= WPM_MIN ? 'true' : 'false');
+      wpmStepperInc.setAttribute('aria-disabled', n >= WPM_MAX ? 'true' : 'false');
     };
     syncWpmUi(currentWpm);
 
@@ -1462,7 +1486,17 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       currentWpm = clamped;
       engine.setWpm(clamped);
       syncWpmUi(clamped);
-      if (opts2.persist) opts.onWpmChange?.(clamped);
+      if (opts2.persist) {
+        opts.onWpmChange?.(clamped);
+        // #214 a11y BLOCK 1 — fire a polite live-region announcement
+        // on user-initiated commits (stepper ± click) so AT users hear
+        // the new value even when focus is not on the display element.
+        // ArrowUp/Down (persist:false) intentionally skips this — per-
+        // tick announcements during live cadence probing would be
+        // deafening. The .aria-live region is polite + aria-atomic, so
+        // consecutive writes replace prior text cleanly.
+        ariaLive.textContent = OVERLAY_TEXT.wpmAnnouncement(clamped);
+      }
     };
     // ArrowUp / ArrowDown — adjust engine cadence without persisting. Issue
     // #24 names the slider as the persistence surface; the keyboard
@@ -1486,14 +1520,21 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     // discrete commit, so unlike the prior slider there is no drag-vs-
     // release distinction to manage. Route both buttons through applyWpm
     // with persist:true so engine cadence updates AND onWpmChange fires
-    // once per click. applyWpm short-circuits when clamping lands on
-    // currentWpm, which is exactly the desired behaviour at the bounds
-    // (the button is also disabled by syncWpmUi so a click can't fire
-    // via mouse, but a programmatic .click() would still no-op cleanly).
+    // once per click.
+    //
+    // #214 a11y HOLD 1 — explicit `aria-disabled` short-circuit. We
+    // moved off native `disabled` (which removes the element from the
+    // tab chain); aria-disabled keeps the button focusable, so we MUST
+    // gate the click ourselves. applyWpm already short-circuits when
+    // clamping lands on currentWpm, but the explicit handler-level
+    // check is clearer for the reader and survives a refactor of
+    // applyWpm's short-circuit logic. Belt-and-suspenders by design.
     wpmStepperDec.addEventListener('click', () => {
+      if (wpmStepperDec.getAttribute('aria-disabled') === 'true') return;
       applyWpm(currentWpm - WPM_STEP, { persist: true });
     });
     wpmStepperInc.addEventListener('click', () => {
+      if (wpmStepperInc.getAttribute('aria-disabled') === 'true') return;
       applyWpm(currentWpm + WPM_STEP, { persist: true });
     });
     // Progress scrubber interaction (#47). Spec: pause-on-scrub, stay

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -508,30 +508,68 @@ export const OVERLAY_CSS = `
   cursor: not-allowed;
 }
 
-/* WPM slider + readout — styled as a pill chip pair.
- * Hit-target ≥44px per WCAG 2.2 AA. */
-.wpm-slider {
-  min-height: 44px;
-  inline-size: clamp(100px, 18cqi, 180px);
-  accent-color: var(--accent, #1a73e8);
-  cursor: pointer;
-}
-
-.wpm-slider:focus-visible {
-  outline: 2px solid var(--accent, #1a73e8);
-  outline-offset: 4px;
-}
-
-.wpm-readout {
-  font: 600 12px / 1 var(--font-mono);
-  font-variant-numeric: tabular-nums;
-  color: var(--text);
+/* WPM stepper (#213) — [−] [num] [wpm] [+] pill chip. Replaces the
+ * prior .wpm-slider + .wpm-readout pair with a button trio + label
+ * inside a single rounded surface, per the Hi-Fi mockup. Hit-target
+ * ≥44px per WCAG 2.2 AA: buttons have min-height 44px even though the
+ * visible glyph circle is 22px (matches the mockup), via padding inside
+ * the larger touch box. */
+.wpm-display {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   padding: 4px 10px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 999px;
-  min-inline-size: 5ch;
+}
+
+.wpm-display .wpm-stepper-num {
+  font: 600 12px / 1 var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+  min-inline-size: 3ch;
   text-align: center;
+}
+
+.wpm-display .wpm-stepper-lbl {
+  font: 500 11px / 1 var(--font-ui);
+  color: var(--text-muted, var(--text));
+}
+
+.wpm-display button {
+  /* WCAG 2.2 AA target-size: 44×44 hit-area on the button element even
+   * though the painted circle is 22×22 (mockup visual). The button's
+   * background paints behind the centered glyph; the larger min-height
+   * keeps touch targets honest without inflating the visual chrome. */
+  min-width: 44px;
+  min-height: 44px;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--text-2);
+  font: 500 14px / 1 var(--font-ui);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+}
+
+.wpm-display button:hover:not(:disabled) {
+  background: var(--accent-soft, #e8f0fe);
+  color: var(--text, #202124);
+}
+
+.wpm-display button:focus-visible {
+  outline: 2px solid var(--accent, #1a73e8);
+  outline-offset: 2px;
+}
+
+.wpm-display button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 /* ===== Resume toast (#48) — Hi-Fi chip styling. ===== */
@@ -700,9 +738,13 @@ export const OVERLAY_CSS = `
   .font-inc-btn:focus-visible,
   .prev-sentence-btn:focus-visible,
   .next-sentence-btn:focus-visible { outline-color: Highlight; }
-  .wpm-slider:focus-visible,
   .scrubber-slider:focus-visible { outline-color: Highlight; }
-  .wpm-readout { color: CanvasText; border-color: CanvasText; background: Canvas; }
+  /* #213 — replaced .wpm-slider + .wpm-readout with the stepper. */
+  .wpm-display { color: CanvasText; border-color: CanvasText; background: Canvas; }
+  .wpm-display button { background: ButtonFace; color: ButtonText; border: 1px solid ButtonText; }
+  .wpm-display button:focus-visible { outline-color: Highlight; }
+  .wpm-display .wpm-stepper-num { color: CanvasText; }
+  .wpm-display .wpm-stepper-lbl { color: CanvasText; }
   .scrubber-labels { color: CanvasText; }
   .context-preview { color: CanvasText; }
   .context-current { color: Highlight; background: Canvas; }
@@ -801,9 +843,14 @@ export const OVERLAY_CSS = `
     width: auto;
     padding: 0 16px;
   }
-  .wpm-slider {
+  /* #213 — stepper buttons bump to ≥48px on touch-primary; the
+   * surrounding .wpm-display chip wraps with row-gap from the .footer
+   * rule above so the pill stays single-row when space allows. */
+  .wpm-display button {
+    min-width: 48px;
     min-height: 48px;
-    inline-size: clamp(140px, 26cqi, 280px);
+    width: 48px;
+    height: 48px;
   }
   .scrubber-slider {
     block-size: 32px;

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -557,7 +557,7 @@ export const OVERLAY_CSS = `
   place-items: center;
 }
 
-.wpm-display button:hover:not(:disabled) {
+.wpm-display button:hover:not([aria-disabled='true']) {
   background: var(--accent-soft, #e8f0fe);
   color: var(--text, #202124);
 }
@@ -567,8 +567,15 @@ export const OVERLAY_CSS = `
   outline-offset: 2px;
 }
 
-.wpm-display button:disabled {
-  opacity: 0.4;
+/* #214 a11y HOLD 1 + HOLD 2 — [aria-disabled="true"] (not native
+ * :disabled) so the button stays in the tab chain, and --text-muted
+ * (not opacity: 0.4) so the disabled glyph clears WCAG 1.4.11 3:1
+ * non-text contrast against --surface. --text-muted is the existing
+ * 75/25 token already documented at ~5.5:1 against light/paper/cream
+ * surfaces; cursor: not-allowed carries the additional state
+ * affordance (WCAG 1.4.1 — meaning not conveyed by contrast alone). */
+.wpm-display button[aria-disabled='true'] {
+  color: var(--text-muted);
   cursor: not-allowed;
 }
 


### PR DESCRIPTION
## Summary

- Replace overlay `<input type="range">` WPM slider with `[−] [num] [wpm] [+]` stepper per Hi-Fi mockup (decoded.html lines 2267-2271).
- Numeric span gets `role="spinbutton"` + `aria-valuemin/max/now`; ± buttons get aria-labels + 44px touch target; buttons disable at `WPM_MIN`/`WPM_MAX`.
- Scrubber styling preserved — shared selector lists with `.wpm-slider` split so `.scrubber-slider` rules stay byte-for-byte identical.

Closes #213.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test` — 1297/1297 pass (21 new control-bar stepper assertions, 5 new wpm-wire assertions)
- [x] `npm run build` — clean
- [x] Mutation-guard 1: `WPM_DEC_LABEL` change → control-bar aria-label assertion flips red ✓
- [x] Mutation-guard 2: `+1` off-by-one in `+` click handler → wpm-wire single-click + multi-click assertions flip red ✓
- [x] Manual: load unpacked, verify ± clicks increment by 10, click − at 100 / + at 600 does nothing, scrubber visuals unchanged
- [x] Manual: `↑↓` global hotkey still adjusts WPM in overlay

## Follow-ups

- Architect review queued (per project memory `feedback_architect_a11y_after_ring`) — focus areas: `Refs` type-shape propagation, `applyWpm` reuse seam.
- a11y-extension-designer review queued — focus areas: `role="spinbutton"` + aria-value plumbing, disabled-state contrast, focus order across ± and number span.

## Builder notes (from coder dispatch)

- `WPM_READOUT` constant folded into `WPM_STEPPER_NUM` (single owner, no external readers).
- `overlay.ts:537` comment about `.wpm-slider`/`.scrubber-slider` shared selector list was inaccurate — `.scrubber-slider` had dedicated rule blocks; only two shared selector lists existed (`:703` forced-colors, `:804` touch-primary). Both split cleanly.
- `OVERLAY_TEXT.wpmReadout()` template removed (no remaining callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

