### PR TITLE
test(nit): #200 — jsdom role query, IDN/IP coverage, companion timing

### DIFF
--- a/src/chrome/options/__tests__/controller.test.ts
+++ b/src/chrome/options/__tests__/controller.test.ts
@@ -567,6 +567,33 @@ describe('options controller', () => {
       expect(onHistoryDisabled).toHaveBeenCalledTimes(2);
     });
 
+    it('does NOT pass alsoClearEntries=true when companion is ticked AFTER toggling off', async () => {
+      // Pin current read-timing behaviour: the companion checkbox is sampled
+      // at the moment the historyEnabled change event fires. Ticking the
+      // companion AFTER the toggle has no effect on that specific disable
+      // event — the hook has already been called with the value that was
+      // present at event time.
+      //
+      // Intent: documents the "check companion BEFORE toggling" contract so
+      // that a future refactor moving the read to a later microtask would
+      // surface here rather than silently changing UX.
+      const stub = makeStub({ ...DEFAULT_SETTINGS, historyEnabled: true });
+      const onHistoryDisabled = vi.fn();
+      await bindOptionsForm(document, window, stub, onHistoryDisabled);
+
+      const toggle = document.getElementById(FIELD_IDS.historyEnabled) as HTMLInputElement;
+      toggle.checked = false;
+      fire(toggle, 'change');
+      await Promise.resolve();
+
+      // Companion ticked AFTER the event has already fired — too late.
+      (document.getElementById('historyClearOnDisable') as HTMLInputElement).checked = true;
+
+      // Hook was called once, but with the companion's state AT event time (false).
+      expect(onHistoryDisabled).toHaveBeenCalledTimes(1);
+      expect(onHistoryDisabled).toHaveBeenCalledWith(false);
+    });
+
     it('does NOT fire onHistoryDisabled when omitted from bindOptionsForm', async () => {
       // No hook supplied → the controller must not throw when the user
       // toggles off. Defaults still apply (no wipe).

--- a/src/core/popup/__tests__/derive-title.test.ts
+++ b/src/core/popup/__tests__/derive-title.test.ts
@@ -82,6 +82,42 @@ describe('deriveTitleFromUrl — query / fragment stripping', () => {
   });
 });
 
+describe('deriveTitleFromUrl — IDN / punycode and IP addresses', () => {
+  // These cases are currently best-effort: the code runs the raw hostname
+  // through the same pipeline as any ASCII hostname. Tests pin CURRENT
+  // behaviour so a future change (e.g., decoding punycode via Intl, or
+  // rejecting private IP ranges) surfaces here rather than silently drifting.
+  // Note: #196 (combined S3 + real title persistence) may supersede derive-title
+  // for common paths, but IP/IDN URLs will still reach this code for any URL
+  // that lacks a persisted title.
+
+  it('shows punycode hostname as-is (no client-side decode)', () => {
+    // `new URL('http://xn--bcher-kva.example.com/')` exposes the xn-- form.
+    // We pin that shape: future Intl.decodePunycode integration would flip this.
+    expect(deriveTitleFromUrl('http://xn--bcher-kva.example.com/article')).toBe(
+      'xn--bcher-kva.example.com / article',
+    );
+  });
+
+  it('shows IPv4 address as the hostname label', () => {
+    expect(deriveTitleFromUrl('http://192.168.1.1/page')).toBe('192.168.1.1 / page');
+  });
+
+  it('shows IPv4 root URL as bare address (no path)', () => {
+    expect(deriveTitleFromUrl('http://192.168.1.1/')).toBe('192.168.1.1');
+  });
+
+  it('shows IPv6 address including brackets (URL host shape)', () => {
+    // `new URL('http://[::1]/page').hostname` → '[::1]' in the Node/jsdom
+    // runtime. The brackets are part of the URL host component.
+    expect(deriveTitleFromUrl('http://[::1]/page')).toBe('[::1] / page');
+  });
+
+  it('shows IPv6 root URL as bare bracketed address', () => {
+    expect(deriveTitleFromUrl('http://[::1]/')).toBe('[::1]');
+  });
+});
+
 describe('deriveTitleFromUrl — defensive', () => {
   it('returns the raw input string when URL fails to parse', () => {
     // Non-URL strings shouldn't crash the popup; surface what the

--- a/src/core/popup/__tests__/history-section.test.ts
+++ b/src/core/popup/__tests__/history-section.test.ts
@@ -57,8 +57,10 @@ describe('renderHistorySection — disabled state', () => {
     const enableBtn = section.querySelector('button');
     expect(enableBtn).not.toBeNull();
     expect(enableBtn?.textContent).toMatch(/enable/i);
-    // No list element when disabled.
-    expect(section.querySelector('[role="list"]')).toBeNull();
+    // No list element when disabled. Query by tag so the assertion holds
+    // whether the implementation uses an explicit role attribute or relies
+    // on <ul>'s implicit ARIA list role.
+    expect(section.querySelector('ul')).toBeNull();
   });
 
   it('Enable link click invokes onEnableInSettings', () => {
@@ -97,7 +99,9 @@ describe('renderHistorySection — enabled but empty', () => {
     // Critical anti-tautology: list element ABSENT, not "list has 0
     // items" — a broken render path could yield an empty <ul> and we'd
     // never catch it. Forces the implementation to a single render path.
-    expect(section.querySelector('[role="list"]')).toBeNull();
+    // Query by tag so the assertion is not coupled to the explicit role
+    // attribute (works with both implicit and explicit ARIA list role).
+    expect(section.querySelector('ul')).toBeNull();
     // No clear-all button when there's nothing to clear.
     expect(section.querySelector('button')).toBeNull();
   });
@@ -127,7 +131,9 @@ describe('renderHistorySection — enabled with entries', () => {
         onEnableInSettings: vi.fn(),
       }),
     );
-    const list = section.querySelector('[role="list"]');
+    // Query by tag: mutation-resistant to the explicit role attribute being
+    // dropped in favour of <ul>'s implicit ARIA list role.
+    const list = section.querySelector('ul');
     expect(list).not.toBeNull();
     const items = section.querySelectorAll('[role="listitem"]');
     expect(items.length).toBe(2);


### PR DESCRIPTION
## Summary
Folds the 3 NITs deferred from PR #199 (#49 ring). Test-only hardening, zero production change.
- **nit-2**: jsdom-permissive `[role="list"]` -> `querySelector('ul')` (mutation-resistant to implicit-role refactor)
- **nit-3**: pin current `derive-title` behavior for IDN/punycode + IPv4/IPv6 hostnames
- **nit-4**: pin companion-checkbox read-at-event-time contract

Closes #200

## Test plan
- [x] `lint && format:check && test && build` — green, coordinator-verified in worktree (1368 tests pass)
- Mutation evidence per test-bearing NIT: builder-reported (each flips red on a production mutation); not independently re-run by coordinator.

Dispatched via model-tier routing (tier:mid -> sonnet builder).
