### PR TITLE
fix(rsvp-engine): preserve elapsed time on setWpm/seekTo reschedule (#118)

### DIFF
--- a/src/core/rsvp-engine/__tests__/chunk-mode.test.ts
+++ b/src/core/rsvp-engine/__tests__/chunk-mode.test.ts
@@ -786,4 +786,31 @@ describe('createRsvpEngine — chunk mode (chunkSize >= 2)', () => {
       expect(afterProgress.index).toBe(afterProgress.total);
     });
   });
+
+  // Issue #118 — rescheduleRemaining is mode-agnostic and runs for
+  // chunk-mode setWpm too. Pin that elapsed-fraction preservation holds
+  // on the chunk axis (one tick = one chunk), not just word mode.
+  describe('setWpm mid-tick preserves elapsed fraction in chunk mode (#118)', () => {
+    it('halving the cadence mid-chunk fires the next chunk at the preserved remaining slice', () => {
+      const engine = createRsvpEngine({
+        words: ['a', 'b', 'c', 'd'],
+        wpm: 100, // 600 ms/chunk
+        chunkSize: 2,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start(); // chunk 0 [a,b] at t=0, 600 ms beat
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ type: 'chunk', startIndex: 0, endIndex: 1 });
+
+      vi.advanceTimersByTime(300); // 50% through chunk 0
+      engine.setWpm(600); // 100 ms/chunk → remaining = 100 * 0.5 = 50 ms
+
+      vi.advanceTimersByTime(49);
+      expect(events).toHaveLength(1); // not yet — old code waited a fresh full beat
+      vi.advanceTimersByTime(1); // 50 ms after setWpm
+      expect(events).toHaveLength(2);
+      expect(events[1]).toMatchObject({ type: 'chunk', startIndex: 2, endIndex: 3 });
+    });
+  });
 });

--- a/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
+++ b/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
@@ -200,6 +200,48 @@ describe('createRsvpEngine', () => {
       vi.advanceTimersByTime(1); // t=200 → 'b' at the word's true original deadline
       expect(events).toHaveLength(2);
     });
+
+    it('setWpm after resume measures elapsed from the RESUME baseline, not the original emit', () => {
+      const engine = createRsvpEngine({ words: ['a', 'b'], wpm: 300 }); // 200 ms/word
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start(); // 'a' at t=0
+      vi.advanceTimersByTime(100); // 50% through 'a'
+      engine.pause(); // beat cancelled mid-tick
+      engine.resume(); // fresh full beat: baseline resets to resume time
+      vi.advanceTimersByTime(100); // 50% through the RESUMED 200 ms beat
+      engine.setWpm(600); // 100 ms → remaining = 100 * (1 - 0.5) = 50 ms
+      // If the baseline had NOT reset on resume, elapsed would read 200 ms
+      // against the original t=0 emit → fraction clamps to 1 → 'b' immediately.
+      vi.advanceTimersByTime(49);
+      expect(events).toHaveLength(1); // discriminates: stale baseline would already be 2
+      vi.advanceTimersByTime(1);
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual({ type: 'word', index: 1, word: 'b' });
+    });
+
+    it('setWpm mid-tick with punctuation pacing preserves the fraction on the multiplied gap', () => {
+      // 'Hi.' is sentence-final → 1.5× gap. The multiplier must survive the
+      // reschedule on BOTH the fraction denominator and the remaining slice.
+      const engine = createRsvpEngine({
+        words: ['Hi.', 'there'],
+        wpm: 100, // 600 ms base → 'Hi.' gap = 600 * 1.5 = 900 ms
+        punctuationPacing: true,
+      });
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start(); // 'Hi.' at t=0
+      expect(events).toHaveLength(1);
+
+      vi.advanceTimersByTime(450); // 50% through the 900 ms paced gap
+      engine.setWpm(600); // base 100 ms → new paced gap 150 ms → remaining 150 * 0.5 = 75 ms
+
+      vi.advanceTimersByTime(74);
+      expect(events).toHaveLength(1);
+      vi.advanceTimersByTime(1); // 75 ms after setWpm
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual({ type: 'word', index: 1, word: 'there' });
+    });
   });
 
   describe('stop', () => {

--- a/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
+++ b/src/core/rsvp-engine/__tests__/rsvp-engine.test.ts
@@ -136,6 +136,72 @@ describe('createRsvpEngine', () => {
     });
   });
 
+  // Issue #118 — a mid-tick setWpm must preserve the FRACTION of the
+  // current word already displayed, not discard it and restart a full
+  // beat at the new cadence. The old behavior (clearPending + full
+  // scheduleNext) cost up to a full msPerWord of jitter — at low WPM
+  // (the accessibility floor) that is the dominant perceived latency.
+  describe('setWpm mid-tick preserves elapsed fraction (#118)', () => {
+    it('AC#3: 100 wpm, 300 ms elapsed, setWpm(600) → next emission at ~50 ms not 100 ms', () => {
+      const engine = createRsvpEngine({ words: ['a', 'b', 'c'], wpm: 100 }); // 600 ms/word
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start(); // 'a' at t=0, 600 ms beat
+      expect(events).toHaveLength(1);
+
+      vi.advanceTimersByTime(300); // 50% through 'a'
+      engine.setWpm(600); // 100 ms/word → remaining = 100 * (1 - 0.5) = 50 ms
+
+      vi.advanceTimersByTime(49);
+      expect(events).toHaveLength(1); // not yet
+      vi.advanceTimersByTime(1); // 50 ms after setWpm
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual({ type: 'word', index: 1, word: 'b' });
+    });
+
+    it('setWpm near the end of a slow beat fires almost immediately, not a fresh full beat', () => {
+      const engine = createRsvpEngine({ words: ['a', 'b'], wpm: 100 }); // 600 ms/word
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+
+      vi.advanceTimersByTime(599); // 599/600 through 'a'
+      engine.setWpm(600); // remaining ≈ 100 * (1/600) ≈ 0.17 ms
+      vi.advanceTimersByTime(1); // next macrotask
+      expect(events).toHaveLength(2); // 'b' fired ~immediately; old code waited a full 100 ms
+    });
+
+    it('setWpm to the SAME wpm still preserves the in-flight beat (no reset)', () => {
+      const engine = createRsvpEngine({ words: ['a', 'b'], wpm: 300 }); // 200 ms/word
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start();
+
+      vi.advanceTimersByTime(150); // 75% through 'a'
+      engine.setWpm(300); // same cadence → remaining = 200 * 0.25 = 50 ms
+      vi.advanceTimersByTime(49);
+      expect(events).toHaveLength(1);
+      vi.advanceTimersByTime(1); // t = 200 total → 'b'
+      expect(events).toHaveLength(2);
+    });
+
+    it('repeated setWpm measures elapsed from the original emit, not the last reschedule', () => {
+      const engine = createRsvpEngine({ words: ['a', 'b'], wpm: 300 }); // 200 ms/word
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start(); // 'a' at t=0
+
+      vi.advanceTimersByTime(100); // 50% through 'a'
+      engine.setWpm(600); // 100 ms → remaining 50 ms (would fire t=150)
+      vi.advanceTimersByTime(20); // t=120 → fraction now 120/200 = 0.6
+      engine.setWpm(300); // 200 ms → remaining 200 * 0.4 = 80 ms (fires t=200)
+      vi.advanceTimersByTime(79);
+      expect(events).toHaveLength(1);
+      vi.advanceTimersByTime(1); // t=200 → 'b' at the word's true original deadline
+      expect(events).toHaveLength(2);
+    });
+  });
+
   describe('stop', () => {
     it('moves to done and prevents further events', () => {
       const engine = createRsvpEngine({ words: ['a', 'b', 'c'], wpm: 300 });

--- a/src/core/rsvp-engine/__tests__/seekTo.test.ts
+++ b/src/core/rsvp-engine/__tests__/seekTo.test.ts
@@ -292,4 +292,52 @@ describe('seekTo() with snapToSentence', () => {
     expect(engine.state).toBe('done');
     expect(events[events.length - 1]).toEqual({ type: 'done' });
   });
+
+  // Issue #118 — seeking onto the word ALREADY displayed while playing
+  // must preserve the in-flight beat rather than re-emit the word and
+  // restart a full beat (which costs up to a full msPerWord of jitter
+  // and a redundant redraw — visible when the scrubber settles on the
+  // current word). Seeking onto a DIFFERENT word keeps the existing
+  // emit-immediately-at-a-full-beat behavior (a new word earns a full
+  // display beat).
+  describe('seekTo preserves the in-flight beat when targeting the current word (#118)', () => {
+    it('seekTo onto the currently displayed word does not re-emit and keeps the original deadline', () => {
+      const words = ['a', 'b', 'c'];
+      const engine = createRsvpEngine({ words, wpm: 300 }); // 200 ms/word
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start(); // 'a' at t=0; displayed index 0; nextIndex = 1
+      expect(events).toHaveLength(1);
+
+      vi.advanceTimersByTime(120); // 60% through 'a'
+      engine.seekTo(0); // == current displayed word → preserve beat (80 ms left)
+
+      expect(engine.state).toBe('playing');
+      expect(events).toHaveLength(1); // NO duplicate 'a' re-emit
+      vi.advanceTimersByTime(79);
+      expect(events).toHaveLength(1);
+      vi.advanceTimersByTime(1); // t = 200 → 'b' at the word's original deadline
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual({ type: 'word', index: 1, word: 'b' });
+    });
+
+    it('seekTo onto a DIFFERENT word still emits it immediately at a full beat', () => {
+      const words = ['a', 'b', 'c', 'd'];
+      const engine = createRsvpEngine({ words, wpm: 300 }); // 200 ms/word
+      const events: RsvpEvent[] = [];
+      engine.subscribe((e) => events.push(e));
+      engine.start(); // 'a'
+
+      vi.advanceTimersByTime(120);
+      engine.seekTo(2); // different word → emit 'c' now, fresh full beat
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual({ type: 'word', index: 2, word: 'c' });
+
+      vi.advanceTimersByTime(199);
+      expect(events).toHaveLength(2);
+      vi.advanceTimersByTime(1); // full 200 ms beat from the seek
+      expect(events).toHaveLength(3);
+      expect(events[2]).toEqual({ type: 'word', index: 3, word: 'd' });
+    });
+  });
 });

--- a/src/core/rsvp-engine/__tests__/seekToSentence.test.ts
+++ b/src/core/rsvp-engine/__tests__/seekToSentence.test.ts
@@ -316,3 +316,33 @@ describe('unified sentence predicate (#208)', () => {
     expect(events).toEqual([{ type: 'word', index: 3, word: 'Then' }]);
   });
 });
+
+// Issue #118 — seekToSentence delegates to seekTo, so a 'prev' that
+// resolves to the currently-displayed word index now rides the new
+// "preserve the in-flight beat" branch. Pin that transitive behavior:
+// no duplicate emit, original deadline kept.
+describe('seekToSentence onto the current word preserves the beat (#118)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('"prev" landing on the displayed word does not re-emit and keeps the original deadline', () => {
+    const engine = createRsvpEngine({ words: STREAM, wpm: 300 }); // 200 ms/word
+    const events: RsvpEvent[] = [];
+    engine.subscribe((e) => events.push(e));
+    engine.start(); // 'Hi.' at index 0, t=0; nextIndex = 1; displayed = 0
+
+    vi.advanceTimersByTime(120); // 60% through 'Hi.'
+    // cur = 1; 'Hi.' is sentence-final so the current sentence start is 1,
+    // which equals cur → back up one sentence to index 0 == the displayed
+    // word → preserve branch fires.
+    engine.seekToSentence('prev');
+
+    expect(engine.state).toBe('playing');
+    expect(events).toHaveLength(1); // no duplicate 'Hi.'
+    vi.advanceTimersByTime(79);
+    expect(events).toHaveLength(1);
+    vi.advanceTimersByTime(1); // t=200 → 'How' at the original deadline
+    expect(events).toHaveLength(2);
+    expect(events[1]).toEqual({ type: 'word', index: 1, word: 'How' });
+  });
+});

--- a/src/core/rsvp-engine/rsvp-engine.ts
+++ b/src/core/rsvp-engine/rsvp-engine.ts
@@ -320,6 +320,16 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
   // Documented on `progress()` so consumers know the axis change.
   let nextIndex = 0;
   let timerId: ReturnType<typeof setTimeout> | null = null;
+  // Issue #118 — the wall-clock time the current word's gap began and the
+  // full gap it was scheduled for. Together they let `setWpm` reschedule the
+  // REMAINING slice of the in-flight gap (preserving the fraction already
+  // displayed) instead of restarting a full beat at the new cadence — the
+  // old behavior cost up to a full msPerWord of jitter, dominant at low WPM.
+  // Both are (re)set on every emit via `scheduleNext`; the baseline is NOT
+  // updated by `rescheduleRemaining`, so repeated `setWpm` calls measure
+  // elapsed against the word's true display start, not the last reschedule.
+  let wordStartedAt: number | null = null;
+  let wordFullDelay = 0;
   let seekInFlight = false;
   // Word just emitted to subscribers — drives Safari-style pacing for the
   // gap BEFORE the next word. In chunk mode this is the chunk's LAST
@@ -355,12 +365,39 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
     return calculatePunctuationDelay(lastEmittedWord, base);
   };
 
-  const scheduleNext = (): void => {
+  const armTimer = (delay: number): void => {
     timerId = setTimeout(() => {
       timerId = null;
       if (state !== RSVP_STATE.PLAYING) return;
       tick();
-    }, nextDelay());
+    }, delay);
+  };
+
+  const scheduleNext = (): void => {
+    const delay = nextDelay();
+    // Record the gap baseline at emit time so a mid-gap `setWpm` can
+    // preserve the elapsed fraction (issue #118).
+    wordStartedAt = Date.now();
+    wordFullDelay = delay;
+    armTimer(delay);
+  };
+
+  // Issue #118 — reschedule the in-flight gap at the CURRENT cadence,
+  // preserving the fraction of the current word already displayed. Replaces
+  // the prior `clearPending()` + full `scheduleNext()`, which discarded the
+  // elapsed time and restarted a whole beat. `wordStartedAt` / `wordFullDelay`
+  // are left at the word's original emit baseline so repeated reschedules
+  // accumulate correctly rather than resetting the clock each call.
+  const rescheduleRemaining = (): void => {
+    if (timerId === null || wordStartedAt === null) {
+      scheduleNext();
+      return;
+    }
+    const elapsed = Date.now() - wordStartedAt;
+    const fraction = wordFullDelay > 0 ? Math.min(1, Math.max(0, elapsed / wordFullDelay)) : 0;
+    const remaining = Math.max(0, nextDelay() * (1 - fraction));
+    clearPending();
+    armTimer(remaining);
   };
 
   // Total ticks remaining: in word mode, `words.length`; in chunk mode,
@@ -539,11 +576,10 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
       assertValidWpm(next);
       wpm = next;
       // Reschedule any pending tick at the new cadence so the next emission
-      // reflects the change. The currently displayed word's remaining time
-      // is reset — acceptable for a control-surface live update.
+      // reflects the change, preserving the fraction of the current word
+      // already displayed (issue #118) rather than restarting a full beat.
       if (state === RSVP_STATE.PLAYING && timerId !== null) {
-        clearPending();
-        scheduleNext();
+        rescheduleRemaining();
       }
     },
     setPunctuationPacing(enabled: boolean): void {
@@ -721,12 +757,24 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
         return;
       }
 
+      // Word currently on screen while playing (the last-emitted word).
+      // Captured before `nextIndex` is overwritten so the #118 preserve
+      // check below can compare the seek target against it.
+      const displayedIndex = nextIndex - 1;
       nextIndex = target;
       seekInFlight = true;
       try {
         if (state === RSVP_STATE.PLAYING) {
-          clearPending();
-          tick();
+          if (target === displayedIndex && timerId !== null) {
+            // Issue #118 — seeking onto the word already displayed: leave the
+            // in-flight beat running (no re-emit, no reschedule) instead of
+            // restarting a full beat. Restore `nextIndex` to the post-emit
+            // invariant (next word to emit = target + 1).
+            nextIndex = target + 1;
+          } else {
+            clearPending();
+            tick();
+          }
         } else if (state === RSVP_STATE.PAUSED) {
           emit({ type: 'word', index: target, word: words[target] });
           // Keep `lastEmittedWord` in sync with the just-emitted word so that

--- a/src/core/rsvp-engine/rsvp-engine.ts
+++ b/src/core/rsvp-engine/rsvp-engine.ts
@@ -388,6 +388,16 @@ export function createRsvpEngine(options: RsvpEngineOptions): RsvpEngine {
   // elapsed time and restarted a whole beat. `wordStartedAt` / `wordFullDelay`
   // are left at the word's original emit baseline so repeated reschedules
   // accumulate correctly rather than resetting the clock each call.
+  //
+  // Clock assumption: elapsed is measured against `Date.now()` (wall clock),
+  // while the gap is armed via `setTimeout` (the runtime's macrotask clock).
+  // These are coherent in the foreground. In a backgrounded/suspended tab —
+  // where `setTimeout` is throttled but the wall clock keeps advancing — the
+  // fraction can read high and is clamped to `[0,1]`, so the worst case is a
+  // word firing on the next (already-throttled) tick. That is strictly no
+  // worse than the old full-beat-restart and is invisible to a reader who
+  // isn't looking at a background tab; the engine lives in `src/core` and
+  // cannot read `document.visibilityState` to gate on foreground. Accepted.
   const rescheduleRemaining = (): void => {
     if (timerId === null || wordStartedAt === null) {
       scheduleNext();


### PR DESCRIPTION
## Summary

Fixes #118 — a mid-tick `setWpm` discarded the elapsed time on the current word and restarted a full beat at the new cadence, costing up to a full `msPerWord` of jitter. Dominant at low WPM (the neurodivergent-accessibility floor). Now reschedules only the **remaining** slice, preserving the elapsed **fraction**.

## What changed

- **`setWpm` mid-tick** preserves the fraction of the current word already shown. Mechanism: `scheduleNext` records the gap's emit-time baseline (`wordStartedAt`, `wordFullDelay`); `rescheduleRemaining()` arms the timer for `nextDelay() * (1 - elapsedFraction)`, clamped `>= 0`. Baseline is **not** reset on reschedule → repeated `setWpm` calls accumulate against the word's true display start.
- **`seekTo` onto the currently displayed word** while playing preserves the in-flight beat (no re-emit, no restart). Seeking onto a **different** word keeps the existing emit-immediately-at-full-beat behavior — a new word earns a full beat.

## Model note (AC#3)

Elapsed-**fraction** preservation, not absolute-ms subtraction. AC#3: 100 WPM (600 ms), 300 ms elapsed, `setWpm(600)` (100 ms) → next at ~50 ms = `100*(1-0.5)`. Absolute subtraction would give `100-300`→0 ms, contradicting AC#3.

## Out of scope (surgical, Karpathy #3)

`setPunctuationPacing` / `setChunkSize` share the same `clearPending`+full-reschedule shape but were not in the issue AC and their existing tests pin full-beat semantics. Flagged, not touched.

## Acceptance criteria

- [x] `setWpm()` mid-tick preserves elapsed time on the current word
- [x] `seekTo()` onto the displayed word does NOT reset its elapsed beat (per maintainer decision: seekTo-to-current preserves; seekTo-to-different keeps full beat)
- [x] Test: 100 WPM, 300 ms elapsed, `setWpm(600)` → ~50 ms not 100 ms
- [x] Tests for both `setWpm` and `seekTo` reschedule

## Test plan

- [x] `npm test` — 1387 passed (incl. 9 #118 tests; 4 added from ring review) (5 new: 4 setWpm fraction + 2 seekTo; ran RED before impl, GREEN after)
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — built

🤖 Generated with [Claude Code](https://claude.com/claude-code)

