### PR TITLE
test: tighten scrubber + chunk-mode discriminators (#207, #202)

### DIFF
--- a/src/chrome/content/__tests__/chunk-size-wire.test.ts
+++ b/src/chrome/content/__tests__/chunk-size-wire.test.ts
@@ -188,11 +188,17 @@ describe('content script — chunkSize wire boundary (#51)', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    // Word region should now contain a multi-word chunk (text
-    // includes a space). Asserting "contains a space" is robust to
-    // exactly which chunk the engine lands on after the live switch.
-    const text = getWordRegion().textContent ?? '';
-    expect(text.includes(' ')).toBe(true);
-    expect(text.split(' ').length).toBeGreaterThanOrEqual(2);
+    // #202 ITEM-B — pin the EXACT chunk text. The old "contains a space"
+    // assertion passed for any multi-word chunk, so a wire defect that
+    // delivered the wrong chunkSize (e.g. 3 when 2 was requested) still
+    // rendered a spaced chunk and stayed green. The expected text is
+    // deterministic from engine state:
+    //   fixture = 9 words ('The' … 'dog.'), word mode emitted 'The' →
+    //   raw pos 1. setChunkSize(2) on PLAYING captures rawPos 1, rebuilds
+    //   chunks [The quick][brown fox][jumps over][the lazy][dog.], maps
+    //   wordIndexToChunkIndex(1) = 0, and ticks immediately → chunk 0,
+    //   text 'The quick'. (chunkSize=3 would render 'The quick brown' —
+    //   spaced, but ≠ this pin.)
+    expect(getWordRegion().textContent).toBe('The quick');
   });
 });

--- a/src/core/overlay/__tests__/scrubber.test.ts
+++ b/src/core/overlay/__tests__/scrubber.test.ts
@@ -347,25 +347,120 @@ describe('createOverlay — scrubber done terminal state (#47 ring-review FIX-2)
   });
 });
 
-describe('createOverlay — scrubber keyboard-only input pause (#47 ring-review FIX-3)', () => {
+describe('createOverlay — scrubber keyboard-only input pause (#47 ring-review FIX-3, tightened per #207 ITEM-M4)', () => {
   // test-gap MED #2: the existing "input event pauses a playing engine"
   // test creates an input event but doesn't pin that NO preceding
   // mousedown fired. A regression that moved `scrubFromPause()` into a
   // mousedown-only branch would leave keyboard-driven scrub un-paused
   // (Arrow keys on the focused range fire `input` with no mousedown).
   // This test is explicit: input WITHOUT mousedown still pauses.
-  test('input event with no preceding mousedown still pauses a playing engine (Arrow-key path)', () => {
+  //
+  // #207 ITEM-M4 — the original `state === 'paused'` assertion was a weak
+  // discriminator: it cannot tell pause-on-transition apart from
+  // pause-on-every-input. `engine.pause()` is internally idempotent, so a
+  // mutation that swaps scrubFromPause's `engine?.state === 'playing'`
+  // guard for the session flag (`if (scrubInProgress)` — already set by
+  // `beginScrubSession()` before scrubFromPause runs) leaves the engine
+  // paused (old assertion green) while redundantly re-invoking
+  // `engine.pause()` on EVERY input of the session. The spy + exactly-once
+  // count below pins the contract: pause is requested only on the
+  // playing→paused transition of the keyboard path, never re-issued on
+  // held-Arrow repeats.
+  test('input event with no preceding mousedown pauses a playing engine exactly once (Arrow-key path)', () => {
     const holder: Holder = { engine: null };
     const overlay = createOverlay(defaultOpts(holder));
     overlay.mount();
     expect(engineOf(holder).state).toBe('playing');
+    const pauseSpy = vi.spyOn(engineOf(holder), 'pause');
     const s = getScrubber();
     s.focus();
     // Simulate the Arrow-key path: the browser fires `input` directly on
     // a focused range when the user presses Arrow. No prior mousedown.
     s.value = '2';
     s.dispatchEvent(new Event('input', { bubbles: true }));
+    // Held-Arrow repeat: a second input in the same session. The engine is
+    // already paused, so no further engine.pause() call may be issued.
+    s.value = '3';
+    s.dispatchEvent(new Event('input', { bubbles: true }));
     expect(engineOf(holder).state).toBe('paused');
+    expect(pauseSpy).toHaveBeenCalledTimes(1);
+    overlay.unmount();
+  });
+});
+
+describe('createOverlay — unmount mid-debounce cleanup (#207 ITEM-M2)', () => {
+  // overlay.ts unmount() clears `scrubDebounceTimer` (#47 ring-review
+  // FIX-6 cleanup) so a pending 250ms session-reset cannot fire into the
+  // detached shadow / nulled engine. That invariant was untested: every
+  // prior test either let the debounce elapse or never armed it before
+  // unmount.
+  test('unmount with a pending scrub debounce clears the timer — no late fire into the detached shadow', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    overlay.mount();
+    const live = getShadow().querySelector<HTMLElement>(`.${OVERLAY_CLASS.ARIA_LIVE}`);
+    if (!live) throw new Error('missing aria-live');
+    const s = getScrubber();
+    s.value = '2';
+    s.dispatchEvent(new Event('input', { bubbles: true }));
+    // Debounce armed: the scrub session-reset timer is pending (the
+    // engine's own tick was cleared by pause-on-scrub, so this is the
+    // only live timer).
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+    const liveBefore = live.textContent;
+    overlay.unmount();
+    // Load-bearing discriminator: deleting the
+    // `clearTimeout(scrubDebounceTimer)` block in unmount() leaves the
+    // debounce pending here (count 1) and flips this red. The late
+    // callback's writes happen to be value-idempotent against a
+    // stopped/nulled engine, so timer absence IS the observable contract.
+    expect(vi.getTimerCount()).toBe(0);
+    // Belt-and-braces: advancing past the window must neither throw nor
+    // mutate the aria-live node captured pre-unmount.
+    expect(() => vi.advanceTimersByTime(300)).not.toThrow();
+    expect(live.textContent).toBe(liveBefore);
+  });
+});
+
+describe('createOverlay — engine done mid-scrub session boundary (#207 ITEM-D1)', () => {
+  // Pins current behavior when the engine transitions to `done` while a
+  // scrub session is open (debounce pending, announcement latch true):
+  // nothing throws, the `done` branch never writes aria-live (the session
+  // announcement remains the defined announcement state), and the session
+  // boundary stays TIMER-driven — the debounce elapsing resets the latch
+  // even though the engine finished mid-session, so the next scrub on the
+  // done engine re-announces.
+  test('done mid-scrub: no throw, announcement preserved, debounce still resets the session latch', () => {
+    const holder: Holder = { engine: null };
+    const overlay = createOverlay(defaultOpts(holder));
+    overlay.mount();
+    const live = getShadow().querySelector<HTMLElement>(`.${OVERLAY_CLASS.ARIA_LIVE}`);
+    if (!live) throw new Error('missing aria-live');
+    const s = getScrubber();
+    s.focus();
+    // Open a scrub session: pauses the engine, fires the announcement,
+    // arms the 250ms debounce, sets the one-shot latch.
+    s.value = '2';
+    s.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(live.textContent).toBe(OVERLAY_TEXT.SCRUB_PAUSED_ANNOUNCEMENT);
+    // Drive the engine to `done` while the session is still open
+    // (paused-state seekTo past the end emits `done` synchronously).
+    expect(() => engineOf(holder).seekTo(999)).not.toThrow();
+    expect(engineOf(holder).state).toBe('done');
+    // The subscribe handler's done branch never writes aria-live: the
+    // session announcement is the defined announcement state.
+    expect(live.textContent).toBe(OVERLAY_TEXT.SCRUB_PAUSED_ANNOUNCEMENT);
+    // The pending debounce fires after `done` without throwing and ends
+    // the session (latch reset included — see next assertion).
+    expect(() => vi.advanceTimersByTime(300)).not.toThrow();
+    // Session boundary is debounce-driven, not engine-state-driven: a new
+    // scrub on the done engine starts a fresh session and re-announces.
+    // Mutation guard: deleting `scrubAnnouncementFired = false` from the
+    // debounce callback leaves the latch stuck and flips this red.
+    live.textContent = '';
+    s.value = '1';
+    s.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(live.textContent).toBe(OVERLAY_TEXT.SCRUB_PAUSED_ANNOUNCEMENT);
     overlay.unmount();
   });
 });

--- a/src/core/overlay/constants.ts
+++ b/src/core/overlay/constants.ts
@@ -228,6 +228,10 @@ export const OVERLAY_TEXT = Object.freeze({
    * suppressed for the remainder of the session by the FIX-6 debounce
    * (so rapid drags don't re-fire). A new session begins after the
    * 250ms scrub-debounce window elapses.
+   *
+   * Session boundaries are debounce-timer-driven ONLY: engine state
+   * transitions mid-scrub (pause/resume/`done`) neither end the session
+   * nor reset the one-shot latch — see #207 ITEM-D1.
    */
   SCRUB_PAUSED_ANNOUNCEMENT: 'Paused. Scrubbing reading position.',
 

--- a/src/core/rsvp-engine/__tests__/chunk-mode.test.ts
+++ b/src/core/rsvp-engine/__tests__/chunk-mode.test.ts
@@ -636,6 +636,48 @@ describe('createRsvpEngine — chunk mode (chunkSize >= 2)', () => {
       });
     });
 
+    it('paused 2 → 3 with advanced position maps the current raw pos into the new layout (#202 ITEM-A)', () => {
+      // Discriminator for the test above: that test sits at raw position 2,
+      // which maps to chunk 0 of the new layout — the SAME result an
+      // "always restart at chunk 0" mutation produces (its expected
+      // startIndex is 0 either way). Advance to raw position 4 first so
+      // correct mapping and mutated mapping diverge.
+      //
+      // Stream (single sentence, no early sentence cuts):
+      //   ['One','two','three','four','five','six','seven','eight.']
+      //      0     1      2      3      4     5      6        7
+      // chunkSize=2 chunks: [One two][three four][five six][seven eight.]
+      // start() emits chunk 0 sync; +200ms tick emits chunk 1 → raw pos
+      // after chunk 1 = chunks[1].endIndex + 1 = 4.
+      // chunkSize=3 chunks: [One two three][four five six][seven eight.]
+      // wordIndexToChunkIndex(4) = 1 → paused replacement emit MUST be
+      // chunk 1: startIndex 3, endIndex 5, text 'four five six'.
+      //
+      // Mutation guard: replacing the `currentRawPos` capture in
+      // setChunkSize with `0` keeps the test above green (it expected
+      // startIndex 0 anyway) and flips this exact-value assertion red
+      // (mutant emits chunk 0: startIndex 0, 'One two three').
+      const engine = createRsvpEngine({
+        words: ['One', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight.'],
+        wpm: 300,
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+      vi.advanceTimersByTime(60000 / 300); // chunk 1 ('three four') emitted
+      engine.pause();
+      engine.setChunkSize(3);
+      const last = events[events.length - 1];
+      expect(last).toEqual({
+        type: 'chunk',
+        startIndex: 3,
+        endIndex: 5,
+        text: 'four five six',
+        words: ['four', 'five', 'six'],
+      });
+    });
+
     it('playing 2 → 1 flips engine to word emission mid-session', () => {
       const engine = createRsvpEngine({
         words: ['The', 'quick', 'brown', 'fox.'],


### PR DESCRIPTION
## Summary

Test-discriminator tightening batch — follow-ups from tier-1 fix-commit critics on PR #204 (#207) and PR #201 (#202). Test-only + one 4-line JSDoc; zero production behavior change.

- **#207 M2**: unmount-mid-debounce cleanup pinned via `vi.getTimerCount() === 0` post-unmount. Finding: the issue-prescribed assertions (no-throw + aria-live unchanged) do NOT flip when the `clearTimeout` block is deleted — the late callback is value-idempotent against a stopped engine. Timer-count assertion is the load-bearing discriminator; prescribed pins kept as secondary.
- **#207 M4**: FIX-3 kbd test spies `engine.pause`, asserts exactly one call across a two-input held-Arrow session — catches the in-function `scrubInProgress` guard-swap mutation the state-only assertion missed (old test stays green under it; demonstrated).
- **#207 D1**: done-mid-scrub session boundary pinned (no throw, announcement preserved, latch still timer-reset) + JSDoc on `SCRUB_PAUSED_ANNOUNCEMENT`.
- **#202 A**: paused `setChunkSize` 2→3 from raw pos 4 asserts exact `startIndex: 3` — red under `currentRawPos→0` mutation while the existing `startIndex: 0` test stays green (tautology confirmed).
- **#202 B**: chunk-size wire test pins exact text `The quick` — red under 3-for-2 chunkSize wire swap the contains-a-space assertion passed.

Closes #207. Closes #202.

## Test plan

- [x] `npm run lint` — 0 warnings
- [x] `npm run format:check` — clean
- [x] `npm run test` — 1362/1362 (86 files; +3 tests over baseline 1359)
- [x] `npm run build` — tsc + vite clean
- [x] Mutation evidence per item: each target mutation applied → named test observed red → reverted → green. Old/weak assertions verified to stay green under #207 M4 and #202 A mutations (the gap each issue named).

🤖 Generated with [Claude Code](https://claude.com/claude-code)