### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ heading and a fresh `[Unreleased]` block is opened above it.
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.3.0] - 2026-06-10
+
+### Added
+
 - Bold overlay text now renders the true OpenDyslexic-Bold face instead of
   a synthetic embolden of the dyslexia-tuned letterforms; the Bold woff2 is
   bundled and injected into the overlay shadow root, and the options page
@@ -98,5 +112,6 @@ parity with the Safari reference plus Hi-Fi overlay polish landed in M2.
 
 ### Security
 
-[Unreleased]: https://github.com/chriscantu/speedreader-chrome/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/chriscantu/speedreader-chrome/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/chriscantu/speedreader-chrome/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/chriscantu/speedreader-chrome/compare/v0.1.0...v0.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speedreader-chrome",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "SpeedReader for Chrome - RSVP reading accessibility extension",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Promotes `[Unreleased]` to `[0.3.0] - 2026-06-10` and bumps `package.json` 0.2.0 → 0.3.0.

Minor bump: `[Unreleased]` contained `### Added` entries (OpenDyslexic-Bold face, `scrubberAutoHide` opt-out) with no Removed/Breaking changes.

## Changes

- `package.json`: 0.2.0 → 0.3.0
- `CHANGELOG.md`: promote `[Unreleased]` → `[0.3.0]`, open fresh `[Unreleased]`, add compare links

## Release plumbing (post-merge)

- Tag `v0.3.0` already pushed; it points at this PR commit and becomes valid once merged into `main`.
- GitHub Release will be published as a **prerelease** (unlisted testing track, matching v0.2.0).
- `.claude-plugin/plugin.json` intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
