### PR TITLE
a11y(overlay): 44×44 scrubber thumb hit-target — WCAG 2.2 AAA SC 2.5.5 (#205)

### DIFF
--- a/src/core/overlay/__tests__/styles.test.ts
+++ b/src/core/overlay/__tests__/styles.test.ts
@@ -71,3 +71,27 @@ describe('OVERLAY_CSS resume-toast is out of flow (issue #218)', () => {
     expect(OVERLAY_CSS).toMatch(/\.resume-toast\s*\{[^}]*position:\s*(absolute|fixed)/);
   });
 });
+
+describe('OVERLAY_CSS scrubber 44×44 thumb target (issue #205)', () => {
+  // #205 upgraded the scrubber thumb to a WCAG 2.2 AAA (SC 2.5.5) 44×44 hit
+  // target. Only the thumb pseudo is restyled (appearance:none); the input
+  // keeps its native track + accent-color fill. jsdom has no paint, so these
+  // guard the CSS-source invariant; the 44px drag-strip height + accent-color
+  // survival are exercised in touch-smoke.spec.ts.
+  test('webkit thumb is 44px with appearance:none', () => {
+    const block = OVERLAY_CSS.match(/\.scrubber-slider::-webkit-slider-thumb\s*\{[^}]*\}/)?.[0];
+    expect(block, 'expected the webkit thumb rule').not.toBeUndefined();
+    expect(block).toMatch(/appearance:\s*none/);
+    expect(block).toMatch(/block-size:\s*44px/);
+  });
+
+  test('moz thumb is 44px', () => {
+    const block = OVERLAY_CSS.match(/\.scrubber-slider::-moz-range-thumb\s*\{[^}]*\}/)?.[0];
+    expect(block, 'expected the moz thumb rule').not.toBeUndefined();
+    expect(block).toMatch(/block-size:\s*44px/);
+  });
+
+  test('scrubber keeps accent-color (native track progress fill preserved)', () => {
+    expect(OVERLAY_CSS).toMatch(/\.scrubber-slider\s*\{[^}]*accent-color:\s*var\(--accent/);
+  });
+});

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -390,16 +390,30 @@ export const OVERLAY_CSS = `
 
 /* #205 — 44×44 thumb hit-target (WCAG 2.2 AAA SC 2.5.5). Only the thumb
  * pseudo is restyled (appearance:none); the input keeps its native track and
- * accent-color progress fill (the reading-position indicator). A radial
- * gradient paints a modest ~18px visible knob centered in the 44px hit area
- * so the thin track is not dominated by an oversized painted thumb. */
+ * accent-color progress fill (the reading-position indicator). A layered
+ * radial gradient paints a modest ~18px visible knob centered in the 44px hit
+ * area so the thin track is not dominated by an oversized painted thumb.
+ *
+ * a11y review (PR #223): the knob shares the --accent hue with the fill it
+ * straddles, so an accent-on-accent disc failed WCAG 1.4.11 (3:1 non-text
+ * contrast) on the already-read half of the track. A 2px --surface halo ring
+ * between the disc and the surrounding fill restores ≥3:1 separation on BOTH
+ * sides and keeps the knob legible as a position cue. --surface is
+ * theme-aware (runtime-injected by applyTheme), so the halo holds in dark
+ * theme too. The hard color stops paint a solid disc (no faint gradient) and
+ * the transparent outer ring keeps the 44px hit area invisible. */
 .scrubber-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
   inline-size: 44px;
   block-size: 44px;
   border-radius: 50%;
-  background: radial-gradient(circle, var(--accent, #1a73e8) 0 9px, transparent 9px);
+  background: radial-gradient(
+    circle,
+    var(--accent, #1a73e8) 0 9px,
+    var(--surface, #ffffff) 9px 11px,
+    transparent 11px
+  );
   cursor: pointer;
 }
 
@@ -408,7 +422,12 @@ export const OVERLAY_CSS = `
   block-size: 44px;
   border: none;
   border-radius: 50%;
-  background: radial-gradient(circle, var(--accent, #1a73e8) 0 9px, transparent 9px);
+  background: radial-gradient(
+    circle,
+    var(--accent, #1a73e8) 0 9px,
+    var(--surface, #ffffff) 9px 11px,
+    transparent 11px
+  );
   cursor: pointer;
 }
 

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -374,7 +374,10 @@ export const OVERLAY_CSS = `
 
 .scrubber-slider {
   inline-size: 100%;
-  block-size: 22px; /* hit-target while visual track stays 4px */
+  /* #205 — 44px-tall drag strip so the whole slider is a WCAG 2.2 AAA
+   * (SC 2.5.5) 44×44 target; the native track + accent-color fill stay
+   * centered inside it. */
+  block-size: 44px;
   accent-color: var(--accent, #1a73e8);
   cursor: pointer;
   margin: 0;
@@ -383,6 +386,30 @@ export const OVERLAY_CSS = `
 .scrubber-slider:focus-visible {
   outline: 2px solid var(--accent, #1a73e8);
   outline-offset: 4px;
+}
+
+/* #205 — 44×44 thumb hit-target (WCAG 2.2 AAA SC 2.5.5). Only the thumb
+ * pseudo is restyled (appearance:none); the input keeps its native track and
+ * accent-color progress fill (the reading-position indicator). A radial
+ * gradient paints a modest ~18px visible knob centered in the 44px hit area
+ * so the thin track is not dominated by an oversized painted thumb. */
+.scrubber-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  inline-size: 44px;
+  block-size: 44px;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--accent, #1a73e8) 0 9px, transparent 9px);
+  cursor: pointer;
+}
+
+.scrubber-slider::-moz-range-thumb {
+  inline-size: 44px;
+  block-size: 44px;
+  border: none;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--accent, #1a73e8) 0 9px, transparent 9px);
+  cursor: pointer;
 }
 
 /* ===== Footer — mockup ".rsvp-controls" =====
@@ -754,6 +781,10 @@ export const OVERLAY_CSS = `
   .prev-sentence-btn:focus-visible,
   .next-sentence-btn:focus-visible { outline-color: Highlight; }
   .scrubber-slider:focus-visible { outline-color: Highlight; }
+  /* #205 — forced-colors strips the radial-gradient knob to nothing; restore a
+   * solid system-color thumb so the drag handle stays visible. */
+  .scrubber-slider::-webkit-slider-thumb { background: Highlight; }
+  .scrubber-slider::-moz-range-thumb { background: Highlight; border: 1px solid CanvasText; }
   /* #213 — replaced .wpm-slider + .wpm-readout with the stepper. */
   .wpm-display { color: CanvasText; border-color: CanvasText; background: Canvas; }
   .wpm-display button { background: ButtonFace; color: ButtonText; border: 1px solid ButtonText; }
@@ -867,8 +898,7 @@ export const OVERLAY_CSS = `
     width: 48px;
     height: 48px;
   }
-  .scrubber-slider {
-    block-size: 32px;
-  }
+  /* #205 — base .scrubber-slider is already 44px (AAA target); no touch
+   * override needed. */
 }
 `;

--- a/tests/e2e/touch-smoke.spec.ts
+++ b/tests/e2e/touch-smoke.spec.ts
@@ -103,6 +103,25 @@ test.describe('Touch-primary smoke (#36 / PR #149)', () => {
     }
   });
 
+  test('scrubber slider is a >=44 CSS px drag target (#205 AAA SC 2.5.5)', async ({ page }) => {
+    await mountOverlay(page);
+    const host = page.locator('[data-speedreader-overlay]');
+    const dims = await host.evaluate((el) => {
+      const root = (el as HTMLElement).shadowRoot;
+      if (!root) throw new Error('no shadowRoot');
+      const s = root.querySelector<HTMLInputElement>('input.scrubber-slider');
+      if (!s) throw new Error('missing scrubber-slider');
+      const r = s.getBoundingClientRect();
+      return { h: r.height, accentColor: getComputedStyle(s).accentColor };
+    });
+    // 44px-tall drag strip = the WCAG 2.2 AAA 44×44 target (the thumb's 44px
+    // hit area is set via the ::*-thumb pseudos, guarded in styles.test.ts).
+    expect(dims.h).toBeGreaterThanOrEqual(44);
+    // accent-color must survive — it paints the native track progress fill
+    // (the reading-position indicator); the thumb-only restyle must not drop it.
+    expect(dims.accentColor).not.toBe('');
+  });
+
   test('footer area resolves a finite computed padding-bottom', async ({ page }) => {
     await mountOverlay(page);
     const host = page.locator('[data-speedreader-overlay]');


### PR DESCRIPTION
## Summary

Upgrades the scrubber thumb to a WCAG 2.2 AAA (SC 2.5.5) 44×44 hit target.

**Scope corrected from the issue:** #213 replaced the WPM *slider* with a stepper, so the overlay has only ONE range slider now (`.scrubber-slider`). The issue's rationale (upgrade both sliders together to avoid side-by-side thumb divergence) is moot — this targets the scrubber only. The proposed `.wpm-slider::-webkit-slider-thumb` rule would have been dead CSS.

## Approach

Thumb-only restyle (not a fully-custom slider):
- `::-webkit-slider-thumb` / `::-moz-range-thumb` → `appearance:none` + 44×44, with a radial-gradient knob (~18px visible) centered in the 44px hit area, so the thin track is not dominated by an oversized painted thumb.
- The input keeps its **native track + `accent-color` progress fill** (the reading-position indicator). A fully-custom slider would have dropped it.
- Drag strip bumped to 44px tall → the whole control is a 44×44 target.
- Forced-colors: the radial gradient strips to nothing, so a solid `Highlight`/`CanvasText` thumb fallback is added.

## Visual

Screenshot-verified during implementation: modest accent knob at the thumb position, native accent fill preserved to its left, footer layout intact. **Requesting `a11y-extension-designer` eyes on the knob size / vertical rhythm.**

## Test plan

- [x] `npx vitest run` — 1338 passed (incl new styles.test scrubber guards)
- [x] `npm run build` (tsc + vite) — clean
- [x] `npm run lint` / `format:check` — clean
- [x] `npx playwright test touch-smoke overlay-polish` — 16 passed; new test asserts 44px drag strip + accent-color survival; 4 axe scans clean across overlay states
- [x] Visual regression (manual screenshot) — knob + fill + layout confirmed

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)