### PR TITLE
a11y(overlay): aria-disabled + color-token for font stepper + play-pause (#215)

### DIFF
--- a/src/core/overlay/__tests__/font-size-stepper.test.ts
+++ b/src/core/overlay/__tests__/font-size-stepper.test.ts
@@ -134,23 +134,59 @@ describe('createOverlay — font-size stepper (#29)', () => {
     overlay.unmount();
   });
 
-  test('A+ is disabled when fontSize === FONT_SIZE_MAX', () => {
+  test('A+ is aria-disabled at FONT_SIZE_MAX and stays in the tab chain (#215)', () => {
     const overlay = createOverlay(
       defaultOpts({ initialSettings: defaultSettings({ fontSize: FONT_SIZE_MAX }) }),
     );
     overlay.mount();
-    expect(getIncBtn().disabled).toBe(true);
-    expect(getDecBtn().disabled).toBe(false);
+    // #215 — aria-disabled (not native `disabled`), so keyboard users tabbing
+    // the control bar still reach the button at the bound.
+    expect(getIncBtn().getAttribute('aria-disabled')).toBe('true');
+    expect(getDecBtn().getAttribute('aria-disabled')).toBe('false');
+    expect(getIncBtn().disabled).toBe(false);
     overlay.unmount();
   });
 
-  test('A− is disabled when fontSize === FONT_SIZE_MIN', () => {
+  test('A− is aria-disabled at FONT_SIZE_MIN and stays in the tab chain (#215)', () => {
     const overlay = createOverlay(
       defaultOpts({ initialSettings: defaultSettings({ fontSize: FONT_SIZE_MIN }) }),
     );
     overlay.mount();
-    expect(getDecBtn().disabled).toBe(true);
-    expect(getIncBtn().disabled).toBe(false);
+    expect(getDecBtn().getAttribute('aria-disabled')).toBe('true');
+    expect(getIncBtn().getAttribute('aria-disabled')).toBe('false');
+    expect(getDecBtn().disabled).toBe(false);
+    overlay.unmount();
+  });
+
+  test('+ click at FONT_SIZE_MAX does not fire onFontSizeChange (aria-disabled handler short-circuit, #215)', () => {
+    const onFontSizeChange = vi.fn<(n: number) => void>();
+    const overlay = createOverlay(
+      defaultOpts({
+        initialSettings: defaultSettings({ fontSize: FONT_SIZE_MAX }),
+        onFontSizeChange,
+      }),
+    );
+    overlay.mount();
+    getIncBtn().click();
+    expect(onFontSizeChange).not.toHaveBeenCalled();
+    overlay.unmount();
+  });
+
+  test('mutation guard — aria-disabled handler gate is load-bearing, independent of the clamp (#215)', () => {
+    // The handler-level early-return is belt-and-suspenders on top of
+    // stepFontSize's `next === currentFontSize` clamp short-circuit. To
+    // discriminate the HANDLER gate from the clamp, force aria-disabled='true'
+    // on the + button at a mid-range fontSize (where the clamp would NOT
+    // short-circuit). Intact gate → click no-ops. Removed gate → click reaches
+    // stepFontSize and fires onFontSizeChange.
+    const onFontSizeChange = vi.fn<(n: number) => void>();
+    const overlay = createOverlay(
+      defaultOpts({ initialSettings: defaultSettings({ fontSize: 20 }), onFontSizeChange }),
+    );
+    overlay.mount();
+    getIncBtn().setAttribute('aria-disabled', 'true');
+    getIncBtn().click();
+    expect(onFontSizeChange).not.toHaveBeenCalled();
     overlay.unmount();
   });
 
@@ -187,7 +223,7 @@ describe('createOverlay — font-size stepper (#29)', () => {
     expect(modal.style.getPropertyValue('--rsvp-font-size')).toBe('36px');
     // Stepper boundary state also refreshes on emission.
     notify({ theme: 'system', wpm: 300, fontSize: FONT_SIZE_MAX });
-    expect(getIncBtn().disabled).toBe(true);
+    expect(getIncBtn().getAttribute('aria-disabled')).toBe('true');
     overlay.unmount();
   });
 

--- a/src/core/overlay/__tests__/play-pause.test.ts
+++ b/src/core/overlay/__tests__/play-pause.test.ts
@@ -122,15 +122,34 @@ describe('createOverlay — play/pause control (#22)', () => {
     overlay.unmount();
   });
 
-  test('engine `done` event disables the button and sets pressed=false', () => {
+  test('engine `done` event aria-disables the button (tab-chain preserved) and sets pressed=false', () => {
     const overlay = createOverlay(defaultOpts({ words: ['only'] }));
     overlay.mount();
     // Advance past the single word's display time → engine emits done.
     vi.advanceTimersByTime(60000 / 300 + 1);
 
     const btn = getPlayPauseBtn();
-    expect(btn.disabled).toBe(true);
+    // #215 — aria-disabled (not native `disabled`) so a keyboard user can
+    // still focus the finished button; togglePlayPause short-circuits on it.
+    expect(btn.getAttribute('aria-disabled')).toBe('true');
+    expect(btn.disabled).toBe(false);
     expect(btn.getAttribute('aria-pressed')).toBe('false');
+    overlay.unmount();
+  });
+
+  test('click on the `done` button does not toggle the engine (aria-disabled handler short-circuit, #215)', () => {
+    const overlay = createOverlay(defaultOpts({ words: ['only'] }));
+    overlay.mount();
+    vi.advanceTimersByTime(60000 / 300 + 1);
+
+    const btn = getPlayPauseBtn();
+    expect(btn.getAttribute('aria-disabled')).toBe('true');
+    // A programmatic click bypasses any pointer-events styling; the handler
+    // gate must keep it inert at 'done'.
+    const labelBefore = btn.getAttribute('aria-label');
+    btn.click();
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+    expect(btn.getAttribute('aria-label')).toBe(labelBefore);
     overlay.unmount();
   });
 });

--- a/src/core/overlay/__tests__/styles.test.ts
+++ b/src/core/overlay/__tests__/styles.test.ts
@@ -38,7 +38,11 @@ describe('OVERLAY_CSS theme-slot consumers (issue #150)', () => {
   });
 
   test('.play-pause-btn:hover binds background to var(--accent-soft, …)', () => {
-    expect(OVERLAY_CSS).toMatch(/\.play-pause-btn:hover\s*\{[^}]*background:\s*var\(--accent-soft/);
+    // #215 — hover is guarded `:not([aria-disabled='true'])` so the disabled
+    // ('done') chip does not light up on hover.
+    expect(OVERLAY_CSS).toMatch(
+      /\.play-pause-btn:hover:not\(\[aria-disabled='true'\]\)\s*\{[^}]*background:\s*var\(--accent-soft/,
+    );
   });
 
   test('.scope-swap-btn:hover binds background to var(--accent-soft, …)', () => {
@@ -69,5 +73,35 @@ describe('OVERLAY_CSS resume-toast is out of flow (issue #218)', () => {
   // in a Playwright pass (noted on #218).
   test('.resume-toast is taken out of flow (position: absolute|fixed)', () => {
     expect(OVERLAY_CSS).toMatch(/\.resume-toast\s*\{[^}]*position:\s*(absolute|fixed)/);
+  });
+});
+
+describe('OVERLAY_CSS disabled-button a11y treatment (issue #215)', () => {
+  // #215 extended the #214 WPM-stepper treatment to the font stepper and
+  // play-pause buttons: native `:disabled` (drops out of tab chain) and
+  // `opacity` (collapses WCAG 1.4.11 3:1 non-text contrast) replaced with
+  // `[aria-disabled="true"]` + a muted color token. jsdom has no layout/paint,
+  // so these guard the CSS-source invariant; the tab-chain + handler behavior
+  // is covered by font-size-stepper.test.ts and play-pause.test.ts, and axe
+  // runs in the e2e overlay-polish pass.
+  test('font stepper disabled rule keys on [aria-disabled] and uses --text-muted', () => {
+    expect(OVERLAY_CSS).toMatch(
+      /\.font-dec-btn\[aria-disabled='true'\],\s*\.font-inc-btn\[aria-disabled='true'\]\s*\{[^}]*color:\s*var\(--text-muted/,
+    );
+  });
+
+  test('font stepper disabled rule does NOT reintroduce opacity (1.4.11 regression guard)', () => {
+    const block = OVERLAY_CSS.match(
+      /\.font-dec-btn\[aria-disabled='true'\],\s*\.font-inc-btn\[aria-disabled='true'\]\s*\{[^}]*\}/,
+    )?.[0];
+    expect(block, 'expected the font aria-disabled rule').not.toBeUndefined();
+    expect(block).not.toMatch(/opacity/);
+  });
+
+  test('play-pause disabled rule keys on [aria-disabled] and drops opacity', () => {
+    const block = OVERLAY_CSS.match(/\.play-pause-btn\[aria-disabled='true'\]\s*\{[^}]*\}/)?.[0];
+    expect(block, 'expected the play-pause aria-disabled rule').not.toBeUndefined();
+    expect(block).toMatch(/color:\s*var\(--text-muted/);
+    expect(block).not.toMatch(/opacity/);
   });
 });

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -835,8 +835,11 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       // avoiding inline-style invalidation on every RSVP tick (~10 Hz
       // at 600 wpm).
       modal.style.setProperty('--rsvp-font-size', `${n}px`);
-      fontDecBtn.disabled = n <= FONT_SIZE_MIN;
-      fontIncBtn.disabled = n >= FONT_SIZE_MAX;
+      // #215 — aria-disabled (not native `disabled`) so the buttons stay in
+      // the tab chain at MIN/MAX (WCAG 2.4.3); the click handlers short-circuit
+      // on it. Mirrors the #214 WPM-stepper treatment.
+      fontDecBtn.setAttribute('aria-disabled', n <= FONT_SIZE_MIN ? 'true' : 'false');
+      fontIncBtn.setAttribute('aria-disabled', n >= FONT_SIZE_MAX ? 'true' : 'false');
     };
     // Clamp at mount-time too (review M4) — subscribeSettings clamps but
     // initialSettings flows in unclamped from caller, so a bad value
@@ -1079,18 +1082,20 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
         playPauseBtn.setAttribute('aria-pressed', 'true');
         playPauseBtn.setAttribute('aria-label', OVERLAY_TEXT.PAUSE_LABEL);
         playPauseBtn.textContent = OVERLAY_TEXT.PAUSE_GLYPH;
-        playPauseBtn.disabled = false;
+        playPauseBtn.setAttribute('aria-disabled', 'false');
       } else if (s === 'paused') {
         playPauseBtn.setAttribute('aria-pressed', 'false');
         playPauseBtn.setAttribute('aria-label', OVERLAY_TEXT.PLAY_LABEL);
         playPauseBtn.textContent = OVERLAY_TEXT.PLAY_GLYPH;
-        playPauseBtn.disabled = false;
+        playPauseBtn.setAttribute('aria-disabled', 'false');
       } else {
-        // 'idle' or 'done'
+        // 'idle' or 'done'. #215 — aria-disabled (not native `disabled`) so a
+        // keyboard user can still focus the finished button; togglePlayPause
+        // short-circuits on it. Only 'done' disables.
         playPauseBtn.setAttribute('aria-pressed', 'false');
         playPauseBtn.setAttribute('aria-label', OVERLAY_TEXT.PLAY_LABEL);
         playPauseBtn.textContent = OVERLAY_TEXT.PLAY_GLYPH;
-        playPauseBtn.disabled = s === 'done';
+        playPauseBtn.setAttribute('aria-disabled', s === 'done' ? 'true' : 'false');
       }
       // Engine-state transitions can flip the auto-hide outcome (e.g.
       // playing → paused → visible). Recompute here so any caller of
@@ -1300,6 +1305,11 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
 
     const togglePlayPause = (): void => {
       if (!engine) return;
+      // #215 — honor aria-disabled. The button stays focusable when 'done'
+      // (no native `disabled`), so guard here against keyboard / programmatic
+      // / tap-to-pause activation. Behavior-preserving: 'done' already fell
+      // through to the no-op `else` below.
+      if (playPauseBtn.getAttribute('aria-disabled') === 'true') return;
       if (engine.state === 'playing') {
         engine.pause();
       } else if (engine.state === 'paused') {
@@ -1483,8 +1493,18 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       applyFontSize(next);
       opts.onFontSizeChange?.(next);
     };
-    fontDecBtn.addEventListener('click', () => stepFontSize(-FONT_SIZE_STEP));
-    fontIncBtn.addEventListener('click', () => stepFontSize(FONT_SIZE_STEP));
+    // #215 — aria-disabled handler short-circuit (mirrors #214). The button
+    // is no longer natively `disabled`, so a programmatic .click() at MIN/MAX
+    // would otherwise reach stepFontSize; the clamp no-ops it, but the explicit
+    // gate keeps this independent of clamp behavior and matches the WPM stepper.
+    fontDecBtn.addEventListener('click', () => {
+      if (fontDecBtn.getAttribute('aria-disabled') === 'true') return;
+      stepFontSize(-FONT_SIZE_STEP);
+    });
+    fontIncBtn.addEventListener('click', () => {
+      if (fontIncBtn.getAttribute('aria-disabled') === 'true') return;
+      stepFontSize(FONT_SIZE_STEP);
+    });
     // Plain clamp — native <input type="range"> already enforces min/max and
     // step on browser-driven events, and the keyboard ArrowUp/Down deltas are
     // always on the canonical grid. The previous `Number.isFinite` guard and

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -440,8 +440,8 @@ export const OVERLAY_CSS = `
 
 .prev-sentence-btn:hover,
 .next-sentence-btn:hover,
-.font-dec-btn:hover,
-.font-inc-btn:hover {
+.font-dec-btn:hover:not([aria-disabled='true']),
+.font-inc-btn:hover:not([aria-disabled='true']) {
   background: var(--accent-soft, #e8f0fe);
   color: var(--text, #202124);
 }
@@ -455,9 +455,14 @@ export const OVERLAY_CSS = `
   outline-offset: 2px;
 }
 
-.font-dec-btn:disabled,
-.font-inc-btn:disabled {
-  opacity: 0.4;
+/* #215 — [aria-disabled="true"] (not native :disabled) so the buttons stay in
+ * the tab chain (WCAG 2.4.3), and --text-muted (not opacity: 0.4) so the
+ * disabled glyph clears WCAG 1.4.11 3:1 non-text contrast against --surface-2.
+ * Mirrors the #214 WPM-stepper treatment; cursor: not-allowed carries the
+ * state affordance (WCAG 1.4.1 — not by contrast alone). */
+.font-dec-btn[aria-disabled='true'],
+.font-inc-btn[aria-disabled='true'] {
+  color: var(--text-muted);
   cursor: not-allowed;
 }
 
@@ -493,7 +498,7 @@ export const OVERLAY_CSS = `
   font-size: 16px;
 }
 
-.play-pause-btn:hover {
+.play-pause-btn:hover:not([aria-disabled='true']) {
   background: var(--accent-soft, #e8f0fe);
   color: var(--text, #202124);
 }
@@ -503,8 +508,15 @@ export const OVERLAY_CSS = `
   outline-offset: 3px;
 }
 
-.play-pause-btn:disabled {
-  opacity: 0.5;
+/* #215 — see font-stepper note. Primary filled button: drop opacity (which
+ * collapsed non-text contrast on the accent fill) for a muted surface + muted
+ * glyph that clears WCAG 1.4.11 against the footer. Only the 'done' engine
+ * state sets aria-disabled here; box-shadow removed so the disabled chip reads
+ * as inert. */
+.play-pause-btn[aria-disabled='true'] {
+  background: var(--surface-3, var(--surface-2));
+  color: var(--text-muted);
+  box-shadow: none;
   cursor: not-allowed;
 }
 


### PR DESCRIPTION
## Summary

Extends the #214 WPM-stepper a11y treatment to the three remaining disabled-button rules (font − / +, play-pause). Pure consistency cleanup, no functional change to overlay behavior.

Two defects fixed on each:
1. **WCAG 2.4.3** — native `disabled` silently dropped the button from the tab chain. Now `aria-disabled="true"` keeps it focusable; the click handler short-circuits.
2. **WCAG 1.4.11** — `opacity: 0.4/0.5` collapsed non-text contrast below 3:1. Now a `--text-muted` glyph (font) / muted surface + glyph (play-pause), no opacity.

## Changes

- `overlay.ts` — `applyFontSize` + `reflectEngineState` write `aria-disabled`; `togglePlayPause` + font click handlers short-circuit on it (behavior-preserving — `done`/clamp already no-opped)
- `styles.ts` — `[aria-disabled="true"]` rules, opacity dropped, hover guarded `:not([aria-disabled="true"])`
- tests — aria-disabled + tab-chain + handler short-circuit + mutation guard; CSS-source regression guards against reintroducing opacity

## Out of scope

Issue noted a possible font-size-change live-region announcement. Play-pause already announces state via `aria-pressed` + `aria-label`; a new font-size live region is additive (new feature), not part of the disabled-treatment defect class — left for a follow-up if wanted.

## Test plan

- [x] `npx vitest run` — 1341 passed (incl updated font-size-stepper, play-pause, styles)
- [x] `npm run build` (tsc --noEmit + vite) — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npx playwright test overlay-polish` — 9 passed incl 4 axe scans clean across orp / chunk / center / playing states (acceptance: no new axe violations on control bar)

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)