### PR TITLE
chore(release): v0.2.0 — first Chrome Web Store submission (unlisted)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ out/
 tests/e2e/profiling/results/*
 !tests/e2e/profiling/results/.gitkeep
 dist-e2e-ext/
+
+# Chrome Web Store release artifacts (built from dist/ via `zip`)
+speedreader-chrome-*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,23 @@ heading and a fresh `[Unreleased]` block is opened above it.
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.2.0] - 2026-05-31
+
+First Chrome Web Store submission build (unlisted testing track). Phase-1
+parity with the Safari reference plus Hi-Fi overlay polish landed in M2.
+
+### Added
+
 - `CHANGELOG.md` seeded with keep-a-changelog scaffolding (#42).
 - `PRIVACY.md` documenting Chrome Web Store privacy claims (no data
   egress, no analytics, no network, no account, no tracking) — required
@@ -48,4 +65,5 @@ heading and a fresh `[Unreleased]` block is opened above it.
 
 ### Security
 
-[Unreleased]: https://github.com/chriscantu/speedreader-chrome/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/chriscantu/speedreader-chrome/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/chriscantu/speedreader-chrome/compare/v0.1.0...v0.2.0

--- a/PRIVACY.html
+++ b/PRIVACY.html
@@ -1,0 +1,257 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Privacy Policy — SpeedReader for Chrome</title>
+    <meta
+      name="description"
+      content="Privacy policy for the SpeedReader Chrome extension: no data collection, no analytics, no network calls."
+    />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --fg: #111;
+        --bg: #fff;
+        --muted: #555;
+        --link: #0366d6;
+        --rule: #e1e4e8;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --fg: #e6edf3;
+          --bg: #0d1117;
+          --muted: #9aa4af;
+          --link: #58a6ff;
+          --rule: #30363d;
+        }
+      }
+      html,
+      body {
+        background: var(--bg);
+        color: var(--fg);
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
+          sans-serif;
+        line-height: 1.55;
+        max-width: 760px;
+        margin: 2rem auto;
+        padding: 0 1.25rem;
+      }
+      h1,
+      h2 {
+        line-height: 1.25;
+      }
+      h1 {
+        margin-bottom: 0.25rem;
+      }
+      h2 {
+        margin-top: 2rem;
+        border-bottom: 1px solid var(--rule);
+        padding-bottom: 0.25rem;
+      }
+      a {
+        color: var(--link);
+      }
+      .meta {
+        color: var(--muted);
+        font-size: 0.95rem;
+        margin-bottom: 1.5rem;
+      }
+      code {
+        background: rgba(127, 127, 127, 0.15);
+        padding: 0.1em 0.35em;
+        border-radius: 4px;
+        font-size: 0.92em;
+      }
+      ul {
+        padding-left: 1.4rem;
+      }
+      li {
+        margin: 0.35rem 0;
+      }
+      footer {
+        margin-top: 3rem;
+        padding-top: 1rem;
+        border-top: 1px solid var(--rule);
+        color: var(--muted);
+        font-size: 0.9rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Privacy Policy</h1>
+    <p class="meta">
+      <strong>SpeedReader for Chrome</strong> &mdash; Effective date:
+      2026-05-29
+    </p>
+
+    <p>
+      SpeedReader is a free, open-source Chrome extension that delivers Rapid
+      Serial Visual Presentation (RSVP) reading for any web page you choose to
+      read with it. It is built for neurodivergent readers (ADHD, dyslexia,
+      processing differences) and adjacent audiences who benefit from
+      distraction-free focused reading.
+    </p>
+
+    <p>
+      This document describes &mdash; in plain terms and with no marketing
+      language &mdash; what data the extension touches, where that data lives,
+      and what it never does.
+    </p>
+
+    <h2>What we collect</h2>
+    <p><strong>Nothing.</strong></p>
+    <p>
+      SpeedReader does not collect, transmit, sell, share, or otherwise transfer
+      any personal information, browsing activity, page content, or analytics.
+    </p>
+    <p>There are no accounts. There is no login. There is no server.</p>
+
+    <h2>What stays on your device</h2>
+    <p>
+      The following data is stored locally on your device via the standard
+      Chrome
+      <a
+        href="https://developer.chrome.com/docs/extensions/reference/api/storage"
+        ><code>chrome.storage</code></a
+      >
+      API and never leaves it:
+    </p>
+    <ul>
+      <li>
+        <strong>User preferences</strong> &mdash; words per minute (WPM), font
+        face, font size, theme (light / dark / system), and other settings
+        exposed in the options page.
+      </li>
+      <li>
+        <strong>Reading session state</strong> &mdash; the current word position
+        when you pause or close the reader. This is held in memory or in
+        <code>chrome.storage</code> for your convenience and is not transmitted
+        anywhere.
+      </li>
+    </ul>
+    <p>
+      You can clear this data at any time from <code>chrome://extensions/</code>
+      &rarr; SpeedReader &rarr; &ldquo;Site settings&rdquo; / &ldquo;Remove
+      extension&rdquo;.
+    </p>
+
+    <h2>What we never do</h2>
+    <ul>
+      <li>
+        <strong>No analytics.</strong> No first-party or third-party analytics
+        SDKs are bundled or loaded.
+      </li>
+      <li>
+        <strong>No telemetry.</strong> No usage pings, no crash reports, no
+        &ldquo;anonymous&rdquo; metrics.
+      </li>
+      <li>
+        <strong>No network calls.</strong> The extension makes no outbound
+        HTTP, WebSocket, <code>fetch</code>, <code>XMLHttpRequest</code>, or
+        <code>sendBeacon</code> calls. The only network activity tied to the
+        extension is Chrome&rsquo;s own update check for new versions, which is
+        controlled by your browser, not by us.
+      </li>
+      <li>
+        <strong>No page content transmission.</strong> When you trigger
+        SpeedReader on a page, the extension reads the page&rsquo;s text locally
+        in the content script and feeds it into the on-device RSVP engine. That
+        text is never sent off the device.
+      </li>
+      <li>
+        <strong>No tracking across sites.</strong> SpeedReader has no concept of
+        &ldquo;the same user across sites&rdquo;. The extension does not know
+        what other pages you visit.
+      </li>
+      <li>
+        <strong>No sale, sharing, or transfer of data</strong> under any meaning
+        of those terms in GDPR, CCPA, or analogous regimes &mdash; because there
+        is no data to sell, share, or transfer.
+      </li>
+    </ul>
+
+    <h2>Permissions, in plain language</h2>
+    <p>
+      Each Chrome permission the extension requests is requested because it is
+      required for the reading experience. None grant any kind of remote
+      access. Per-permission justifications live in
+      <a
+        href="https://github.com/chriscantu/speedreader-chrome/blob/main/docs/permission-justifications.md"
+        ><code>docs/permission-justifications.md</code></a
+      >; the short form:
+    </p>
+    <ul>
+      <li>
+        <code>storage</code> &mdash; persist your settings (WPM, font, theme)
+        locally.
+      </li>
+      <li>
+        <code>activeTab</code> &mdash; read the text of the tab you actively
+        invoke the extension on, for the duration of that user gesture.
+        Replaces broad <code>&lt;all_urls&gt;</code> host permissions.
+      </li>
+      <li>
+        <code>scripting</code> &mdash; inject the content script into the
+        active tab on demand when you open the popup or press the keyboard
+        shortcut.
+      </li>
+      <li>
+        <code>contextMenus</code> &mdash; register the right-click
+        &ldquo;SpeedReader&rdquo; entry on text selections.
+      </li>
+    </ul>
+
+    <h2>Children&rsquo;s privacy</h2>
+    <p>
+      SpeedReader does not knowingly collect any information from children
+      under 13, because it does not collect information from anyone.
+    </p>
+
+    <h2>Open source</h2>
+    <p>
+      The full source code is published at
+      <a href="https://github.com/chriscantu/speedreader-chrome"
+        >github.com/chriscantu/speedreader-chrome</a
+      >. Anyone may inspect, audit, build, or fork it. If the source
+      code&rsquo;s behavior ever diverges from the claims in this document, the
+      source is the truth &mdash; please open an issue.
+    </p>
+
+    <h2>Changes to this policy</h2>
+    <p>
+      If a future release ever needs to change any of the claims above (for
+      example, an opt-in feature that touches a network), this document will be
+      updated in the same commit as the change, and the entry will be called
+      out in
+      <a
+        href="https://github.com/chriscantu/speedreader-chrome/blob/main/CHANGELOG.md"
+        ><code>CHANGELOG.md</code></a
+      >.
+    </p>
+
+    <h2>Contact</h2>
+    <p>
+      Questions, concerns, or corrections: open an issue at
+      <a href="https://github.com/chriscantu/speedreader-chrome/issues"
+        >github.com/chriscantu/speedreader-chrome/issues</a
+      >.
+    </p>
+
+    <footer>
+      Canonical Markdown source:
+      <a
+        href="https://github.com/chriscantu/speedreader-chrome/blob/main/PRIVACY.md"
+        >PRIVACY.md</a
+      >
+      &middot; License:
+      <a
+        href="https://github.com/chriscantu/speedreader-chrome/blob/main/LICENSE"
+        >MIT</a
+      >.
+    </footer>
+  </body>
+</html>

--- a/docs/cws/SUBMISSION-RUNBOOK.md
+++ b/docs/cws/SUBMISSION-RUNBOOK.md
@@ -28,6 +28,49 @@ building. The CWS form is unforgiving about partial submissions.
 
 ---
 
+## 0. v0.2.0 handoff checklist (initial unlisted-testing submission)
+
+This block is a one-time checklist for the first submission cycle. Once
+v0.2.0 ships and a `1.0.0` public submission is queued, the items here
+graduate into the standard §1–§6 flow and this section can be deleted
+(or kept as the historical record).
+
+The agent has already produced:
+
+- [x] Version bumped: `package.json` + `src/chrome/manifest.ts` → `0.2.0`
+- [x] `CHANGELOG.md` `[Unreleased]` promoted to `[0.2.0] - 2026-05-31`
+- [x] Production zip built: `speedreader-chrome-0.2.0.zip` (≈198 KB, gitignored)
+- [x] Standalone `PRIVACY.html` at repo root for GitHub Pages hosting
+- [x] Release branch `release/v0.2.0` pushed; PR open
+
+Maintainer-owned items (agent cannot drive these):
+
+- [ ] **Enable GitHub Pages.** Repo → Settings → Pages → Source: `Deploy from a branch` → Branch: `main` / `/ (root)`. Save. Wait ~1–2 min for first build.
+  - Verify: `curl -I https://chriscantu.github.io/speedreader-chrome/PRIVACY.html` returns `200 OK`.
+  - This URL is what you paste into the CWS "Privacy policy" field.
+- [ ] **Capture screenshots** per [`docs/cws/SCREENSHOT-PLAYBOOK.md`](SCREENSHOT-PLAYBOOK.md). Five 1280×800 PNGs minimum. Drop them in a local capture folder; do NOT commit (they're listing assets, not source).
+- [ ] **Design 440×280 promo tile.** Brief in the screenshot playbook. Solid background, store icon centered, product name in Open Sans Bold. PNG, sRGB.
+- [ ] **Register Chrome Web Store developer account.** <https://chrome.google.com/webstore/devconsole>. One-time $5 USD. Enable 2FA on the Google account first.
+- [ ] **Upload `speedreader-chrome-0.2.0.zip`** in the dev console → "New item" → drag-drop the zip.
+- [ ] **Fill listing fields verbatim from `docs/cws/LISTING.md`** — name, summary, description, category (Accessibility), language (en-US), single-purpose statement, permission justifications (paste from `docs/permission-justifications.md`), privacy URL (the GH Pages URL above).
+- [ ] **Visibility: Unlisted.** Distribution → Visibility → "Unlisted". This is the staged-release gate — the listing is reviewable by Google but not surfaced in search.
+- [ ] **Submit for review.** Click "Submit for review". Approval typically 1–3 business days.
+- [ ] **On approval:** smoke-test the install on a fresh Chrome profile via the unlisted URL. Verify popup, overlay activation, options page, context-menu entry, theme apply. If all green, queue the `1.0.0` public submission (re-run §0 with version bumped + visibility flipped to Public).
+- [ ] **On rejection:** capture the reviewer message, route to [`§5 Reviewer-feedback template`](#5-reviewer-feedback-template) for canned response; address root cause in code; bump patch version (`0.2.1`), rebuild zip, re-submit.
+
+Release artifact build, repeatable:
+
+```bash
+git checkout main && git pull
+npm ci
+npm run lint
+npm test
+npm run build
+(cd dist && zip -r ../speedreader-chrome-$(node -p "require('../package.json').version").zip . -x "*.DS_Store")
+```
+
+---
+
 ## 1. Pre-flight checklist
 
 Run these checks from the repository root **before** starting the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speedreader-chrome",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SpeedReader for Chrome - RSVP reading accessibility extension",
   "type": "module",
   "scripts": {

--- a/src/chrome/manifest.ts
+++ b/src/chrome/manifest.ts
@@ -23,7 +23,7 @@
 export default {
   manifest_version: 3,
   name: 'SpeedReader',
-  version: '0.1.0',
+  version: '0.2.0',
   description: 'RSVP reading accessibility extension for Chrome',
 
   // --- Background service worker ------------------------------------------


### PR DESCRIPTION
## Summary

First Chrome Web Store submission build (unlisted testing track). Phase-1 parity with the Safari reference plus Hi-Fi overlay polish landed in M2. This PR is **release-only** — it ships no new product code; it bumps version metadata, promotes the changelog, hosts the privacy policy as static HTML for GitHub Pages, and adds a §0 handoff checklist to the existing submission runbook.

- Bump version: `package.json` + `src/chrome/manifest.ts` 0.1.0 → 0.2.0
- Promote `CHANGELOG.md` `[Unreleased]` → `[0.2.0] - 2026-05-31`
- Add `PRIVACY.html` (standalone) for CWS privacy-URL target at `https://chriscantu.github.io/speedreader-chrome/PRIVACY.html`
- Add `§0 v0.2.0 handoff checklist` to `docs/cws/SUBMISSION-RUNBOOK.md` — agent-produced ✓ + maintainer-owned □ items
- gitignore `speedreader-chrome-*.zip` release artifacts

### Why staged (0.2.0 unlisted → 1.0.0 public)

Submitting unlisted first validates Google's review pipeline against the actual extension, manifest, and privacy claims without exposing a public listing. On approval + a fresh-profile smoke test, the next PR bumps to 1.0.0 and flips visibility to Public. Lower rework risk than a direct 1.0.0 public submission.

## Test plan

- [x] `npm run lint` — 0 warnings
- [x] `npm run format:check` — clean
- [x] `npm test` — 1303 / 1303 pass (85 files)
- [x] `npm run build` — `dist/manifest.json` shows `"version": "0.2.0"`
- [x] Production zip built locally: `speedreader-chrome-0.2.0.zip`, 198 KB, `manifest.json` at root
- [x] CI green on this PR
- [ ] After merge: enable GitHub Pages (Settings → Pages → main / root) → verify `curl -I https://chriscantu.github.io/speedreader-chrome/PRIVACY.html` returns `200 OK`
- [ ] Maintainer captures screenshots per `docs/cws/SCREENSHOT-PLAYBOOK.md`
- [ ] Maintainer registers CWS dev account ($5) + uploads zip + pastes listing per `docs/cws/SUBMISSION-RUNBOOK.md §0`

## Out of scope

- Screenshots / promo tile (manual capture, see playbook)
- Dev-account registration (maintainer-only)
- Actual CWS upload (maintainer-only)
- 1.0.0 public bump (follow-up PR after unlisted approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

