### PR TITLE
polish: unify sentence-boundary predicate across engine + preview + chunks (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ heading and a fresh `[Unreleased]` block is opened above it.
 
 ### Changed
 
+- Sentence-boundary detection is now unified across sentence navigation
+  (← / →), the paused context preview, and chunk mode (#208). All three
+  share the chunk-mode predicate: ellipsis (`…`) and CJK terminators
+  (`。！？`) end sentences, trailing closing quotes/brackets after a
+  terminator are recognized, and honorifics (Dr., Mr., Mrs., Ms., St.,
+  Prof., Sr., Jr.) no longer count as sentence ends. Behavior change for
+  `seekToSentence` / snap-to-sentence: boundaries land differently on
+  abbreviation-heavy, quoted, or CJK text — previously the preview and
+  chunk boundaries could disagree on the same sentence.
+
 ### Deprecated
 
 ### Removed

--- a/src/core/overlay/__tests__/context-preview.test.ts
+++ b/src/core/overlay/__tests__/context-preview.test.ts
@@ -292,3 +292,36 @@ describe('createOverlay — context preview (#20)', () => {
     overlay.unmount();
   });
 });
+
+describe('buildSentenceContext — unified sentence predicate (#208)', () => {
+  // Preview now shares `endsSentence` with the engine and chunk-mode
+  // (`tokenize/sentence-boundary.ts`). Pre-#208 the naive `[.!?]$`
+  // predicate made the preview disagree with chunk boundaries on
+  // honorifics, ellipsis, and trailing closing quotes.
+
+  test('honorific: "Dr." does not split the before-walk', () => {
+    const ctx = buildSentenceContext(['Dr.', 'Smith', 'said', 'hi'], 3);
+    // Naive predicate stops the backward walk at 'Dr.' → ['Smith', 'said'].
+    expect(ctx?.before).toEqual(['Dr.', 'Smith', 'said']);
+  });
+
+  test('ellipsis terminates the after-walk', () => {
+    const ctx = buildSentenceContext(['Wait…', 'Then', 'we', 'go', 'now', 'ok'], 0);
+    // Current word is itself the terminator → after = next 3 words.
+    // Naive predicate finds no terminator → after runs to end of stream.
+    expect(ctx?.after).toEqual(['Then', 'we', 'go']);
+  });
+
+  test('terminator followed by closing quote ends the after-walk', () => {
+    const ctx = buildSentenceContext(['He', 'said,', '"Stop."', 'And', 'then', 'more', 'words'], 1);
+    // Terminator at index 2 → after = terminator + next 3 words.
+    // Naive predicate misses the quoted terminator → after runs to end.
+    expect(ctx?.after).toEqual(['"Stop."', 'And', 'then', 'more']);
+  });
+
+  test('CJK terminator splits the before-walk', () => {
+    const ctx = buildSentenceContext(['你好。', '我们', '走吧'], 2);
+    // '你好。' ends a sentence → before excludes it.
+    expect(ctx?.before).toEqual(['我们']);
+  });
+});

--- a/src/core/overlay/sentence-context.ts
+++ b/src/core/overlay/sentence-context.ts
@@ -5,18 +5,17 @@
  * builds the preview region from the slices returned here; rendering and
  * visibility toggling live in `overlay.ts`.
  *
- * Sentence model intentionally mirrors the engine's `[.!?]$` predicate
- * (see `rsvp-engine.ts` `SENTENCE_END`, `snapToSentenceStart`,
- * `findNextSentenceStart`). Keeping the predicate identical means the
- * preview's "before / current / after" slices agree with
- * `seekToSentence('prev' | 'next')` navigation — the user sees the same
- * sentence shape the engine will jump within. Drift here would surface
- * as a subtle UX mismatch where ←/→ would skip past words the preview
- * had just shown as part of the current sentence.
+ * Sentence model uses the shared `endsSentence` predicate from
+ * `tokenize/sentence-boundary.ts` (#208) — the same predicate behind the
+ * engine's `seekToSentence` navigation and chunk-mode `sentenceStart`
+ * flags. Keeping all three identical means the preview's "before /
+ * current / after" slices agree with ←/→ navigation AND chunk
+ * boundaries — the user sees the same sentence shape everywhere.
+ * Drift here would surface as a subtle UX mismatch where ←/→ would
+ * skip past words the preview had just shown as part of the current
+ * sentence, or chunks would respect an honorific the preview split on.
  */
-
-/** Match the engine's sentence terminator. Do NOT introduce a divergent regex. */
-const SENTENCE_END = /[.!?]$/;
+import { endsSentence } from '../tokenize/sentence-boundary';
 
 export interface SentenceContext {
   /** Words preceding the current word in the same sentence. May be empty. */
@@ -86,7 +85,7 @@ export function buildSentenceContext(
   const beforeFloor = Math.max(0, currentIndex - BEFORE_MAX_WORDS);
   let sentenceStart = beforeFloor;
   for (let i = currentIndex - 1; i >= beforeFloor; i--) {
-    if (SENTENCE_END.test(words[i])) {
+    if (endsSentence(words[i])) {
       sentenceStart = i + 1;
       break;
     }
@@ -99,7 +98,7 @@ export function buildSentenceContext(
   // `terminatorIndex` equals `currentIndex` and `after` starts past it.
   let terminatorIndex = -1;
   for (let i = currentIndex; i < words.length; i++) {
-    if (SENTENCE_END.test(words[i])) {
+    if (endsSentence(words[i])) {
       terminatorIndex = i;
       break;
     }

--- a/src/core/rsvp-engine/__tests__/seekTo.test.ts
+++ b/src/core/rsvp-engine/__tests__/seekTo.test.ts
@@ -261,22 +261,23 @@ describe('seekTo() with snapToSentence', () => {
     expect(last).toEqual({ type: 'word', index: 0, word: 'First.' });
   });
 
-  it('TODO #90: naive snap mis-fires on abbreviations ("Dr." treated as sentence end)', () => {
-    // Pins the CURRENT (intentionally naive) [.!?]$ heuristic so a future
-    // sentence-detector refactor (issue #90 markSentenceBoundaries) gets caught
-    // as a behavior change rather than slipping in silently. Builder
-    // self-weakness #1.
+  it('snap exempts honorifics ("Dr." not treated as sentence end) — #208', () => {
+    // Pre-#208 this test pinned the naive [.!?]$ heuristic (snap to 1,
+    // 'Smith') so a sentence-detector refactor would be caught as a
+    // behavior change rather than slipping in silently. #208 unified the
+    // predicate with chunk-mode's `endsSentence` — the honorific
+    // exemption now applies, and this test pins the CORRECTED behavior.
     const words = ['Dr.', 'Smith', 'said', 'hello.', 'Next', 'sentence', 'here.'];
     const engine = createRsvpEngine({ words, wpm: 300 });
     const events: RsvpEvent[] = [];
     engine.subscribe((e) => events.push(e));
     engine.start();
 
-    // Seek to index 2 ("said") with snap. Naive heuristic sees "Dr." as a
-    // sentence end and snaps to 1 ("Smith") — INCORRECT for English prose.
+    // Seek to index 2 ("said") with snap. "Dr." is exempt, so the
+    // sentence start is index 0.
     engine.seekTo(2, { snapToSentence: true });
 
-    expect(events[events.length - 1]).toEqual({ type: 'word', index: 1, word: 'Smith' });
+    expect(events[events.length - 1]).toEqual({ type: 'word', index: 0, word: 'Dr.' });
   });
 
   it('snapToSentence past-end still → done (snap is bypassed for out-of-range targets)', () => {

--- a/src/core/rsvp-engine/__tests__/seekToSentence.test.ts
+++ b/src/core/rsvp-engine/__tests__/seekToSentence.test.ts
@@ -219,3 +219,100 @@ describe('seekToSentence edge cases', () => {
     expect(events).toEqual([{ type: 'word', index: 0, word: 'no' }]);
   });
 });
+
+describe('unified sentence predicate (#208)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  // Engine seek now shares `endsSentence` with chunk-mode
+  // (`tokenize/sentence-boundary.ts`) so honorifics, ellipsis, CJK
+  // terminators, and trailing closing quotes agree across seek,
+  // preview, and chunk boundaries. Pre-#208 the naive `[.!?]$`
+  // predicate diverged on every case below.
+
+  //   0      1        2       3         4       5
+  const HONORIFIC = ['Dr.', 'Smith', 'said', 'hello.', 'Next', 'one.'];
+
+  it('honorific: next does not break after "Dr."', () => {
+    //   0      1      2      3        4         5       6
+    // ['She', 'met', 'Dr.', 'Smith', 'today.', 'Then', 'left.']
+    const engine = createRsvpEngine({
+      words: ['She', 'met', 'Dr.', 'Smith', 'today.', 'Then', 'left.'],
+      wpm: 300,
+    });
+    const events: RsvpEvent[] = [];
+    engine.subscribe((e) => events.push(e));
+    engine.start();
+    engine.pause(); // emitted 'She' (index 0); nextIndex=1
+    events.length = 0;
+
+    engine.seekToSentence('next');
+
+    // Naive predicate breaks after 'Dr.' and jumps to 3 ('Smith');
+    // unified skips the honorific and lands on the true next sentence at 5.
+    expect(events).toEqual([{ type: 'word', index: 5, word: 'Then' }]);
+  });
+
+  it('honorific: prev snaps past "Dr." to the true sentence start', () => {
+    const engine = createRsvpEngine({ words: HONORIFIC, wpm: 300 });
+    const events: RsvpEvent[] = [];
+    engine.subscribe((e) => events.push(e));
+    engine.start();
+    engine.pause();
+    engine.seekTo(2); // mid "Dr. Smith said hello."
+    events.length = 0;
+
+    engine.seekToSentence('prev');
+
+    // Naive predicate treats 'Dr.' as a boundary and snaps to 1;
+    // unified walks through it to index 0.
+    expect(events).toEqual([{ type: 'word', index: 0, word: 'Dr.' }]);
+  });
+
+  it('ellipsis terminates a sentence for next', () => {
+    const engine = createRsvpEngine({ words: ['OK,', 'wait…', 'Then', 'go.'], wpm: 300 });
+    const events: RsvpEvent[] = [];
+    engine.subscribe((e) => events.push(e));
+    engine.start();
+    engine.pause(); // emitted 'OK,' (index 0); nextIndex=1
+    events.length = 0;
+
+    engine.seekToSentence('next');
+
+    // Naive predicate sees no boundary until the final word (whose
+    // next-start is past-end) → no-op. Unified breaks after 'wait…'.
+    expect(events).toEqual([{ type: 'word', index: 2, word: 'Then' }]);
+  });
+
+  it('CJK terminator ends a sentence for next', () => {
+    const engine = createRsvpEngine({ words: ['先说', '你好。', '下一句', '结束'], wpm: 300 });
+    const events: RsvpEvent[] = [];
+    engine.subscribe((e) => events.push(e));
+    engine.start();
+    engine.pause(); // emitted '先说' (index 0); nextIndex=1
+    events.length = 0;
+
+    engine.seekToSentence('next');
+
+    // Naive predicate never matches '。' → no-op.
+    expect(events).toEqual([{ type: 'word', index: 2, word: '下一句' }]);
+  });
+
+  it('terminator followed by closing quote ends a sentence for next', () => {
+    const engine = createRsvpEngine({
+      words: ['He', 'said,', '"Stop."', 'Then', 'left.'],
+      wpm: 300,
+    });
+    const events: RsvpEvent[] = [];
+    engine.subscribe((e) => events.push(e));
+    engine.start();
+    engine.pause(); // emitted 'He' (index 0)
+    events.length = 0;
+
+    engine.seekToSentence('next');
+
+    // Naive predicate fails on the trailing quote → walks to 'left.'
+    // whose next-start is past-end → no-op.
+    expect(events).toEqual([{ type: 'word', index: 3, word: 'Then' }]);
+  });
+});

--- a/src/core/rsvp-engine/rsvp-engine.ts
+++ b/src/core/rsvp-engine/rsvp-engine.ts
@@ -10,7 +10,7 @@
 
 import { calculatePunctuationDelay } from './punctuation-pacing';
 import { buildChunks, type Chunk, type ChunkSize, type WordToken } from './chunks';
-import { markSentenceBoundaries } from '../tokenize/sentence-boundary';
+import { markSentenceBoundaries, endsSentence } from '../tokenize/sentence-boundary';
 
 export const RSVP_STATE = {
   IDLE: 'idle',
@@ -248,12 +248,13 @@ export function wpmToDelay(wpm: number): number {
 // "Cannot read properties of null" surprise.
 // Walk backward from `target - 1` to find the nearest preceding word ending in
 // sentence-final punctuation. Sentence-start = the word immediately after that
-// boundary. If no such boundary exists, snap to 0. Naive — does not handle
-// abbreviations like "Dr." or "U.S.A."; documented in PR self-weakness #1.
-const SENTENCE_END = /[.!?]$/;
+// boundary. If no such boundary exists, snap to 0. Uses the shared
+// `endsSentence` predicate (#208) so seek, the pause-state preview, and
+// chunk-mode `sentenceStart` flags all agree on what a sentence is —
+// honorifics (Dr./Mr./…), ellipsis, CJK terminators, trailing quotes.
 function snapToSentenceStart(words: string[], target: number): number {
   for (let i = target - 1; i >= 0; i--) {
-    if (SENTENCE_END.test(words[i])) return i + 1;
+    if (endsSentence(words[i])) return i + 1;
   }
   return 0;
 }
@@ -266,7 +267,7 @@ function snapToSentenceStart(words: string[], target: number): number {
 // punctuation-free text AND on a terminator at the last word).
 function findNextSentenceStart(words: string[], from: number): number {
   for (let i = from; i < words.length; i++) {
-    if (SENTENCE_END.test(words[i])) {
+    if (endsSentence(words[i])) {
       const next = i + 1;
       return next < words.length ? next : -1;
     }

--- a/src/core/tokenize/index.ts
+++ b/src/core/tokenize/index.ts
@@ -1,3 +1,3 @@
 export { tokenize } from './tokenize';
-export { markSentenceBoundaries, type MarkedToken } from './sentence-boundary';
+export { markSentenceBoundaries, endsSentence, type MarkedToken } from './sentence-boundary';
 export { contextSentence, type ContextSentence } from './context-sentence';

--- a/src/core/tokenize/sentence-boundary.ts
+++ b/src/core/tokenize/sentence-boundary.ts
@@ -76,7 +76,17 @@ const SENTENCE_END_RE = /[.!?…。！？](?:\[[^\]]*\]|\([^)]*\)|["'”’)\]])
 // sentence). Read spec §"Looks like an abbreviation" before adding to this set.
 const ABBREVIATION_RE = /\b(?:Dr|Mr|Mrs|Ms|St|Prof|Sr|Jr)\.(?:\[[^\]]*\]|\([^)]*\)|["'”’)\]])*$/u;
 
-function endsSentence(word: string): boolean {
+/**
+ * Single source of truth for "does this word end a sentence?" (#208).
+ *
+ * Shared by `markSentenceBoundaries` (chunk-mode `sentenceStart` flags),
+ * the engine's `snapToSentenceStart` / `findNextSentenceStart`
+ * (`seekToSentence` navigation), and the pause-state preview
+ * (`overlay/sentence-context.ts`). All three consumers MUST agree —
+ * divergent predicates surface as the preview showing one sentence
+ * shape while seek/chunks use another (issue #208's defect).
+ */
+export function endsSentence(word: string): boolean {
   return SENTENCE_END_RE.test(word) && !ABBREVIATION_RE.test(word);
 }
 


### PR DESCRIPTION
## Summary

Fixes #208 — Approach A from the issue (unify everything on the sophisticated predicate).

Three divergent sentence-end predicates existed: engine seek (naive `[.!?]$`), pause-state preview (naive, intentionally mirroring engine), and chunk-mode (`SENTENCE_END_RE` — ellipsis + CJK + closing-quote/bracket + honorific exemption). A user reading "Dr. Smith said hello." at chunkSize=2 saw chunks respect the honorific while the preview split after "Dr.".

- Export `endsSentence` from `src/core/tokenize/sentence-boundary.ts` as the single source of truth (re-exported via `tokenize/index.ts`)
- `rsvp-engine.ts` `snapToSentenceStart` / `findNextSentenceStart` switch to it (covers `seekToSentence` + `seekTo({snapToSentence})`)
- `overlay/sentence-context.ts` before/after walks switch to it
- Chunk-mode unchanged (already used it)

**Behavior change** (changelogged): seek boundaries move on abbreviation-heavy, quoted, and CJK text. The `seekTo` TODO-#90 pin test asserted the naive behavior by design to catch exactly this refactor; flipped to pin the corrected behavior.

## Tests

9 new tests, all red before the change, green after: 5 engine (`seekToSentence` honorific next/prev, ellipsis, CJK, trailing quote) + 4 preview (`buildSentenceContext` honorific before-walk, ellipsis after-walk, quoted terminator, CJK before-walk). Fixtures account for `cur = nextIndex` walk-start semantics so each case discriminates naive vs unified.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 1353/1353 passed
- [x] `npm run build` — tsc --noEmit + vite build clean
- [x] e2e: `chunk-mode.spec.ts` + `overlay-polish.spec.ts` (sentence-touching specs incl. axe scans) — 12/12 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
