### PR TITLE
feat(settings): scrubberAutoHide opt-out — settings V7 + overlay gate (#211)

### DIFF
--- a/src/chrome/background/context-menu/__tests__/factory.test.ts
+++ b/src/chrome/background/context-menu/__tests__/factory.test.ts
@@ -6,13 +6,13 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { SettingsV6 } from '../../../../core/settings';
+import type { SettingsV7 } from '../../../../core/settings';
 import { DEFAULT_SETTINGS } from '../../../../core/settings/defaults';
 import { buildMenuItems, type CtxMenuItemId } from '../factory';
 
 const HTTP = ['http://*/*', 'https://*/*'];
 
-function withSettings(partial: Partial<SettingsV6>): SettingsV6 {
+function withSettings(partial: Partial<SettingsV7>): SettingsV7 {
   return { ...DEFAULT_SETTINGS, ...partial };
 }
 

--- a/src/chrome/background/context-menu/__tests__/install.test.ts
+++ b/src/chrome/background/context-menu/__tests__/install.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
-import type { SettingsV6 } from '../../../../core/settings';
+import type { SettingsV7 } from '../../../../core/settings';
 import { DEFAULT_SETTINGS } from '../../../../core/settings/defaults';
 
 vi.mock('../../../settings/storage', () => ({
@@ -101,7 +101,7 @@ describe('ensureContextMenu', () => {
     stub.contextMenus.create.mockClear();
     stub.contextMenus.update.mockClear();
 
-    const nextSettings: SettingsV6 = { ...DEFAULT_SETTINGS, lastUsedWpm: 420 };
+    const nextSettings: SettingsV7 = { ...DEFAULT_SETTINGS, lastUsedWpm: 420 };
     loadSettings.mockResolvedValueOnce(nextSettings);
     await ensureContextMenu();
 
@@ -122,7 +122,7 @@ describe('ensureContextMenu', () => {
     stub.contextMenus.create.mockClear();
     stub.contextMenus.update.mockClear();
 
-    const nextSettings: SettingsV6 = { ...DEFAULT_SETTINGS, contextLine: true };
+    const nextSettings: SettingsV7 = { ...DEFAULT_SETTINGS, contextLine: true };
     loadSettings.mockResolvedValueOnce(nextSettings);
     await ensureContextMenu();
 
@@ -155,7 +155,7 @@ describe('ensureContextMenu', () => {
     let loadResolved = false;
     loadSettings.mockImplementationOnce(
       () =>
-        new Promise<SettingsV6>((resolve) => {
+        new Promise<SettingsV7>((resolve) => {
           setTimeout(() => {
             loadResolved = true;
             resolve(DEFAULT_SETTINGS);

--- a/src/chrome/background/context-menu/factory.ts
+++ b/src/chrome/background/context-menu/factory.ts
@@ -4,7 +4,7 @@
  * No `chrome.*` calls — `install.ts` owns the adapter side. Keeping this
  * file pure means every shape decision (titles, checkbox state, separator
  * placement) is exercised by `factory.test.ts` against a plain
- * `SettingsV6` input without any chrome-stub scaffolding.
+ * `SettingsV7` input without any chrome-stub scaffolding.
  *
  * See:
  * - `docs/superpowers/specs/2026-05-25-context-menu-integration.md`
@@ -13,7 +13,7 @@
  *   §"File Layout" — the factory / adapter / listener split.
  */
 
-import type { SettingsV6 } from '../../../core/settings';
+import type { SettingsV7 } from '../../../core/settings';
 
 /**
  * Stable, versioned menu-item IDs. The `v1` suffix lets a future shape
@@ -63,7 +63,7 @@ const HTTP_PATTERNS = ['http://*/*', 'https://*/*'] as const;
  * `chrome.*` references. Items are emitted in the order they should
  * appear in the submenu; the adapter preserves order on `create`.
  */
-export function buildMenuItems(settings: SettingsV6): CtxItemSpec[] {
+export function buildMenuItems(settings: SettingsV7): CtxItemSpec[] {
   const PARENT_ID: CtxMenuItemId = 'speedreader.ctx.parent.v1';
 
   const parent: CtxItemSpec = {

--- a/src/chrome/content/__tests__/chunk-size-wire.test.ts
+++ b/src/chrome/content/__tests__/chunk-size-wire.test.ts
@@ -20,7 +20,7 @@
  */
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
-import type { SettingsV6 } from '../../../core/settings/schema';
+import type { SettingsV7 } from '../../../core/settings/schema';
 import { OVERLAY_CLASS } from '../../../core/overlay/constants';
 
 const SETTINGS_KEY = 'speedreader.settings';
@@ -55,10 +55,10 @@ interface ChromeMock {
   };
 }
 
-function installChromeMock(stored: SettingsV6): {
+function installChromeMock(stored: SettingsV7): {
   mock: ChromeMock;
   getListener: () => Listener;
-  emitStorageChange: (next: SettingsV6) => void;
+  emitStorageChange: (next: SettingsV7) => void;
 } {
   let capturedListener: Listener | undefined;
   const storageListeners: StorageChangedListener[] = [];
@@ -92,7 +92,7 @@ function installChromeMock(stored: SettingsV6): {
       if (!capturedListener) throw new Error('content script never registered listener');
       return capturedListener;
     },
-    emitStorageChange: (next: SettingsV6) => {
+    emitStorageChange: (next: SettingsV7) => {
       for (const l of storageListeners) {
         l({ [SETTINGS_KEY]: { newValue: next, oldValue: stored } }, 'sync');
       }

--- a/src/chrome/content/__tests__/font-wire.test.ts
+++ b/src/chrome/content/__tests__/font-wire.test.ts
@@ -17,7 +17,7 @@
  */
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
-import type { SettingsV6 } from '../../../core/settings/schema';
+import type { SettingsV7 } from '../../../core/settings/schema';
 import { OVERLAY_CLASS } from '../../../core/overlay/constants';
 
 const SETTINGS_KEY = 'speedreader.settings';
@@ -52,10 +52,10 @@ interface ChromeMock {
   };
 }
 
-function installChromeMock(stored: SettingsV6): {
+function installChromeMock(stored: SettingsV7): {
   mock: ChromeMock;
   getListener: () => Listener;
-  emitStorageChange: (next: SettingsV6) => void;
+  emitStorageChange: (next: SettingsV7) => void;
 } {
   let capturedListener: Listener | undefined;
   const storageListeners: StorageChangedListener[] = [];
@@ -89,7 +89,7 @@ function installChromeMock(stored: SettingsV6): {
       if (!capturedListener) throw new Error('content script never registered listener');
       return capturedListener;
     },
-    emitStorageChange: (next: SettingsV6) => {
+    emitStorageChange: (next: SettingsV7) => {
       for (const l of storageListeners) {
         l({ [SETTINGS_KEY]: { newValue: next, oldValue: stored } }, 'sync');
       }

--- a/src/chrome/content/__tests__/scrubber-autohide-wire.test.ts
+++ b/src/chrome/content/__tests__/scrubber-autohide-wire.test.ts
@@ -1,32 +1,31 @@
 /**
- * alignment-wire.test.ts — issue #52 PART A (test-gap HIGH #1)
+ * scrubber-autohide-wire.test.ts — issue #211 (CS-glue boundary)
  *
  * End-to-end wire from `chrome.storage.sync.get` → loadSettings →
- * createOverlay (`initialSettings.alignment` slot) → subscribeSettings
- * push → host `data-alignment` attribute. The unit tests in
- * `core/overlay/__tests__/alignment-wire.test.ts` pin the overlay's
- * local behaviour; this file pins the chrome-glue boundary so a
- * regression that drops `alignment: settings.alignment` from the CS
- * payload or the subscribe wiring lands as a test failure rather
+ * createOverlay (`initialSettings.scrubberAutoHide` slot) →
+ * subscribeSettings push → overlay scrubber visibility. The unit tests in
+ * `core/overlay/__tests__/scrubber-autohide.test.ts` pin the overlay's
+ * local gate behaviour; this file pins the chrome-glue boundary so a
+ * regression that drops `scrubberAutoHide: settings.scrubberAutoHide` from
+ * the CS payload or the subscribe wiring lands as a test failure rather
  * than a silent default at the boundary.
  *
- * This is the same defect class as the original "alignment dead since V3"
- * bug — the schema slot existed but no boundary code read it. The unit
- * tests can't detect that the CS doesn't forward — only this boundary
- * test can.
+ * Same defect class as the "alignment dead since V3" bug: the schema slot
+ * exists but no boundary code reads it. The unit tests can't detect that
+ * the CS doesn't forward — only this boundary test can.
  *
  * Mutation guards:
- *   - Dropping `alignment: settings.alignment` from the initial-mount
- *     payload fails the first test (host attribute would default to
- *     'orp' regardless of stored value).
- *   - Dropping `alignment: s.alignment` from the subscribe payload
- *     fails the second test (the live push from orp → center would
- *     have no effect at the host attribute).
+ *   - Dropping `scrubberAutoHide: settings.scrubberAutoHide` from the
+ *     initial-mount payload fails the first test (the overlay would default
+ *     the gate to true and hide the bar despite stored `false`).
+ *   - Dropping `scrubberAutoHide: s.scrubberAutoHide` from the subscribe
+ *     payload fails the live-push test (the opt-out flip would have no
+ *     effect on the bar).
  */
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
 import type { SettingsV7 } from '../../../core/settings/schema';
-import { OVERLAY_ATTR } from '../../../core/overlay/constants';
+import { OVERLAY_CLASS } from '../../../core/overlay/constants';
 
 const SETTINGS_KEY = 'speedreader.settings';
 const EXT_ID = 'test-ext';
@@ -61,7 +60,6 @@ interface ChromeMock {
 }
 
 function installChromeMock(stored: SettingsV7): {
-  mock: ChromeMock;
   getListener: () => Listener;
   emitStorageChange: (next: SettingsV7) => void;
 } {
@@ -92,7 +90,6 @@ function installChromeMock(stored: SettingsV7): {
   };
   (globalThis as unknown as { chrome: ChromeMock }).chrome = mock;
   return {
-    mock,
     getListener: () => {
       if (!capturedListener) throw new Error('content script never registered listener');
       return capturedListener;
@@ -105,12 +102,14 @@ function installChromeMock(stored: SettingsV7): {
   };
 }
 
-function getHost(): HTMLElement {
+function isScrubberHidden(): boolean {
   const host = document.body.querySelector('[data-speedreader-overlay]');
-  if (!(host instanceof HTMLElement)) {
-    throw new Error('overlay host missing');
+  if (!(host instanceof HTMLElement) || !host.shadowRoot) {
+    throw new Error('overlay host missing or no shadow root');
   }
-  return host;
+  const area = host.shadowRoot.querySelector<HTMLElement>(`.${OVERLAY_CLASS.SCRUBBER_AREA}`);
+  if (!area) throw new Error('overlay shadow: missing scrubber-area');
+  return area.dataset.hidden === 'true';
 }
 
 async function mountOverlay(getListener: () => Listener): Promise<void> {
@@ -125,7 +124,7 @@ async function mountOverlay(getListener: () => Listener): Promise<void> {
   await Promise.resolve();
 }
 
-describe('content script — alignment wire boundary (#52 PART A)', () => {
+describe('content script — scrubberAutoHide wire boundary (#211)', () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -138,47 +137,44 @@ describe('content script — alignment wire boundary (#52 PART A)', () => {
     vi.resetModules();
   });
 
-  test('initialSettings.alignment reflects stored value — host data-alignment="center" on mount', async () => {
-    // The overlay forwards initialSettings.alignment to the host
-    // data-alignment attribute. With stored alignment='center', a
-    // regression that hardcodes alignment:'orp' (or drops the field) at
-    // the mount-site payload would leave the host on the default 'orp'
-    // and fail this test.
+  test('stored scrubberAutoHide=false → scrubber stays visible on mount (anchor opt-out wired)', async () => {
+    // Engine plays on mount. With auto-hide opted out, the bar must NOT
+    // hide. A regression that drops scrubberAutoHide from the mount payload
+    // defaults the gate to true and hides the bar — failing this test.
     const { getListener } = installChromeMock({
       ...DEFAULT_SETTINGS,
-      alignment: 'center',
+      scrubberAutoHide: false,
     });
     await mountOverlay(getListener);
-    expect(getHost().getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('center');
+    expect(isScrubberHidden()).toBe(false);
   });
 
-  test('initialSettings.alignment="orp" wires through (default value also passes the boundary)', async () => {
+  test('stored scrubberAutoHide=true → scrubber hides on mount (default behavior also passes the boundary)', async () => {
     const { getListener } = installChromeMock({
       ...DEFAULT_SETTINGS,
-      alignment: 'orp',
+      scrubberAutoHide: true,
     });
     await mountOverlay(getListener);
-    expect(getHost().getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('orp');
+    expect(isScrubberHidden()).toBe(true);
   });
 
-  test('subscribeSettings push delivers alignment change — live update flips host attribute', async () => {
-    // Start at alignment='orp'. Then push alignment='center'; the overlay's
-    // subscribe handler MUST receive the new value and flip the host
-    // data-alignment attribute. A regression that drops
-    // `alignment: s.alignment` from the subscribe payload would leave the
-    // attribute on 'orp' and fail this test.
+  test('subscribeSettings push delivers scrubberAutoHide change — live flip reveals the bar', async () => {
+    // Start auto-hide on (bar hidden during playback). Push the opt-out; the
+    // overlay subscribe handler MUST receive it and reveal the bar. Dropping
+    // `scrubberAutoHide: s.scrubberAutoHide` from the subscribe payload
+    // leaves the bar hidden and fails this test.
     const { getListener, emitStorageChange } = installChromeMock({
       ...DEFAULT_SETTINGS,
-      alignment: 'orp',
+      scrubberAutoHide: true,
     });
     await mountOverlay(getListener);
-    expect(getHost().getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('orp');
+    expect(isScrubberHidden()).toBe(true);
 
-    emitStorageChange({ ...DEFAULT_SETTINGS, alignment: 'center' });
+    emitStorageChange({ ...DEFAULT_SETTINGS, scrubberAutoHide: false });
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(getHost().getAttribute(OVERLAY_ATTR.ALIGNMENT)).toBe('center');
+    expect(isScrubberHidden()).toBe(false);
   });
 });

--- a/src/chrome/content/index.ts
+++ b/src/chrome/content/index.ts
@@ -282,6 +282,10 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
             // via subscribeSettings below so a user can toggle modes
             // mid-session.
             alignment: settings.alignment,
+            // #211 — scrubber auto-hide opt-out. Live-updated via
+            // subscribeSettings below so a user can toggle the position
+            // anchor mid-session without a remount.
+            scrubberAutoHide: settings.scrubberAutoHide,
           },
           subscribeSettings: (listener) =>
             subscribeSettings((s) =>
@@ -293,6 +297,7 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
                 font: resolveFontId(s),
                 chunkSize: s.chunkSize,
                 alignment: s.alignment,
+                scrubberAutoHide: s.scrubberAutoHide,
               }),
             ),
           // OpenDyslexic font URL (#27, #10). `core/` cannot call

--- a/src/chrome/options/__tests__/controller.test.ts
+++ b/src/chrome/options/__tests__/controller.test.ts
@@ -37,6 +37,7 @@ const HTML = `
     <option value="2"></option>
     <option value="3"></option>
   </select>
+  <input type="checkbox" id="${FIELD_IDS.scrubberAutoHide}" />
   <div id="saved"></div>
   <div id="save-error"></div>
 `;
@@ -440,6 +441,42 @@ describe('options controller', () => {
         expect.arrayContaining(['wpm']),
       );
       err.mockRestore();
+    });
+  });
+
+  // #211 — scrubberAutoHide opt-out. The options page is the feature's
+  // primary write surface; pin the populate + save round-trip so a
+  // regression that drops the FIELD_IDS/FIELD_READERS/populate wiring
+  // (leaving the user's opt-out unable to persist) lands as a test failure.
+  describe('scrubberAutoHide toggle (#211)', () => {
+    it('populates scrubberAutoHide checkbox from loaded settings (false reflects)', async () => {
+      const stub = makeStub({ ...DEFAULT_SETTINGS, scrubberAutoHide: false });
+      await bindOptionsForm(document, window, stub);
+      expect(
+        (document.getElementById(FIELD_IDS.scrubberAutoHide) as HTMLInputElement).checked,
+      ).toBe(false);
+    });
+
+    it('populates scrubberAutoHide checkbox as checked for the default (true)', async () => {
+      const stub = makeStub({ ...DEFAULT_SETTINGS, scrubberAutoHide: true });
+      await bindOptionsForm(document, window, stub);
+      expect(
+        (document.getElementById(FIELD_IDS.scrubberAutoHide) as HTMLInputElement).checked,
+      ).toBe(true);
+    });
+
+    it('saves scrubberAutoHide on change like every other field (opt-out persists)', async () => {
+      // Mutation guard: dropping `scrubberAutoHide: readCheckbox` from
+      // FIELD_READERS (or the FIELD_IDS entry) means unchecking the box
+      // never calls save — the user's opt-out silently never persists.
+      // This assertion is the only thing pinning that write path.
+      const stub = makeStub({ ...DEFAULT_SETTINGS, scrubberAutoHide: true });
+      await bindOptionsForm(document, window, stub);
+      const toggle = document.getElementById(FIELD_IDS.scrubberAutoHide) as HTMLInputElement;
+      toggle.checked = false;
+      fire(toggle, 'change');
+      await Promise.resolve();
+      expect(stub.saveMock).toHaveBeenCalledWith({ scrubberAutoHide: false });
     });
   });
 

--- a/src/chrome/options/__tests__/controller.test.ts
+++ b/src/chrome/options/__tests__/controller.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { bindOptionsForm, FIELD_IDS, type SettingsApi } from '../controller';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
-import type { SettingsV6 } from '../../../core/settings/schema';
+import type { SettingsV7 } from '../../../core/settings/schema';
 
 const HTML = `
   <div id="load-error-banner"></div>
@@ -46,15 +46,15 @@ interface Stub extends SettingsApi {
   saveMock: ReturnType<typeof vi.fn>;
   flushMock: ReturnType<typeof vi.fn>;
   subscribeMock: ReturnType<typeof vi.fn>;
-  emit(s: SettingsV6): void;
+  emit(s: SettingsV7): void;
 }
 
-function makeStub(initial: SettingsV6 = DEFAULT_SETTINGS): Stub {
-  let listener: ((s: SettingsV6) => void) | null = null;
+function makeStub(initial: SettingsV7 = DEFAULT_SETTINGS): Stub {
+  let listener: ((s: SettingsV7) => void) | null = null;
   const loadMock = vi.fn(async () => initial);
   const saveMock = vi.fn(async () => undefined);
   const flushMock = vi.fn(async () => undefined);
-  const subscribeMock = vi.fn((cb: (s: SettingsV6) => void) => {
+  const subscribeMock = vi.fn((cb: (s: SettingsV7) => void) => {
     listener = cb;
     return () => {
       listener = null;
@@ -444,7 +444,7 @@ describe('options controller', () => {
   });
 
   // #49 — historyEnabled toggle + onHistoryDisabled side-effect hook.
-  // The controller's settings data model is pure SettingsV6; the hook
+  // The controller's settings data model is pure SettingsV7; the hook
   // is the bridge to the position-store wipe action wired in index.ts.
   describe('history toggle (#49)', () => {
     it('populates historyEnabled checkbox from loaded settings', async () => {

--- a/src/chrome/options/__tests__/index-html.test.ts
+++ b/src/chrome/options/__tests__/index-html.test.ts
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { bindOptionsForm, FIELD_IDS, type SettingsApi } from '../controller';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
-import type { SettingsV6 } from '../../../core/settings/schema';
+import type { SettingsV7 } from '../../../core/settings/schema';
 import manifest from '../../manifest';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -118,6 +118,7 @@ describe('options index.html structure', () => {
       startFromWordOne: 'Always start from word one',
       historyEnabled: 'Remember recently read articles',
       chunkSize: 'Words per display',
+      scrubberAutoHide: 'Hide the position bar during playback',
     };
 
     it.each(Object.entries(FIELD_IDS))(
@@ -215,7 +216,7 @@ describe('options index.html structure', () => {
    * assertion below go red.
    */
   describe('controller binds against real index.html', () => {
-    function makeStubApi(initial: SettingsV6 = DEFAULT_SETTINGS): SettingsApi & {
+    function makeStubApi(initial: SettingsV7 = DEFAULT_SETTINGS): SettingsApi & {
       loadMock: ReturnType<typeof vi.fn>;
       saveMock: ReturnType<typeof vi.fn>;
       flushMock: ReturnType<typeof vi.fn>;

--- a/src/chrome/options/controller.ts
+++ b/src/chrome/options/controller.ts
@@ -1,4 +1,4 @@
-import type { SettingsV6 } from '../../core/settings/schema';
+import type { SettingsV7 } from '../../core/settings/schema';
 import { DEFAULT_SETTINGS } from '../../core/settings/defaults';
 import {
   FONT_SIZE_MAX,
@@ -10,10 +10,10 @@ import {
 import { resolveFontId } from '../../core/overlay/font-ids';
 
 export interface SettingsApi {
-  load(): Promise<SettingsV6>;
-  save(partial: Partial<Omit<SettingsV6, 'version' | 'lastUsedWpm'>>): Promise<void>;
+  load(): Promise<SettingsV7>;
+  save(partial: Partial<Omit<SettingsV7, 'version' | 'lastUsedWpm'>>): Promise<void>;
   flush(): Promise<void>;
-  subscribe(listener: (s: SettingsV6) => void): () => void;
+  subscribe(listener: (s: SettingsV7) => void): () => void;
 }
 
 /**
@@ -45,6 +45,9 @@ export const FIELD_IDS = {
   // #51 — chunk size select (1 | 2 | 3). Default 1 keeps today's
   // single-word display; opting into 2 or 3 enables multi-word RSVP.
   chunkSize: 'chunkSize',
+  // #211 — scrubber auto-hide opt-out checkbox. Default checked (auto-hide
+  // on); ADHD readers who use the position bar as an anchor uncheck it.
+  scrubberAutoHide: 'scrubberAutoHide',
 } as const;
 
 /**
@@ -54,7 +57,7 @@ export const FIELD_IDS = {
  * common case; nuking stored data is the destructive sub-action.
  *
  * This ID is read by `index.ts` (the chrome glue), NOT by the controller
- * — the controller's data model is `SettingsV6` only. The wipe call goes
+ * — the controller's data model is `SettingsV7` only. The wipe call goes
  * to the position store directly.
  */
 export const HISTORY_CLEAR_ON_DISABLE_ID = 'historyClearOnDisable';
@@ -66,8 +69,8 @@ const SAVED_INDICATOR_MS = 1500;
 const SAVE_ERROR_MS = 4000;
 
 type EditableField = keyof typeof FIELD_IDS;
-type EditableValue<K extends EditableField> = SettingsV6[K];
-type EditablePatch = Partial<Omit<SettingsV6, 'version' | 'lastUsedWpm'>>;
+type EditableValue<K extends EditableField> = SettingsV7[K];
+type EditablePatch = Partial<Omit<SettingsV7, 'version' | 'lastUsedWpm'>>;
 
 const THEME_VALUES = ['system', 'light', 'dark', 'sepia', 'paper', 'cream', 'nord'] as const;
 const ALIGNMENT_VALUES = ['orp', 'center'] as const;
@@ -79,7 +82,7 @@ function getInput(doc: Document, id: string): HTMLInputElement | HTMLSelectEleme
   return null;
 }
 
-function populate(doc: Document, s: SettingsV6): void {
+function populate(doc: Document, s: SettingsV7): void {
   const wpm = getInput(doc, FIELD_IDS.wpm);
   if (wpm) wpm.value = String(s.wpm);
 
@@ -114,6 +117,9 @@ function populate(doc: Document, s: SettingsV6): void {
 
   const chunkSize = getInput(doc, FIELD_IDS.chunkSize);
   if (chunkSize) chunkSize.value = String(s.chunkSize);
+
+  const scrubberAutoHide = getInput(doc, FIELD_IDS.scrubberAutoHide);
+  if (scrubberAutoHide instanceof HTMLInputElement) scrubberAutoHide.checked = s.scrubberAutoHide;
 }
 
 function flashIndicator(doc: Document, win: Window, id: string, ms: number): void {
@@ -131,7 +137,7 @@ function showLoadErrorBanner(doc: Document): void {
 
 /**
  * Per-field reader. `K` ties the element-read result to the exact
- * `SettingsV6[K]` slot so `theme`-shaped readers can't accidentally return
+ * `SettingsV7[K]` slot so `theme`-shaped readers can't accidentally return
  * a number. Each reader returns `null` to reject invalid input — the binder
  * suppresses save on null, leaving the stored value untouched.
  */
@@ -167,13 +173,13 @@ function readFont(el: HTMLInputElement | HTMLSelectElement): string | null {
   return v;
 }
 
-function readTheme(el: HTMLInputElement | HTMLSelectElement): SettingsV6['theme'] | null {
-  const v = el.value as SettingsV6['theme'];
+function readTheme(el: HTMLInputElement | HTMLSelectElement): SettingsV7['theme'] | null {
+  const v = el.value as SettingsV7['theme'];
   return (THEME_VALUES as readonly string[]).includes(v) ? v : null;
 }
 
-function readAlignment(el: HTMLInputElement | HTMLSelectElement): SettingsV6['alignment'] | null {
-  const v = el.value as SettingsV6['alignment'];
+function readAlignment(el: HTMLInputElement | HTMLSelectElement): SettingsV7['alignment'] | null {
+  const v = el.value as SettingsV7['alignment'];
   return (ALIGNMENT_VALUES as readonly string[]).includes(v) ? v : null;
 }
 
@@ -181,7 +187,7 @@ function readCheckbox(el: HTMLInputElement | HTMLSelectElement): boolean | null 
   return el instanceof HTMLInputElement ? el.checked : null;
 }
 
-function readChunkSize(el: HTMLInputElement | HTMLSelectElement): SettingsV6['chunkSize'] | null {
+function readChunkSize(el: HTMLInputElement | HTMLSelectElement): SettingsV7['chunkSize'] | null {
   // Select values are strings even when the underlying schema is a
   // numeric literal union; parse, then validate against the V6 literal
   // set so HTML drift (a "4" option added to the select) does not
@@ -190,7 +196,7 @@ function readChunkSize(el: HTMLInputElement | HTMLSelectElement): SettingsV6['ch
   const n = Number(el.value);
   if (!Number.isInteger(n)) return null;
   if (!(CHUNK_SIZE_VALUES as readonly number[]).includes(n)) return null;
-  return n as SettingsV6['chunkSize'];
+  return n as SettingsV7['chunkSize'];
 }
 
 const FIELD_READERS: { [K in EditableField]: Reader<K> } = {
@@ -204,6 +210,7 @@ const FIELD_READERS: { [K in EditableField]: Reader<K> } = {
   startFromWordOne: readCheckbox,
   historyEnabled: readCheckbox,
   chunkSize: readChunkSize,
+  scrubberAutoHide: readCheckbox,
 };
 
 function bindField<K extends EditableField>(
@@ -256,7 +263,7 @@ export async function bindOptionsForm(
   onHistoryDisabled?: OnHistoryDisabled,
 ): Promise<() => void> {
   let degraded = false;
-  let initial: SettingsV6;
+  let initial: SettingsV7;
   try {
     initial = await api.load();
   } catch (err) {

--- a/src/chrome/options/index.html
+++ b/src/chrome/options/index.html
@@ -290,6 +290,19 @@
             across the end of a sentence.
           </span>
         </div>
+
+        <!-- #211 — scrubber auto-hide opt-out. Checked by default (the bar
+             fades during playback to keep the eye on the word region).
+             ADHD readers who use the position bar as a visual anchor to
+             fight time-blindness uncheck this to keep it visible. -->
+        <div class="field inline">
+          <input type="checkbox" id="scrubberAutoHide" aria-describedby="scrubberAutoHide-hint" />
+          <label for="scrubberAutoHide">Hide the position bar during playback</label>
+        </div>
+        <p class="hint" id="scrubberAutoHide-hint">
+          Uncheck to keep the position bar visible while reading — useful as a
+          steady anchor if an auto-hiding bar is distracting.
+        </p>
       </fieldset>
 
       <!-- Pacing -->

--- a/src/chrome/settings/__tests__/storage.test.ts
+++ b/src/chrome/settings/__tests__/storage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import sinonChrome from 'sinon-chrome';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
-import type { SettingsV6 } from '../../../core/settings/schema';
+import type { SettingsV7 } from '../../../core/settings/schema';
 import { DEBOUNCE_MS } from '../storage';
 
 const KEY = 'speedreader.settings';
@@ -81,7 +81,7 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('loadSettings returns valid stored payload as-is', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS, wpm: 380 } satisfies SettingsV6;
+    storedRaw = { ...DEFAULT_SETTINGS, wpm: 380 } satisfies SettingsV7;
     const { loadSettings } = await import('../storage');
     const settings = await loadSettings();
     expect(settings.wpm).toBe(380);
@@ -96,7 +96,7 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('saveSettings coalesces 10 calls within 300ms into one write', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV6;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV7;
     const { saveSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
@@ -113,14 +113,14 @@ describe('chrome settings storage adapter', () => {
     // Exactly one set call (the trailing-edge write); set may also fire from
     // an internal load() canonicalisation if storedRaw mismatched, so assert
     // the *final* persisted wpm rather than count alone.
-    const finalStored = storedRaw as SettingsV6;
+    const finalStored = storedRaw as SettingsV7;
     expect(finalStored.wpm).toBe(340);
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
   });
 
   // #68 — debounce window resolution contract.
   it('saveSettings: 3 calls in one window share resolution, all resolve on one set', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV6;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV7;
     const { saveSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
@@ -145,12 +145,12 @@ describe('chrome settings storage adapter', () => {
     // All three resolved together, and exactly one set fired.
     expect(resolved).toEqual([true, true, true]);
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
-    expect((storedRaw as SettingsV6).wpm).toBe(280);
+    expect((storedRaw as SettingsV7).wpm).toBe(280);
   });
 
   // #68 — late call landing during in-flight flush queues for next window.
   it('saveSettings: call landing during in-flight flush queues for next window (distinct resolutions)', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV6;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV7;
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
     // Replace `get` with a controllable Promise so we can park the in-flight
@@ -207,12 +207,12 @@ describe('chrome settings storage adapter', () => {
 
     // Two distinct sets — late call did not coalesce into the in-flight write.
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(2);
-    expect((storedRaw as SettingsV6).wpm).toBe(380);
+    expect((storedRaw as SettingsV7).wpm).toBe(380);
   });
 
   // #68 — flushSettings semantics.
   it('flushSettings resolves immediately when no pending save', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV6;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV7;
     const { flushSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
@@ -221,7 +221,7 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('flushSettings cancels debounce timer and forces an immediate flush', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV6;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV7;
     const { saveSettings, flushSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
 
@@ -250,7 +250,7 @@ describe('chrome settings storage adapter', () => {
     expect(flushPromiseResolved).toBe(true);
     expect(savePromiseResolved).toBe(true);
     expect(stub.storage.sync.set).toHaveBeenCalledTimes(1);
-    expect((storedRaw as SettingsV6).wpm).toBe(410);
+    expect((storedRaw as SettingsV7).wpm).toBe(410);
 
     // Confirm there is no zombie timer left behind — advancing past 300ms
     // must not produce a second set.
@@ -259,7 +259,7 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('flushSettings rejects when the forced flush fails', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV6;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV7;
     const { saveSettings, flushSettings } = await import('../storage');
     const stub = (globalThis as unknown as { chrome: ChromeStub }).chrome;
     const setErr = new Error('quota exceeded');
@@ -280,13 +280,13 @@ describe('chrome settings storage adapter', () => {
   });
 
   it('saveSettings preserves the version field', async () => {
-    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV6;
+    storedRaw = { ...DEFAULT_SETTINGS } satisfies SettingsV7;
     const { saveSettings } = await import('../storage');
     const p = saveSettings({ theme: 'dark' });
     await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
     await p;
-    const stored = storedRaw as SettingsV6;
-    expect(stored.version).toBe(6);
+    const stored = storedRaw as SettingsV7;
+    expect(stored.version).toBe(7);
     expect(stored.theme).toBe('dark');
   });
 
@@ -295,7 +295,7 @@ describe('chrome settings storage adapter', () => {
     const listener = vi.fn();
     const unsubscribe = subscribeSettings(listener);
 
-    const next: SettingsV6 = { ...DEFAULT_SETTINGS, wpm: 420 };
+    const next: SettingsV7 = { ...DEFAULT_SETTINGS, wpm: 420 };
     emitChange(next, 'sync');
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith(next);

--- a/src/chrome/settings/storage.ts
+++ b/src/chrome/settings/storage.ts
@@ -1,10 +1,10 @@
-import type { SettingsV6 } from '../../core/settings/schema';
+import type { SettingsV7 } from '../../core/settings/schema';
 import { migrate } from '../../core/settings/migrations';
 
 const KEY = 'speedreader.settings';
 export const DEBOUNCE_MS = 300;
 
-export type SaveSettingsInput = Omit<Partial<SettingsV6>, 'version'>;
+export type SaveSettingsInput = Omit<Partial<SettingsV7>, 'version'>;
 
 /**
  * Read settings from `chrome.storage.sync`, migrating + validating the raw
@@ -12,7 +12,7 @@ export type SaveSettingsInput = Omit<Partial<SettingsV6>, 'version'>;
  * or repair of a partial payload), the canonical form is written back so the
  * next read is a fast pass-through.
  */
-export async function loadSettings(): Promise<SettingsV6> {
+export async function loadSettings(): Promise<SettingsV7> {
   const result = await chrome.storage.sync.get(KEY);
   const raw = result[KEY];
   const settings = migrate(raw);
@@ -50,7 +50,7 @@ async function flushPendingSave(): Promise<void> {
   pendingRejectors = [];
   try {
     const current = await loadSettings();
-    const next: SettingsV6 = { ...current, ...partial, version: current.version };
+    const next: SettingsV7 = { ...current, ...partial, version: current.version };
     await chrome.storage.sync.set({ [KEY]: next });
     resolvers.forEach((r) => r());
   } catch (err) {
@@ -119,7 +119,7 @@ export function flushSettings(): Promise<void> {
  * the options page, or a different signed-in device via Chrome sync. Returns
  * an unsubscribe function.
  */
-export function subscribeSettings(listener: (s: SettingsV6) => void): () => void {
+export function subscribeSettings(listener: (s: SettingsV7) => void): () => void {
   const handler = (
     changes: Record<string, chrome.storage.StorageChange>,
     area: chrome.storage.AreaName,

--- a/src/chrome/welcome/__tests__/controller.test.ts
+++ b/src/chrome/welcome/__tests__/controller.test.ts
@@ -20,7 +20,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { bindWelcome, WELCOME_IDS, type SettingsApi } from '../controller';
 import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
 import { SAMPLE_PASSAGE } from '../sample';
-import type { SettingsV6 } from '../../../core/settings/schema';
+import type { SettingsV7 } from '../../../core/settings/schema';
 
 const HTML = `
   <header>
@@ -46,16 +46,16 @@ interface Stub extends SettingsApi {
   loadMock: ReturnType<typeof vi.fn>;
   saveMock: ReturnType<typeof vi.fn>;
   flushMock: ReturnType<typeof vi.fn>;
-  resolveLoad(s: SettingsV6): void;
+  resolveLoad(s: SettingsV7): void;
   rejectLoad(err: unknown): void;
 }
 
-function makeStub(options: { initial?: SettingsV6; deferLoad?: boolean } = {}): Stub {
+function makeStub(options: { initial?: SettingsV7; deferLoad?: boolean } = {}): Stub {
   const initial = options.initial ?? DEFAULT_SETTINGS;
-  let resolveLoad: (s: SettingsV6) => void = () => undefined;
+  let resolveLoad: (s: SettingsV7) => void = () => undefined;
   let rejectLoad: (e: unknown) => void = () => undefined;
   const loadPromise = options.deferLoad
-    ? new Promise<SettingsV6>((res, rej) => {
+    ? new Promise<SettingsV7>((res, rej) => {
         resolveLoad = res;
         rejectLoad = rej;
       })

--- a/src/chrome/welcome/controller.ts
+++ b/src/chrome/welcome/controller.ts
@@ -11,14 +11,14 @@
  * See docs/superpowers/specs/2026-05-30-onboarding-surface.md.
  */
 
-import type { SettingsV6 } from '../../core/settings/schema';
+import type { SettingsV7 } from '../../core/settings/schema';
 import { DEFAULT_SETTINGS } from '../../core/settings/defaults';
 import { createRsvpEngine, type RsvpEngine } from '../../core/rsvp-engine';
 import { SAMPLE_PASSAGE } from './sample';
 
 export interface SettingsApi {
-  load(): Promise<SettingsV6>;
-  save(partial: Partial<Omit<SettingsV6, 'version' | 'lastUsedWpm'>>): Promise<void>;
+  load(): Promise<SettingsV7>;
+  save(partial: Partial<Omit<SettingsV7, 'version' | 'lastUsedWpm'>>): Promise<void>;
   flush(): Promise<void>;
 }
 

--- a/src/core/overlay/__tests__/scrubber-autohide.test.ts
+++ b/src/core/overlay/__tests__/scrubber-autohide.test.ts
@@ -20,7 +20,7 @@
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { createOverlay } from '../overlay';
-import type { OverlayOptions } from '../types';
+import type { OverlayOptions, SettingsSubscriber } from '../types';
 import { createRsvpEngine, type RsvpEngine, type RsvpEngineOptions } from '../../rsvp-engine';
 import { OVERLAY_CLASS } from '../constants';
 
@@ -330,6 +330,77 @@ describe('createOverlay — scrubber visibility state machine (#52 PART D)', () 
     playPauseBtn.click(); // pause
     playPauseBtn.click(); // resume
     expect(engineOf(holder).state).toBe('playing');
+    expect(isHidden(area)).toBe(true);
+    overlay.unmount();
+  });
+
+  // #211 — scrubberAutoHide opt-out. ADHD readers keep the bar visible
+  // during playback as a position anchor. The gate is `settings.scrubberAutoHide`
+  // ANDed into `shouldHide`; undefined is treated as `true` (back-compat).
+  test('scrubberAutoHide:false → scrubber stays VISIBLE while playing (ADHD anchor)', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, scrubberAutoHide: false },
+      }),
+    );
+    overlay.mount();
+    expect(engineOf(holder).state).toBe('playing');
+    // Mutation guard: with the gate present, shouldHide is false even though
+    // engine is playing + no hover + no focus. Dropping `settings.scrubberAutoHide &&`
+    // from shouldHide would hide the bar here and fail this assertion.
+    expect(isHidden(getArea())).toBe(false);
+    overlay.unmount();
+  });
+
+  test('scrubberAutoHide:true (explicit) → scrubber hides while playing (default behavior)', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, scrubberAutoHide: true },
+      }),
+    );
+    overlay.mount();
+    expect(engineOf(holder).state).toBe('playing');
+    expect(isHidden(getArea())).toBe(true);
+    overlay.unmount();
+  });
+
+  test('scrubberAutoHide undefined → treated as true (back-compat: hides while playing)', () => {
+    // defaultOpts omits scrubberAutoHide. The overlay must default the gate
+    // to true so pre-#211 callers retain the auto-hide behavior.
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    overlay.mount();
+    expect(isHidden(getArea())).toBe(true);
+    overlay.unmount();
+  });
+
+  test('live subscribeSettings flip scrubberAutoHide true→false reveals the bar mid-playback', () => {
+    const holder: Holder = { engine: null };
+    // Holder ref (not a bare `let`) so TS control-flow doesn't narrow the
+    // closure-assigned listener back to `null` at the call sites below.
+    const pushRef: { current: SettingsSubscriber | null } = { current: null };
+    const overlay = createOverlay(
+      defaultOpts(holder, {
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, scrubberAutoHide: true },
+        subscribeSettings: (listener) => {
+          pushRef.current = listener;
+          return () => undefined;
+        },
+      }),
+    );
+    overlay.mount();
+    const area = getArea();
+    expect(engineOf(holder).state).toBe('playing');
+    expect(isHidden(area)).toBe(true);
+    if (!pushRef.current) throw new Error('subscribeSettings never registered a listener');
+    const push = pushRef.current;
+    // User opts out mid-session. The bar must reveal without a remount.
+    push({ theme: 'system', wpm: 300, fontSize: 20, scrubberAutoHide: false });
+    expect(isHidden(area)).toBe(false);
+    // And flipping back re-enables auto-hide (engine still playing, no hover).
+    push({ theme: 'system', wpm: 300, fontSize: 20, scrubberAutoHide: true });
     expect(isHidden(area)).toBe(true);
     overlay.unmount();
   });

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -789,6 +789,11 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     // short-circuit no-op echoes and only re-write the host attribute
     // when alignment actually changed. Default `'orp'` matches schema.
     let currentAlignment: 'orp' | 'center' = opts.initialSettings.alignment ?? 'orp';
+    // #211 — local cache for the scrubber auto-hide opt-out. Default `true`
+    // (undefined treated as on) matches the post-#210 behavior; the
+    // subscribeSettings handler flips it and recomputes so a user toggling
+    // the option reveals/hides the bar mid-session without a remount.
+    let currentScrubberAutoHide: boolean = opts.initialSettings.scrubberAutoHide ?? true;
 
     // Single point of truth for keeping the stepper UI in sync with
     // `currentWpm`. Called from mount-time init, the ArrowUp/Down keyboard
@@ -902,6 +907,14 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
         currentAlignment = nextAlignment;
         host?.setAttribute(OVERLAY_ATTR.ALIGNMENT, nextAlignment);
       }
+      // #211 — live scrubber auto-hide opt-out. Recompute visibility so a
+      // user toggling the option reveals/hides the bar mid-session. Guarded
+      // on a real change so a no-op echo doesn't churn the recompute.
+      const nextScrubberAutoHide: boolean = s.scrubberAutoHide ?? true;
+      if (nextScrubberAutoHide !== currentScrubberAutoHide) {
+        currentScrubberAutoHide = nextScrubberAutoHide;
+        recomputeScrubberVisibility();
+      }
     });
 
     const engineWords = scopeView ? scopeView.activeWords : opts.words;
@@ -1004,7 +1017,14 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     const recomputeScrubberVisibility = (): void => {
       if (!scrubberArea) return;
       const playing = engine?.state === 'playing';
-      const shouldHide = playing && !scrubberHovered && !scrubberFocused && !scrubInProgress;
+      // #211 — auto-hide is gated on the opt-out. When the user disables it,
+      // the bar stays visible during playback as a position anchor.
+      const shouldHide =
+        currentScrubberAutoHide &&
+        playing &&
+        !scrubberHovered &&
+        !scrubberFocused &&
+        !scrubInProgress;
       const wasHidden = scrubberArea.dataset.hidden === 'true';
       if (shouldHide) {
         scrubberArea.style.opacity = '0';

--- a/src/core/overlay/types.ts
+++ b/src/core/overlay/types.ts
@@ -73,6 +73,19 @@ export interface OverlaySettings {
    * selectors. Live updates land via `subscribeSettings`.
    */
   alignment?: 'orp' | 'center';
+  /**
+   * Playback scrubber auto-hide (#211). When `true` (default), the scrubber
+   * area fades out during active playback (no hover / focus / mid-scrub) so
+   * the eye stays on the word region. When `false`, the scrubber stays
+   * visible during playback as a position anchor — an ADHD affordance to
+   * fight time-blindness while reading.
+   *
+   * Optional so existing callers and tests that pre-date this field continue
+   * to type-check — overlay treats `undefined` as `true` (back-compat with
+   * the auto-hide behavior shipped in #52/#210). Live-updated via
+   * `subscribeSettings`.
+   */
+  scrubberAutoHide?: boolean;
 }
 
 export type SettingsSubscriber = (s: OverlaySettings) => void;

--- a/src/core/settings/__tests__/migrations.test.ts
+++ b/src/core/settings/__tests__/migrations.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { migrate } from '../migrations';
 import { DEFAULT_SETTINGS } from '../defaults';
-import { SettingsSchemaV6 } from '../schema';
+import { SettingsSchemaV7 } from '../schema';
 
 describe('migrate', () => {
   it('returns a fresh defaults clone for undefined input (first install)', () => {
@@ -37,14 +37,14 @@ describe('migrate', () => {
     const written = JSON.parse(JSON.stringify(modified)); // simulate storage round-trip
     const read = migrate(written);
     expect(read).toEqual(modified);
-    expect(SettingsSchemaV6.safeParse(read).success).toBe(true);
+    expect(SettingsSchemaV7.safeParse(read).success).toBe(true);
   });
 
   it('migrates a synthetic v0 payload up through the full chain to current version', () => {
     // v0 lacks an explicit version field; defaults fill in the rest.
     const v0 = { wpm: 300, theme: 'dark', font: 'Georgia', fontSize: 22 };
     const result = migrate(v0);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.wpm).toBe(300);
     expect(result.theme).toBe('dark');
     // Fields absent in v0 come from defaults.
@@ -55,7 +55,7 @@ describe('migrate', () => {
   it('fills in missing fields from defaults when partial v2 is stored', () => {
     const partial = { version: 2, wpm: 350 };
     const result = migrate(partial);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.wpm).toBe(350);
     expect(result.theme).toBe(DEFAULT_SETTINGS.theme);
     expect(result.fontSize).toBe(DEFAULT_SETTINGS.fontSize);
@@ -82,7 +82,7 @@ describe('migrate', () => {
     const result = migrate(v3MissingField);
     expect(result.punctuationPacing).toBe(DEFAULT_SETTINGS.punctuationPacing);
     // And the rest of the user's values survive the repair.
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.wpm).toBe(300);
     expect(result.theme).toBe('dark');
   });
@@ -105,7 +105,7 @@ describe('migrate — V1 -> V2 alignment field (forward-compatible)', () => {
       punctuationPacing: true,
     };
     const result = migrate(v1);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.alignment).toBe('orp');
     expect(result.wpm).toBe(300);
     expect(result.theme).toBe('dark');
@@ -118,7 +118,7 @@ describe('migrate — V1 -> V2 alignment field (forward-compatible)', () => {
   it('V0 payload (no version) -> chained 0->1->2->3 with alignment: orp', () => {
     const v0 = { wpm: 280, theme: 'light' as const };
     const result = migrate(v0);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.alignment).toBe('orp');
     expect(result.wpm).toBe(280);
     expect(result.theme).toBe('light');
@@ -136,7 +136,7 @@ describe('migrate — V1 -> V2 alignment field (forward-compatible)', () => {
       alignment: 'center' as const,
     };
     const result = migrate(v2);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.alignment).toBe('center');
     expect(result.wpm).toBe(300);
     expect(result.theme).toBe('dark');
@@ -176,7 +176,7 @@ describe('migrate — V2 -> V3 theme enum widening (#101)', () => {
     'V2 payload with legacy theme "%s" -> V3 preserves theme, stamps version: 3',
     (theme) => {
       const result = migrate({ ...V2_BASE, theme });
-      expect(result.version).toBe(6);
+      expect(result.version).toBe(7);
       expect(result.theme).toBe(theme);
       expect(result.wpm).toBe(300);
       expect(result.alignment).toBe('orp');
@@ -190,14 +190,14 @@ describe('migrate — V2 -> V3 theme enum widening (#101)', () => {
       const result = migrate(v3);
       expect(result).toEqual(v3);
       expect(result.theme).toBe(newTheme);
-      expect(result.version).toBe(6);
+      expect(result.version).toBe(7);
     },
   );
 
   it('V0 payload with legacy theme: light chains through to V3', () => {
     const v0 = { wpm: 320, theme: 'light' as const };
     const result = migrate(v0);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.theme).toBe('light');
     expect(result.alignment).toBe('orp'); // stamped at 1->2
   });
@@ -210,7 +210,7 @@ describe('migrate — V2 -> V3 theme enum widening (#101)', () => {
     // here as an intentional change, not silent data loss.
     const v2Corrupt = { ...V2_BASE, theme: 'sepia' as const };
     const result = migrate(v2Corrupt);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.theme).toBe('sepia');
   });
 });
@@ -224,7 +224,7 @@ describe('migrate — version-boundary policies', () => {
     // a future "reject future versions" change surfaces here.
     const future = { version: 99, wpm: 400, theme: 'dark' as const, alignment: 'orp' as const };
     const result = migrate(future);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.wpm).toBe(400);
     expect(result.theme).toBe('dark');
     expect(result.alignment).toBe('orp');
@@ -261,7 +261,7 @@ describe('migrate — version-boundary policies', () => {
   it('partial V3 payload (missing alignment) -> defaults fill alignment: orp', () => {
     const partialV3 = { version: 3, wpm: 300, theme: 'nord' };
     const result = migrate(partialV3);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.theme).toBe('nord');
     expect(result.alignment).toBe('orp');
   });
@@ -287,7 +287,7 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
 
   it('V3 payload (no contextLine/startFromWordOne/lastUsedWpm) -> V4 defaults the new fields; lastUsedWpm mirrors input wpm', () => {
     const result = migrate(V3_BASE);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.contextLine).toBe(false);
     expect(result.startFromWordOne).toBe(false);
     expect(result.lastUsedWpm).toBe(V3_BASE.wpm);
@@ -300,7 +300,7 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
   it('V0 payload chains 0 -> 1 -> 2 -> 3 -> 4 with new V4 fields defaulted', () => {
     const v0 = { wpm: 320, theme: 'light' as const };
     const result = migrate(v0);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.contextLine).toBe(false);
     expect(result.startFromWordOne).toBe(false);
     expect(result.lastUsedWpm).toBe(320); // mirrors wpm at 3->4 step
@@ -326,7 +326,7 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
 
   it('V3 payload with custom wpm: 380 -> V4 with lastUsedWpm: 380 (mirrors input wpm)', () => {
     const result = migrate({ ...V3_BASE, wpm: 380 });
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.wpm).toBe(380);
     expect(result.lastUsedWpm).toBe(380);
   });
@@ -343,7 +343,7 @@ describe('migrate — V3 -> V4 context-menu fields (#72)', () => {
       punctuationPacing: true,
       alignment: 'orp',
     });
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.contextLine).toBe(false);
     expect(result.startFromWordOne).toBe(false);
     expect(result.lastUsedWpm).toBe(250);
@@ -409,7 +409,7 @@ describe('migrate — V4 -> V5 historyEnabled field (#49)', () => {
 
   it('V4 payload (no historyEnabled) -> V5 with historyEnabled: false (opt-in default)', () => {
     const result = migrate(V4_BASE);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.historyEnabled).toBe(false);
     // Other V4 fields preserved.
     expect(result.wpm).toBe(250);
@@ -463,7 +463,7 @@ describe('migrate — V4 -> V5 historyEnabled field (#49)', () => {
   it('V0 payload chains all the way to V5 with historyEnabled: false', () => {
     const v0 = { wpm: 300, theme: 'light' as const };
     const result = migrate(v0);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.historyEnabled).toBe(false);
   });
 
@@ -471,7 +471,7 @@ describe('migrate — V4 -> V5 historyEnabled field (#49)', () => {
     const partial: Record<string, unknown> = { ...DEFAULT_SETTINGS };
     delete partial.historyEnabled;
     const result = migrate(partial);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.historyEnabled).toBe(false);
   });
 });
@@ -498,7 +498,7 @@ describe('migrate — V5 -> V6 chunkSize field (#51)', () => {
 
   it('V5 payload (no chunkSize) -> V6 with chunkSize: 1 (back-compat default)', () => {
     const result = migrate(V5_BASE);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.chunkSize).toBe(1);
     // Other V5 fields preserved.
     expect(result.wpm).toBe(250);
@@ -542,7 +542,7 @@ describe('migrate — V5 -> V6 chunkSize field (#51)', () => {
   it('V0 payload chains all the way to V6 with chunkSize: 1', () => {
     const v0 = { wpm: 300, theme: 'light' as const };
     const result = migrate(v0);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.chunkSize).toBe(1);
   });
 
@@ -550,7 +550,77 @@ describe('migrate — V5 -> V6 chunkSize field (#51)', () => {
     const partial: Record<string, unknown> = { ...DEFAULT_SETTINGS };
     delete partial.chunkSize;
     const result = migrate(partial);
-    expect(result.version).toBe(6);
+    expect(result.version).toBe(7);
     expect(result.chunkSize).toBe(1);
+  });
+});
+
+// V6 -> V7 scrubberAutoHide field — issue #211.
+// V7 adds `scrubberAutoHide: boolean` defaulted to `true` (back-compat —
+// the auto-hide behavior shipped in #52/#210). The migrator never silently
+// opts users out of auto-hide.
+describe('migrate — V6 -> V7 scrubberAutoHide field (#211)', () => {
+  const V6_BASE = {
+    version: 6 as const,
+    wpm: 250,
+    theme: 'dark' as const,
+    font: 'system-ui',
+    fontSize: 20,
+    openDyslexic: false,
+    punctuationPacing: true,
+    alignment: 'orp' as const,
+    contextLine: false,
+    startFromWordOne: false,
+    lastUsedWpm: 250,
+    historyEnabled: false,
+    chunkSize: 1 as const,
+  };
+
+  it('V6 payload (no scrubberAutoHide) -> V7 with scrubberAutoHide: true (back-compat default)', () => {
+    const result = migrate(V6_BASE);
+    expect(result.version).toBe(7);
+    expect(result.scrubberAutoHide).toBe(true);
+    // Other V6 fields preserved.
+    expect(result.wpm).toBe(250);
+    expect(result.theme).toBe('dark');
+    expect(result.chunkSize).toBe(1);
+  });
+
+  // A hand-edited V6 blob carrying ANY non-boolean `scrubberAutoHide` value
+  // MUST end up at the back-compat default `true` after migration. Spread
+  // order (`...raw, scrubberAutoHide: true`) is the floor; even if a future
+  // refactor flipped to `scrubberAutoHide: true, ...raw`, the V7 safeParse
+  // rejects the non-boolean and the defaults fallback restores `true`.
+  it.each([
+    ['string', 'false'],
+    ['number 0', 0],
+    ['null', null],
+    ['object {}', {}],
+  ])('V6 -> V7 forces scrubberAutoHide to true regardless of hand-edited %s', (_label, value) => {
+    const hand = { ...V6_BASE, scrubberAutoHide: value };
+    const result = migrate(hand);
+    expect(result.scrubberAutoHide).toBe(true);
+  });
+
+  it('V7-already-present payload with scrubberAutoHide: false round-trips unchanged', () => {
+    const v7 = { ...DEFAULT_SETTINGS, scrubberAutoHide: false };
+    const result = migrate(v7);
+    expect(result).toEqual(v7);
+    expect(result.scrubberAutoHide).toBe(false);
+  });
+
+  it('V0 payload chains all the way to V7 with scrubberAutoHide: true', () => {
+    const v0 = { wpm: 300, theme: 'light' as const };
+    const result = migrate(v0);
+    expect(result.version).toBe(7);
+    expect(result.scrubberAutoHide).toBe(true);
+  });
+
+  it('partial V7 payload missing scrubberAutoHide — defaults fill it as true (forward-compat repair)', () => {
+    const partial: Record<string, unknown> = { ...DEFAULT_SETTINGS };
+    delete partial.scrubberAutoHide;
+    const result = migrate(partial);
+    expect(result.version).toBe(7);
+    expect(result.scrubberAutoHide).toBe(true);
   });
 });

--- a/src/core/settings/__tests__/migrations.test.ts
+++ b/src/core/settings/__tests__/migrations.test.ts
@@ -609,6 +609,19 @@ describe('migrate — V6 -> V7 scrubberAutoHide field (#211)', () => {
     expect(result.scrubberAutoHide).toBe(false);
   });
 
+  // Asymmetry pin: a V6 hand-edit with a non-boolean is FLOORED to `true`
+  // by the migrator stamp (tested above), but a *current-version* (V7) blob
+  // with a non-boolean skips the migrator loop entirely (v=7 not < 7),
+  // fails `SettingsSchemaV7.safeParse`, and resets the WHOLE payload to
+  // defaults (not just the field). Pin that the reset lands on the
+  // back-compat default, documenting the whole-payload behavior.
+  it('V7-already-present payload with non-boolean scrubberAutoHide resets to full defaults', () => {
+    const corrupt = { ...DEFAULT_SETTINGS, scrubberAutoHide: 'nope' };
+    const result = migrate(corrupt);
+    expect(result).toEqual(DEFAULT_SETTINGS);
+    expect(result.scrubberAutoHide).toBe(true);
+  });
+
   it('V0 payload chains all the way to V7 with scrubberAutoHide: true', () => {
     const v0 = { wpm: 300, theme: 'light' as const };
     const result = migrate(v0);

--- a/src/core/settings/__tests__/schema.test.ts
+++ b/src/core/settings/__tests__/schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  SettingsSchemaV7,
   SettingsSchemaV6,
   SettingsSchemaV5,
   SettingsSchemaV4,
@@ -11,15 +12,15 @@ import {
 const VALID_THEMES_V4 = ['system', 'light', 'dark', 'sepia', 'paper', 'cream', 'nord'] as const;
 import { DEFAULT_SETTINGS } from '../defaults';
 
-describe('SettingsSchemaV6 (current)', () => {
+describe('SettingsSchemaV7 (current)', () => {
   it('accepts the canonical defaults', () => {
-    const parsed = SettingsSchemaV6.safeParse(DEFAULT_SETTINGS);
+    const parsed = SettingsSchemaV7.safeParse(DEFAULT_SETTINGS);
     expect(parsed.success).toBe(true);
   });
 
   it('accepts a known-good payload', () => {
-    const parsed = SettingsSchemaV6.safeParse({
-      version: 6,
+    const parsed = SettingsSchemaV7.safeParse({
+      version: 7,
       wpm: 400,
       theme: 'dark',
       font: 'Georgia',
@@ -32,65 +33,131 @@ describe('SettingsSchemaV6 (current)', () => {
       lastUsedWpm: 400,
       historyEnabled: false,
       chunkSize: 2,
+      scrubberAutoHide: false,
     });
     expect(parsed.success).toBe(true);
   });
 
   it('rejects wpm outside [100, 600]', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, wpm: 50 }).success).toBe(false);
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, wpm: 9999 }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, wpm: 50 }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, wpm: 9999 }).success).toBe(false);
   });
 
   it('rejects wpm not multiples of 10', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, wpm: 255 }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, wpm: 255 }).success).toBe(false);
   });
 
   it('rejects fontSize outside [12, 48]', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, fontSize: 8 }).success).toBe(false);
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, fontSize: 64 }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, fontSize: 8 }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, fontSize: 64 }).success).toBe(false);
   });
 
   it('rejects an unknown theme', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, theme: 'rainbow' }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, theme: 'rainbow' }).success).toBe(
       false,
     );
   });
 
   it('rejects a wrong version literal', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, version: 1 }).success).toBe(false);
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, version: 2 }).success).toBe(false);
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, version: 3 }).success).toBe(false);
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, version: 4 }).success).toBe(false);
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, version: 5 }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, version: 1 }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, version: 2 }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, version: 3 }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, version: 4 }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, version: 5 }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, version: 6 }).success).toBe(false);
   });
 });
 
 // V6 new field (#51) — chunkSize literal-union [1,2,3], default 1.
-describe('SettingsSchemaV6 — chunkSize field (#51)', () => {
+describe('SettingsSchemaV7 — chunkSize field (#51)', () => {
   it.each([1, 2, 3] as const)('ACCEPTS chunkSize: %d', (n) => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, chunkSize: n }).success).toBe(true);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, chunkSize: n }).success).toBe(true);
   });
 
   it('REJECTS chunkSize: 0', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, chunkSize: 0 }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, chunkSize: 0 }).success).toBe(false);
   });
 
   it('REJECTS chunkSize: 4 (outside literal union)', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, chunkSize: 4 }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, chunkSize: 4 }).success).toBe(false);
   });
 
   it('REJECTS chunkSize: non-integer', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, chunkSize: 2.5 }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, chunkSize: 2.5 }).success).toBe(false);
   });
 
   it('REJECTS chunkSize: string', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, chunkSize: '2' }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, chunkSize: '2' }).success).toBe(false);
   });
 
   it('REJECTS missing chunkSize', () => {
     const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
     delete partial.chunkSize;
-    expect(SettingsSchemaV6.safeParse(partial).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse(partial).success).toBe(false);
+  });
+});
+
+// V7 new field (#211) — scrubberAutoHide boolean, default true.
+describe('SettingsSchemaV7 — scrubberAutoHide field (#211)', () => {
+  it('ACCEPTS scrubberAutoHide: true (default)', () => {
+    expect(
+      SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, scrubberAutoHide: true }).success,
+    ).toBe(true);
+  });
+
+  it('ACCEPTS scrubberAutoHide: false (opt-out)', () => {
+    expect(
+      SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, scrubberAutoHide: false }).success,
+    ).toBe(true);
+  });
+
+  it.each([
+    { label: 'string', value: 'true' },
+    { label: 'number 1', value: 1 },
+    { label: 'null', value: null },
+  ])('REJECTS scrubberAutoHide: $label (non-boolean)', ({ value }) => {
+    expect(
+      SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, scrubberAutoHide: value }).success,
+    ).toBe(false);
+  });
+
+  it('REJECTS missing scrubberAutoHide', () => {
+    const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
+    delete partial.scrubberAutoHide;
+    expect(SettingsSchemaV7.safeParse(partial).success).toBe(false);
+  });
+});
+
+// Legacy V6 schema preserved for the V6 -> V7 migrator (#211 retention policy).
+describe('SettingsSchemaV6 (legacy, migration consumer)', () => {
+  const V6_CANONICAL = {
+    version: 6 as const,
+    wpm: 250,
+    theme: 'system' as const,
+    font: 'system-ui',
+    fontSize: 20,
+    openDyslexic: false,
+    punctuationPacing: true,
+    alignment: 'orp' as const,
+    contextLine: false,
+    startFromWordOne: false,
+    lastUsedWpm: 250,
+    historyEnabled: false,
+    chunkSize: 1 as const,
+  };
+
+  it('accepts a V6 payload with version literal 6', () => {
+    expect(SettingsSchemaV6.safeParse(V6_CANONICAL).success).toBe(true);
+  });
+
+  it('rejects version: 7 (V6 schema is version-literal 6)', () => {
+    expect(SettingsSchemaV6.safeParse({ ...V6_CANONICAL, version: 7 }).success).toBe(false);
+  });
+
+  it('strips unknown V7 field scrubberAutoHide (V6 schema has no scrubberAutoHide)', () => {
+    expect(SettingsSchemaV6.safeParse({ ...V6_CANONICAL, scrubberAutoHide: false }).success).toBe(
+      true,
+    );
   });
 });
 
@@ -125,30 +192,30 @@ describe('SettingsSchemaV5 (legacy, migration consumer)', () => {
 });
 
 // V4 new fields (#72) — pin the three context-menu integration fields.
-describe('SettingsSchemaV6 — context-menu fields (#72)', () => {
+describe('SettingsSchemaV7 — context-menu fields (#72)', () => {
   it('rejects contextLine: non-boolean', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, contextLine: 'yes' }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, contextLine: 'yes' }).success).toBe(
       false,
     );
   });
 
   it('rejects startFromWordOne: non-boolean', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, startFromWordOne: 1 }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, startFromWordOne: 1 }).success).toBe(
       false,
     );
   });
 
   it('rejects lastUsedWpm outside [100, 600]', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 50 }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 50 }).success).toBe(
       false,
     );
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 9999 }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 9999 }).success).toBe(
       false,
     );
   });
 
   it('rejects lastUsedWpm not multiple of 10', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 255 }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, lastUsedWpm: 255 }).success).toBe(
       false,
     );
   });
@@ -156,33 +223,33 @@ describe('SettingsSchemaV6 — context-menu fields (#72)', () => {
   it('rejects missing contextLine', () => {
     const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
     delete partial.contextLine;
-    expect(SettingsSchemaV6.safeParse(partial).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse(partial).success).toBe(false);
   });
 });
 
 // V4 retains V3's 7-value theme enum (ADR #0002). Pin acceptance of
 // each design-pack theme so a regression collapsing back to V2's
 // 3-value set surfaces immediately.
-describe('SettingsSchemaV6 — theme enum (inherited from V3 widening, issue #101)', () => {
+describe('SettingsSchemaV7 — theme enum (inherited from V3 widening, issue #101)', () => {
   it.each(VALID_THEMES_V4)('ACCEPTS theme "%s"', (theme) => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, theme }).success).toBe(true);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, theme }).success).toBe(true);
   });
 
   it.each(['sepia', 'paper', 'cream', 'nord'] as const)(
     'design-pack theme "%s" is parseable',
     (theme) => {
-      expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, theme }).success).toBe(true);
+      expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, theme }).success).toBe(true);
     },
   );
 });
 
 // V5 new field (#49) — pin the historyEnabled boolean.
-describe('SettingsSchemaV6 — historyEnabled field (#49)', () => {
+describe('SettingsSchemaV7 — historyEnabled field (#49)', () => {
   it('rejects historyEnabled: non-boolean', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: 'yes' }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: 'yes' }).success).toBe(
       false,
     );
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: 1 }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: 1 }).success).toBe(
       false,
     );
   });
@@ -190,17 +257,17 @@ describe('SettingsSchemaV6 — historyEnabled field (#49)', () => {
   it('rejects missing historyEnabled', () => {
     const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
     delete partial.historyEnabled;
-    expect(SettingsSchemaV6.safeParse(partial).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse(partial).success).toBe(false);
   });
 
   it('ACCEPTS historyEnabled: true', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: true }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: true }).success).toBe(
       true,
     );
   });
 
   it('ACCEPTS historyEnabled: false (default)', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: false }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, historyEnabled: false }).success).toBe(
       true,
     );
   });
@@ -305,41 +372,41 @@ describe('SettingsSchemaV2 (legacy, migration consumer)', () => {
 // input. Chrome rejects-on-parse via Zod instead. Both strategies protect
 // downstream code from invalid values; these tests assert the rejection
 // behavior at the same boundaries Safari clamps to.
-describe('SettingsSchemaV6 — boundary cases (Safari parity)', () => {
+describe('SettingsSchemaV7 — boundary cases (Safari parity)', () => {
   it('accepts fontSize at lower boundary 12 (parity: clampFontSize accepts FONT_SIZE_MIN)', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, fontSize: 12 }).success).toBe(true);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, fontSize: 12 }).success).toBe(true);
   });
 
   it('accepts fontSize at upper boundary 48 (parity: clampFontSize accepts FONT_SIZE_MAX)', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, fontSize: 48 }).success).toBe(true);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, fontSize: 48 }).success).toBe(true);
   });
 
   it('accepts wpm at lower boundary 100', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, wpm: 100 }).success).toBe(true);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, wpm: 100 }).success).toBe(true);
   });
 
   it('accepts wpm at upper boundary 600', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, wpm: 600 }).success).toBe(true);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, wpm: 600 }).success).toBe(true);
   });
 
   it('rejects fontSize NaN (parity: clampFontSize returns FONT_SIZE_DEFAULT)', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, fontSize: NaN }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, fontSize: NaN }).success).toBe(false);
   });
 
   it('rejects fontSize string (parity: clampFontSize returns FONT_SIZE_DEFAULT)', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, fontSize: 'big' }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, fontSize: 'big' }).success).toBe(
       false,
     );
   });
 
   it('rejects wpm NaN', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, wpm: NaN }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, wpm: NaN }).success).toBe(false);
   });
 
   it('rejects missing wpm key', () => {
     const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
     delete partial.wpm;
-    expect(SettingsSchemaV6.safeParse(partial).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse(partial).success).toBe(false);
   });
 });
 
@@ -356,11 +423,11 @@ describe('SettingsSchemaV6 — boundary cases (Safari parity)', () => {
 //     note `project_safari_no_context_menu.md`.
 describe('DEFAULT_SETTINGS covers every schema field (Safari parity)', () => {
   it('DEFAULT_SETTINGS round-trips through the schema', () => {
-    expect(SettingsSchemaV6.safeParse(DEFAULT_SETTINGS).success).toBe(true);
+    expect(SettingsSchemaV7.safeParse(DEFAULT_SETTINGS).success).toBe(true);
   });
 
   it('DEFAULT_SETTINGS has a value for every schema key', () => {
-    const shapeKeys = Object.keys(SettingsSchemaV6.shape);
+    const shapeKeys = Object.keys(SettingsSchemaV7.shape);
     for (const key of shapeKeys) {
       expect(DEFAULT_SETTINGS).toHaveProperty(key);
     }
@@ -371,37 +438,37 @@ describe('DEFAULT_SETTINGS covers every schema field (Safari parity)', () => {
 // spec docs/superpowers/specs/2026-05-23-alignment-field-v2.md).
 // Target: 7 cases (2 accept + 5 reject). Type-mismatch cases (42, true)
 // are paired into a single parameterized it.each per spec author note.
-describe('SettingsSchemaV6 — alignment field (Safari parity)', () => {
+describe('SettingsSchemaV7 — alignment field (Safari parity)', () => {
   it("ACCEPTS alignment: 'orp'", () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, alignment: 'orp' }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, alignment: 'orp' }).success).toBe(
       true,
     );
   });
 
   it("ACCEPTS alignment: 'center'", () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, alignment: 'center' }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, alignment: 'center' }).success).toBe(
       true,
     );
   });
 
   it("REJECTS alignment: 'left' (string outside enum)", () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, alignment: 'left' }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, alignment: 'left' }).success).toBe(
       false,
     );
   });
 
   it("REJECTS alignment: '' (empty string)", () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, alignment: '' }).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, alignment: '' }).success).toBe(false);
   });
 
   it('REJECTS alignment: undefined (missing required key)', () => {
     const partial = { ...DEFAULT_SETTINGS } as Partial<typeof DEFAULT_SETTINGS>;
     delete partial.alignment;
-    expect(SettingsSchemaV6.safeParse(partial).success).toBe(false);
+    expect(SettingsSchemaV7.safeParse(partial).success).toBe(false);
   });
 
   it('REJECTS alignment: null', () => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, alignment: null }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, alignment: null }).success).toBe(
       false,
     );
   });
@@ -410,7 +477,7 @@ describe('SettingsSchemaV6 — alignment field (Safari parity)', () => {
     { label: 'number 42', value: 42 },
     { label: 'boolean true', value: true },
   ])('REJECTS alignment: $label (type mismatch)', ({ value }) => {
-    expect(SettingsSchemaV6.safeParse({ ...DEFAULT_SETTINGS, alignment: value }).success).toBe(
+    expect(SettingsSchemaV7.safeParse({ ...DEFAULT_SETTINGS, alignment: value }).success).toBe(
       false,
     );
   });
@@ -419,13 +486,17 @@ describe('SettingsSchemaV6 — alignment field (Safari parity)', () => {
 // Defaults / VALID_ALIGNMENTS export — pins the Safari mirror at the
 // constant layer so accidental enum widening surfaces immediately.
 describe('alignment defaults and VALID_ALIGNMENTS export', () => {
-  it("DEFAULT_SETTINGS.alignment === 'orp' AND version === 6 (current)", () => {
+  it("DEFAULT_SETTINGS.alignment === 'orp' AND version === 7 (current)", () => {
     expect(DEFAULT_SETTINGS.alignment).toBe('orp');
-    expect(DEFAULT_SETTINGS.version).toBe(6);
+    expect(DEFAULT_SETTINGS.version).toBe(7);
   });
 
   it('DEFAULT_SETTINGS.chunkSize === 1 (back-compat default for #51)', () => {
     expect(DEFAULT_SETTINGS.chunkSize).toBe(1);
+  });
+
+  it('DEFAULT_SETTINGS.scrubberAutoHide === true (back-compat default for #211)', () => {
+    expect(DEFAULT_SETTINGS.scrubberAutoHide).toBe(true);
   });
 
   it("VALID_ALIGNMENTS has length 2 and equals ['orp', 'center']", () => {

--- a/src/core/settings/bounds.ts
+++ b/src/core/settings/bounds.ts
@@ -1,5 +1,5 @@
 /**
- * Canonical numeric bounds for SettingsV6 fields.
+ * Canonical numeric bounds for SettingsV7 fields.
  *
  * Single source of truth — `schema.ts` derives its Zod constraints from these
  * constants, and consumers that need to clamp/validate outside Zod (the

--- a/src/core/settings/defaults.ts
+++ b/src/core/settings/defaults.ts
@@ -1,7 +1,7 @@
-import type { SettingsV6 } from './schema';
+import type { SettingsV7 } from './schema';
 
-export const DEFAULT_SETTINGS: SettingsV6 = {
-  version: 6,
+export const DEFAULT_SETTINGS: SettingsV7 = {
+  version: 7,
   wpm: 250,
   theme: 'system',
   font: 'system-ui',
@@ -18,4 +18,8 @@ export const DEFAULT_SETTINGS: SettingsV6 = {
   // #51 — single-word display is today's behavior and the safe default.
   // Users opt into 2 or 3 via the options page.
   chunkSize: 1,
+  // #211 — auto-hide on by default (matches post-#210 behavior). ADHD
+  // readers who use the scrubber as a position anchor opt out via the
+  // options page.
+  scrubberAutoHide: true,
 };

--- a/src/core/settings/index.ts
+++ b/src/core/settings/index.ts
@@ -1,4 +1,5 @@
 export {
+  SettingsSchemaV7,
   SettingsSchemaV6,
   SettingsSchemaV5,
   SettingsSchemaV4,
@@ -6,6 +7,7 @@ export {
   SettingsSchemaV2,
   CURRENT_VERSION,
   VALID_ALIGNMENTS,
+  type SettingsV7,
   type SettingsV6,
   type SettingsV5,
   type SettingsV4,

--- a/src/core/settings/migrations.ts
+++ b/src/core/settings/migrations.ts
@@ -1,12 +1,13 @@
-import { SettingsSchemaV6, CURRENT_VERSION, type SettingsV6 } from './schema';
+import { SettingsSchemaV7, CURRENT_VERSION, type SettingsV7 } from './schema';
 import { DEFAULT_SETTINGS } from './defaults';
 
 type Migrator = (raw: Record<string, unknown>) => Record<string, unknown>;
 
 /**
  * Sequential migrators keyed by source version. Forward-only chain:
- * `0 -> 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> ...`. To add a 6->7 migration in
- * the future, drop in `6: m6to7` and bump `CURRENT_VERSION` in `schema.ts`.
+ * `0 -> 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> 7 -> ...`. To add a 7->8 migration
+ * in the future, drop in `7: m7to8` and bump `CURRENT_VERSION` in
+ * `schema.ts`.
  *
  * Spread order is load-bearing: `...raw` first, then literals. New
  * payloads get the literal `alignment: 'orp'` stamp; V4-already-present
@@ -40,6 +41,11 @@ type Migrator = (raw: Record<string, unknown>) => Record<string, unknown>;
  * truthy/invalid `chunkSize` value snaps back to `1` — even though the
  * V6 schema gate would reject the bogus value, the migrator's stamp
  * is the privacy-equivalent floor (back-compat by default).
+ *
+ * 6 -> 7 (#211) adds `scrubberAutoHide: true`. Existing users keep the
+ * auto-hide behavior shipped in #52/#210; users opt out via the options
+ * page. Stamped AFTER `...raw` so a hand-edited V6 blob carrying a
+ * non-boolean `scrubberAutoHide` snaps back to the back-compat default.
  */
 function clampLastUsedWpm(raw: unknown): number {
   if (typeof raw !== 'number' || !Number.isFinite(raw)) return 250;
@@ -60,6 +66,7 @@ const MIGRATIONS: Record<number, Migrator> = {
   }),
   4: (raw) => ({ ...raw, historyEnabled: false, version: 5 }),
   5: (raw) => ({ ...raw, chunkSize: 1, version: 6 }),
+  6: (raw) => ({ ...raw, scrubberAutoHide: true, version: 7 }),
 };
 
 /**
@@ -83,7 +90,7 @@ const MIGRATIONS: Record<number, Migrator> = {
  * `'migrates v3 blob with missing field by filling defaults (explicit repair
  * behavior)'` in `__tests__/migrations.test.ts`.
  */
-export function migrate(rawValue: unknown): SettingsV6 {
+export function migrate(rawValue: unknown): SettingsV7 {
   if (rawValue == null || typeof rawValue !== 'object' || Array.isArray(rawValue)) {
     return { ...DEFAULT_SETTINGS };
   }
@@ -99,7 +106,7 @@ export function migrate(rawValue: unknown): SettingsV6 {
   }
 
   const merged = { ...DEFAULT_SETTINGS, ...value, version: CURRENT_VERSION };
-  const parsed = SettingsSchemaV6.safeParse(merged);
+  const parsed = SettingsSchemaV7.safeParse(merged);
   if (!parsed.success) {
     console.warn(
       '[speedreader] settings failed validation, falling back to defaults',

--- a/src/core/settings/schema.ts
+++ b/src/core/settings/schema.ts
@@ -2,6 +2,13 @@ import { z } from 'zod';
 import { FONT_SIZE_MAX, FONT_SIZE_MIN, WPM_MAX, WPM_MIN, WPM_STEP } from './bounds';
 
 /**
+ * V7 adds `scrubberAutoHide` (issue #211) — opt-out for the playback
+ * scrubber auto-hide shipped in #52/#210. Default `true` (auto-hide on,
+ * matching post-#210 behavior). ADHD readers who use the position bar as
+ * a visual anchor set it `false` to keep the bar visible during playback.
+ * The 6 -> 7 migrator stamps `scrubberAutoHide: true` for every existing
+ * payload; users opt out via the options page.
+ *
  * V6 adds `chunkSize` (issue #51) — multi-word RSVP display. Default
  * `1` (single-word, today's behavior). The 5 -> 6 migrator stamps
  * `chunkSize: 1` for every existing payload; users opt into 2 or 3
@@ -46,6 +53,31 @@ const WPM_SCHEMA = z.number().int().min(WPM_MIN).max(WPM_MAX).multipleOf(WPM_STE
  */
 const CHUNK_SIZE_SCHEMA = z.union([z.literal(1), z.literal(2), z.literal(3)]);
 
+export const SettingsSchemaV7 = z.object({
+  version: z.literal(7),
+  wpm: WPM_SCHEMA,
+  theme: z.enum(['system', 'light', 'dark', 'sepia', 'paper', 'cream', 'nord']),
+  font: z.string(),
+  fontSize: z.number().int().min(FONT_SIZE_MIN).max(FONT_SIZE_MAX),
+  openDyslexic: z.boolean(),
+  punctuationPacing: z.boolean(),
+  alignment: z.enum(['orp', 'center']),
+  contextLine: z.boolean(),
+  startFromWordOne: z.boolean(),
+  lastUsedWpm: WPM_SCHEMA,
+  historyEnabled: z.boolean(),
+  chunkSize: CHUNK_SIZE_SCHEMA,
+  scrubberAutoHide: z.boolean(),
+});
+
+export type SettingsV7 = z.infer<typeof SettingsSchemaV7>;
+
+export const CURRENT_VERSION = 7 as const;
+
+/**
+ * V6 preserved for the V6 -> V7 migrator (#211) per the schema retention
+ * policy adopted at V2 (issue #101 AC: "keep prior schema exported").
+ */
 export const SettingsSchemaV6 = z.object({
   version: z.literal(6),
   wpm: WPM_SCHEMA,
@@ -63,8 +95,6 @@ export const SettingsSchemaV6 = z.object({
 });
 
 export type SettingsV6 = z.infer<typeof SettingsSchemaV6>;
-
-export const CURRENT_VERSION = 6 as const;
 
 /**
  * V5 preserved for the V5 -> V6 migrator (#51) per the schema retention

--- a/tests/e2e/overlay-polish.spec.ts
+++ b/tests/e2e/overlay-polish.spec.ts
@@ -235,7 +235,9 @@ test.describe('Overlay polish bundle (#52)', () => {
     expect(results.violations).toEqual([]);
   });
 
-  test('axe-core is clean in playing-state with hidden scrubber (A11y MED #5)', async ({ page }) => {
+  test('axe-core is clean in playing-state with hidden scrubber (A11y MED #5)', async ({
+    page,
+  }) => {
     // During playback the scrubber-area is visibility:hidden — it MUST
     // not surface in the AT rotor (visibility:hidden removes from
     // accessible tree). Axe should be clean: the hidden region's labels
@@ -272,6 +274,49 @@ test.describe('Overlay polish bundle (#52)', () => {
     expect(hidden).toBe('true');
     const results = await new AxeBuilder({ page }).include('[data-speedreader-overlay]').analyze();
     expect(results.violations).toEqual([]);
+  });
+
+  test('#211 — scrubberAutoHide:false keeps the scrubber VISIBLE during playback (ADHD anchor)', async ({
+    page,
+  }) => {
+    // Acceptance #211: with the opt-out, the position bar stays visible
+    // while the engine is playing so ADHD readers retain a position anchor.
+    // Mirrors the hidden-state scan above but flips the gate to false and
+    // asserts the scrubber-area is NOT in its hidden state on mount.
+    await page.goto('about:blank');
+    await page.addScriptTag({ path: BUNDLE_PATH });
+    await page.evaluate((words) => {
+      type OverlayMod = {
+        createOverlay: (o: Record<string, unknown>) => { mount(): void };
+      };
+      type RsvpMod = { createRsvpEngine: (o: Record<string, unknown>) => unknown };
+      const overlayMod = (window as unknown as { __speedreader_overlay__: OverlayMod })
+        .__speedreader_overlay__;
+      const rsvpMod = (window as unknown as { __speedreader_rsvp__: RsvpMod }).__speedreader_rsvp__;
+      const overlay = overlayMod.createOverlay({
+        doc: document,
+        words,
+        initialSettings: {
+          theme: 'light',
+          wpm: 300,
+          fontSize: 20,
+          alignment: 'orp',
+          scrubberAutoHide: false,
+        },
+        subscribeSettings: () => () => undefined,
+        engineFactory: rsvpMod.createRsvpEngine,
+      });
+      overlay.mount();
+    }, ARTICLE_WORDS);
+    const state = await page.evaluate(() => {
+      const host = document.querySelector('[data-speedreader-overlay]');
+      const area = host?.shadowRoot?.querySelector('.scrubber-area') as HTMLElement | null;
+      return { hidden: area?.dataset.hidden ?? null, opacity: area?.style.opacity ?? null };
+    });
+    // Engine plays on mount, but the opt-out keeps the bar visible: dataset
+    // flag is NOT 'true' and opacity is not forced to '0'.
+    expect(state.hidden).not.toBe('true');
+    expect(state.opacity).not.toBe('0');
   });
 
   test('touch-primary viewport — chunk-mode .word-run siblings render inline, do NOT overlap (architect H1 SHIP BLOCKER)', async ({

--- a/tests/e2e/overlay-polish.spec.ts
+++ b/tests/e2e/overlay-polish.spec.ts
@@ -235,9 +235,7 @@ test.describe('Overlay polish bundle (#52)', () => {
     expect(results.violations).toEqual([]);
   });
 
-  test('axe-core is clean in playing-state with hidden scrubber (A11y MED #5)', async ({
-    page,
-  }) => {
+  test('axe-core is clean in playing-state with hidden scrubber (A11y MED #5)', async ({ page }) => {
     // During playback the scrubber-area is visibility:hidden — it MUST
     // not surface in the AT rotor (visibility:hidden removes from
     // accessible tree). Axe should be clean: the hidden region's labels


### PR DESCRIPTION
Closes #211.

## Problem

ADHD readers use the playback position bar as a visual anchor to fight
time-blindness. The scrubber auto-hide shipped in #52/#210 fades the bar
during playback, defeating that affordance with no way to opt out.

## Change

- **Settings V6 → V7**: new `scrubberAutoHide: boolean`, default `true`
  (matches post-#210 behavior). V6 schema retained; 6 → 7 migrator stamps
  `scrubberAutoHide: true` (never silently opts a user out).
- **Overlay**: `shouldHide` gated on the flag via a local cache;
  live-updated through `subscribeSettings` so a toggle reveals/hides the
  bar mid-session without a remount. `undefined` treated as `true`
  (back-compat with pre-#211 callers).
- **Chrome content**: forwards the flag at initial mount + on subscribe.
- **Options page**: 'Hide the position bar during playback' checkbox in
  Appearance (checked = auto-hide on).
- Current-settings-type consumers renamed `SettingsV6 → SettingsV7` per the
  established per-version-bump convention.

The a11y critic's `createScrubberVisibilityController` extraction was
considered and deferred — the gate is a single `&&` clause plus one cache;
extracting a controller for already-well-tested single-use logic is
speculative abstraction (Karpathy Simplicity).

## Acceptance (#211)

- [x] Settings V7 with `scrubberAutoHide` field
- [x] Default `true` (matches current behavior post-#210)
- [x] Options-page surface (toggle in Appearance section — no 'Reading' section exists; Appearance holds the other overlay-chrome toggles)
- [x] Chrome content forwarding through subscribeSettings
- [x] Recompute gated on the new flag
- [x] Tests: schema, migration, overlay wire-up, e2e showing scrubber stays visible during playing when flag is `false`

## Test plan

- [x] `npm run lint` — clean (eslint --max-warnings=0)
- [x] `npm run format:check` — all files match Prettier
- [x] `npm test` — 1331 passed (86 files), incl. new schema/migration/overlay/CS-wire/options coverage
- [x] `npm run build` — `tsc --noEmit` + vite build clean
- [x] `npm run build:e2e-bundle && npx playwright test -g 'scrubberAutoHide:false'` — passed (bar stays visible during playback with flag false)
- [x] Overlay gate mutation-verified: dropping `currentScrubberAutoHide &&` from `shouldHide` fails 2 overlay tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
