### PR TITLE
feat(#196): SW-owned reading-position store (setAccessLevel gate, sender-bound RPCs)

### DIFF
--- a/src/chrome/__tests__/manifest.test.ts
+++ b/src/chrome/__tests__/manifest.test.ts
@@ -10,6 +10,19 @@ import manifest from '../manifest';
  * binary lands separately (see fonts/README.md); the manifest contract
  * MUST be in place first so #27/#28 don't have to touch this surface.
  */
+/**
+ * #196 — `minimum_chrome_version` is pinned to the `local.setAccessLevel`
+ * floor (Chrome 140 per MDN browser-compat-data). This is a security-load-
+ * bearing merge precondition: below the floor the gate API is absent and the
+ * cross-origin reading-history enumeration threat would reopen. A regression
+ * that drops or downgrades this string must fail CI, not ship green.
+ */
+describe('manifest — minimum_chrome_version floor (#196)', () => {
+  it('pins minimum_chrome_version to the local.setAccessLevel floor (140)', () => {
+    expect(manifest.minimum_chrome_version).toBe('140');
+  });
+});
+
 describe('manifest — web_accessible_resources for fonts (#10)', () => {
   const wars = manifest.web_accessible_resources ?? [];
   const fontEntry = wars.find((entry) =>

--- a/src/chrome/background/__tests__/route.test.ts
+++ b/src/chrome/background/__tests__/route.test.ts
@@ -213,6 +213,39 @@ describe('route — activate-reader handler', () => {
     expect(deps.dispatchActivation).not.toHaveBeenCalled();
   });
 
+  // #196 — route delegates the six position types to handlePosition before
+  // the activate-reader branch. (In this unit env the default position store
+  // is the fail-closed null store, since no chrome.storage.local is present.)
+  it('dispatches popup position/list (returns ok with the default store)', async () => {
+    const { promise, sendResponse } = waitForResponse();
+    route(
+      { type: 'position/list' },
+      popupSender(),
+      sendResponse,
+      makeDeps({ ok: true, data: undefined }),
+    );
+    const resp = await promise;
+    expect(resp.ok).toBe(true);
+  });
+
+  it('dispatches CS position/get bound to sender.url (returns ok)', async () => {
+    const csSender: chrome.runtime.MessageSender = {
+      id: OWN_ID,
+      url: 'https://example.com/article',
+      tab: { id: 7 } as chrome.tabs.Tab,
+      frameId: 0,
+    };
+    const { promise, sendResponse } = waitForResponse();
+    route(
+      { type: 'position/get' },
+      csSender,
+      sendResponse,
+      makeDeps({ ok: true, data: undefined }),
+    );
+    const resp = await promise;
+    expect(resp.ok).toBe(true);
+  });
+
   it('returns invalid-payload for unknown message types', () => {
     const sendResponse = vi.fn();
     const deps = makeDeps({ ok: true, data: undefined });

--- a/src/chrome/background/index.ts
+++ b/src/chrome/background/index.ts
@@ -39,6 +39,17 @@
  * - `docs/superpowers/specs/2026-05-08-messaging-contract.md`
  */
 
+// Side-effect import: #196 SW access-gate. Evaluating this module calls
+// `chrome.storage.local.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' })`
+// synchronously at top-level on EVERY SW wake (before the first await), the
+// same MV3 discipline as listener registration — so the `local` area is
+// re-gated against content scripts on every startup regardless of whether the
+// access level persists across restarts. Feature-detected + fail-closed; see
+// `./position/access-gate.ts`. Imported FIRST so the gate is asserted ahead of
+// any message handling. See spec
+// `docs/superpowers/specs/2026-06-11-position-store-service-worker.md`.
+import './position/access-gate';
+
 import { dispatchActivation } from './activation/dispatch';
 import { handleOnMessage } from './messaging/on-message';
 import { route } from './route';

--- a/src/chrome/background/messaging/__tests__/on-message.test.ts
+++ b/src/chrome/background/messaging/__tests__/on-message.test.ts
@@ -187,4 +187,64 @@ describe('handleOnMessage — sender-provenance validation', () => {
 
     expect(route).toHaveBeenCalledWith(msg, sender, sendResponse);
   });
+
+  // #196 — position RPC provenance. The gate is the type-confusion-closing
+  // layer: a CS-only type from a popup sender (and vice-versa) is rejected
+  // BEFORE the router, for all six types.
+  const CS_POSITION = ['position/get', 'position/set', 'position/clear'] as const;
+  const POPUP_POSITION = ['position/list', 'position/delete', 'position/clear-all'] as const;
+
+  it.each(CS_POSITION)('accepts CS-only %s from a content-script sender', async (type) => {
+    const { handleOnMessage } = await import('../on-message');
+    const route = vi.fn();
+    const handled = handleOnMessage({ type }, contentScriptSender(), vi.fn(), { route });
+    expect(handled).toBe(true);
+    expect(route).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(CS_POSITION)('REJECTS CS-only %s from a popup sender', async (type) => {
+    const { handleOnMessage } = await import('../on-message');
+    const route = vi.fn();
+    const sendResponse = vi.fn();
+    handleOnMessage({ type }, popupSender(), sendResponse, { route });
+    expect(route).not.toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: { kind: 'sender-shape-mismatch', expected: 'content-script', got: 'popup' },
+    });
+  });
+
+  it.each(POPUP_POSITION)('accepts popup-only %s from a popup sender', async (type) => {
+    const { handleOnMessage } = await import('../on-message');
+    const route = vi.fn();
+    const handled = handleOnMessage({ type }, popupSender(), vi.fn(), { route });
+    expect(handled).toBe(true);
+    expect(route).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(POPUP_POSITION)('REJECTS popup-only %s from a content-script sender', async (type) => {
+    const { handleOnMessage } = await import('../on-message');
+    const route = vi.fn();
+    const sendResponse = vi.fn();
+    handleOnMessage({ type }, contentScriptSender(), sendResponse, { route });
+    expect(route).not.toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: { kind: 'sender-shape-mismatch', expected: 'popup', got: 'content-script' },
+    });
+  });
+
+  // Fail-closed default: a type in NEITHER provenance set is rejected, not
+  // forwarded to the router by sender shape alone.
+  it('rejects a type in neither provenance set (fail-closed default)', async () => {
+    const { handleOnMessage } = await import('../on-message');
+    const route = vi.fn();
+    const sendResponse = vi.fn();
+    const handled = handleOnMessage({ type: 'totally-unknown' }, popupSender(), sendResponse, {
+      route,
+    });
+    expect(handled).toBe(false);
+    expect(route).not.toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({ ok: false, error: { kind: 'invalid-payload' } });
+  });
 });

--- a/src/chrome/background/messaging/__tests__/on-message.test.ts
+++ b/src/chrome/background/messaging/__tests__/on-message.test.ts
@@ -234,6 +234,51 @@ describe('handleOnMessage — sender-provenance validation', () => {
     });
   });
 
+  // #196 ring finding #2 — the OPTIONS page opens in a real tab, so its
+  // sender has `tab.id` defined + `frameId === 0` (looks like a CS by shape)
+  // but a `chrome-extension://` origin. It MUST be classified as a trusted
+  // (popup-shaped) sender so its popup-only `position/clear-all` RPC is
+  // accepted, and MUST still be refused for CS-only types.
+  function optionsTabSender(): chrome.runtime.MessageSender {
+    return {
+      id: OWN_ID,
+      url: `chrome-extension://${OWN_ID}/src/chrome/options/index.html`,
+      tab: { id: 9 } as chrome.tabs.Tab,
+      frameId: 0,
+    };
+  }
+
+  it.each(POPUP_POSITION)(
+    'accepts popup-only %s from the options page (extension-origin, in a tab)',
+    async (type) => {
+      const { handleOnMessage } = await import('../on-message');
+      const route = vi.fn();
+      const handled = handleOnMessage({ type }, optionsTabSender(), vi.fn(), { route });
+      expect(handled).toBe(true);
+      expect(route).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(CS_POSITION)(
+    'REJECTS CS-only %s from the options page (trusted, not a CS)',
+    async (type) => {
+      const { handleOnMessage } = await import('../on-message');
+      const route = vi.fn();
+      const sendResponse = vi.fn();
+      handleOnMessage({ type }, optionsTabSender(), sendResponse, { route });
+      expect(route).not.toHaveBeenCalled();
+      expect(sendResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: false,
+          error: expect.objectContaining({
+            kind: 'sender-shape-mismatch',
+            expected: 'content-script',
+          }),
+        }),
+      );
+    },
+  );
+
   // Fail-closed default: a type in NEITHER provenance set is rejected, not
   // forwarded to the router by sender shape alone.
   it('rejects a type in neither provenance set (fail-closed default)', async () => {

--- a/src/chrome/background/messaging/on-message.ts
+++ b/src/chrome/background/messaging/on-message.ts
@@ -85,14 +85,32 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+/**
+ * A trusted extension page (popup / options / welcome). #196 — the trust
+ * signal is the Chrome-populated `sender.url` ORIGIN, not tab-absence: the
+ * browser-action popup has no `sender.tab`, but the OPTIONS page opens in a
+ * real tab (so `sender.tab.id` is defined), and classifying it by tab-presence
+ * alone mis-labels it as a content script — which would reject its popup-only
+ * `position/clear-all` RPC at the gate (ring security finding #2). A content
+ * script injected into a web page always has an `http(s)` `sender.url`; a CS
+ * cannot forge a `chrome-extension://` origin (`sender.url` is set by Chrome,
+ * not the sender — spec §Sender-URL Binding), so this is a safe trust signal.
+ */
+function isExtensionPageSender(sender: chrome.runtime.MessageSender): boolean {
+  return typeof sender.url === 'string' && sender.url.startsWith('chrome-extension://');
+}
+
 function isPopupShape(sender: chrome.runtime.MessageSender): boolean {
-  // Popup messages come from an extension page; no `sender.tab`.
-  return sender.tab === undefined;
+  // Trusted extension page: no `sender.tab` (browser-action popup) OR an
+  // extension-origin sender (options page in a tab).
+  return sender.tab === undefined || isExtensionPageSender(sender);
 }
 
 function isContentScriptShape(sender: chrome.runtime.MessageSender): boolean {
-  // Content-script messages have a tab id AND must be from the top frame.
-  return sender.tab?.id !== undefined && sender.frameId === 0;
+  // Content-script messages have a tab id AND must be from the top frame AND
+  // must NOT be an extension page (an extension page in a tab is trusted, not
+  // a CS — exclude it so its popup-only RPCs aren't mis-gated as CS-only).
+  return !isExtensionPageSender(sender) && sender.tab?.id !== undefined && sender.frameId === 0;
 }
 
 /**

--- a/src/chrome/background/messaging/on-message.ts
+++ b/src/chrome/background/messaging/on-message.ts
@@ -34,6 +34,10 @@ const POPUP_ONLY_TYPES = new Set<string>([
   'activate-reader',
   'extract-summary',
   'restricted-url-probe',
+  // #196 — popup-only position RPCs (history management). SSOT in
+  // `core/messaging/types.ts` so gate membership and handler wiring cannot
+  // drift apart (spec §"Gate is allowlist, registered atomically").
+  ...POPUP_POSITION_TYPES,
 ]);
 
 /**
@@ -41,9 +45,16 @@ const POPUP_ONLY_TYPES = new Set<string>([
  * CS→SW signals). Listed here so the gate refuses popup-shaped senders
  * for these types.
  */
-const CS_ONLY_TYPES = new Set<string>(['cs-progress', 'overlay-state']);
+const CS_ONLY_TYPES = new Set<string>([
+  'cs-progress',
+  'overlay-state',
+  // #196 — content-script-only position RPCs (sender-bound; no `url` in wire
+  // shape). SSOT in `core/messaging/types.ts`.
+  ...CS_POSITION_TYPES,
+]);
 
 import type { ActivationError } from '../activation/types';
+import { CS_POSITION_TYPES, POPUP_POSITION_TYPES } from '../../../core/messaging/types';
 
 export type OnMessageError =
   | { kind: 'sender-rejected' }
@@ -135,6 +146,16 @@ export function handleOnMessage(
       ok: false,
       error: { kind: 'sender-shape-mismatch', expected: 'content-script', got },
     });
+    return false;
+  }
+
+  // 3b. Fail-closed default (#196, spec §"Gate is allowlist, registered
+  //     atomically"). A type in NEITHER provenance set previously reached the
+  //     router by sender shape alone — so an accidentally-omitted position
+  //     type would route ungated. Reject unknown types here so an omitted
+  //     gate-registration fails closed (invalid-payload) instead of leaking.
+  if (!POPUP_ONLY_TYPES.has(msg.type) && !CS_ONLY_TYPES.has(msg.type)) {
+    sendResponse({ ok: false, error: { kind: 'invalid-payload' } });
     return false;
   }
 

--- a/src/chrome/background/position/__tests__/access-gate.test.ts
+++ b/src/chrome/background/position/__tests__/access-gate.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { applyLocalAccessGate } from '../access-gate';
+
+interface LocalStub {
+  setAccessLevel?: ReturnType<typeof vi.fn<(opts: { accessLevel: string }) => Promise<void>>>;
+  get: ReturnType<typeof vi.fn<(keys: string[]) => Promise<Record<string, unknown>>>>;
+}
+
+function makeLocal(withSetAccessLevel: boolean): LocalStub {
+  const local: LocalStub = {
+    get: vi.fn(async () => ({})),
+  };
+  if (withSetAccessLevel) {
+    local.setAccessLevel = vi.fn(async () => undefined);
+  }
+  return local;
+}
+
+describe('applyLocalAccessGate — setAccessLevel feature-detect + fail-closed', () => {
+  it('calls setAccessLevel exactly once with TRUSTED_CONTEXTS and returns true', () => {
+    const local = makeLocal(true);
+    const enabled = applyLocalAccessGate(local as unknown as chrome.storage.LocalStorageArea);
+
+    expect(enabled).toBe(true);
+    expect(local.setAccessLevel).toHaveBeenCalledTimes(1);
+    expect(local.setAccessLevel).toHaveBeenCalledWith({ accessLevel: 'TRUSTED_CONTEXTS' });
+  });
+
+  it('returns false and does NOT throw when setAccessLevel is absent (fail-closed)', () => {
+    const local = makeLocal(false);
+    let enabled: boolean | undefined;
+    expect(() => {
+      enabled = applyLocalAccessGate(local as unknown as chrome.storage.LocalStorageArea);
+    }).not.toThrow();
+    expect(enabled).toBe(false);
+  });
+
+  it('returns false when the local area itself is undefined', () => {
+    expect(applyLocalAccessGate(undefined)).toBe(false);
+  });
+
+  it('issues setAccessLevel BEFORE any storage access (call ordering)', async () => {
+    const local = makeLocal(true);
+    applyLocalAccessGate(local as unknown as chrome.storage.LocalStorageArea);
+    // Simulate the store's first storage op happening after the gate.
+    await local.get(['position-index']);
+
+    const sal = local.setAccessLevel;
+    if (!sal) throw new Error('test: setAccessLevel missing');
+    const gateOrder = sal.mock.invocationCallOrder[0];
+    const getOrder = local.get.mock.invocationCallOrder[0];
+    expect(gateOrder).toBeLessThan(getOrder);
+  });
+
+  it('swallows a setAccessLevel rejection without throwing synchronously', () => {
+    const local = makeLocal(true);
+    const sal = local.setAccessLevel;
+    if (!sal) throw new Error('test: setAccessLevel missing');
+    sal.mockImplementationOnce(() => Promise.reject(new Error('boom')));
+    expect(() =>
+      applyLocalAccessGate(local as unknown as chrome.storage.LocalStorageArea),
+    ).not.toThrow();
+  });
+});

--- a/src/chrome/background/position/__tests__/access-gate.test.ts
+++ b/src/chrome/background/position/__tests__/access-gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { applyLocalAccessGate } from '../access-gate';
+import { applyLocalAccessGate, positionPersistenceEnabled } from '../access-gate';
 
 interface LocalStub {
   setAccessLevel?: ReturnType<typeof vi.fn<(opts: { accessLevel: string }) => Promise<void>>>;
@@ -17,48 +17,88 @@ function makeLocal(withSetAccessLevel: boolean): LocalStub {
 }
 
 describe('applyLocalAccessGate — setAccessLevel feature-detect + fail-closed', () => {
-  it('calls setAccessLevel exactly once with TRUSTED_CONTEXTS and returns true', () => {
+  it('calls setAccessLevel exactly once with TRUSTED_CONTEXTS and enables persistence on resolve', async () => {
     const local = makeLocal(true);
-    const enabled = applyLocalAccessGate(local as unknown as chrome.storage.LocalStorageArea);
+    const enabled = await applyLocalAccessGate(local as unknown as chrome.storage.LocalStorageArea);
 
     expect(enabled).toBe(true);
+    expect(positionPersistenceEnabled()).toBe(true);
     expect(local.setAccessLevel).toHaveBeenCalledTimes(1);
     expect(local.setAccessLevel).toHaveBeenCalledWith({ accessLevel: 'TRUSTED_CONTEXTS' });
   });
 
-  it('returns false and does NOT throw when setAccessLevel is absent (fail-closed)', () => {
+  it('disables persistence and does NOT throw when setAccessLevel is absent (fail-closed)', async () => {
     const local = makeLocal(false);
     let enabled: boolean | undefined;
-    expect(() => {
-      enabled = applyLocalAccessGate(local as unknown as chrome.storage.LocalStorageArea);
-    }).not.toThrow();
+    await expect(
+      (async () => {
+        enabled = await applyLocalAccessGate(local as unknown as chrome.storage.LocalStorageArea);
+      })(),
+    ).resolves.toBeUndefined();
     expect(enabled).toBe(false);
+    expect(positionPersistenceEnabled()).toBe(false);
   });
 
-  it('returns false when the local area itself is undefined', () => {
-    expect(applyLocalAccessGate(undefined)).toBe(false);
+  it('disables persistence when the local area itself is undefined', async () => {
+    await expect(applyLocalAccessGate(undefined)).resolves.toBe(false);
+    expect(positionPersistenceEnabled()).toBe(false);
   });
 
-  it('issues setAccessLevel BEFORE any storage access (call ordering)', async () => {
-    const local = makeLocal(true);
-    applyLocalAccessGate(local as unknown as chrome.storage.LocalStorageArea);
-    // Simulate the store's first storage op happening after the gate.
-    await local.get(['position-index']);
-
-    const sal = local.setAccessLevel;
-    if (!sal) throw new Error('test: setAccessLevel missing');
-    const gateOrder = sal.mock.invocationCallOrder[0];
-    const getOrder = local.get.mock.invocationCallOrder[0];
-    expect(gateOrder).toBeLessThan(getOrder);
-  });
-
-  it('swallows a setAccessLevel rejection without throwing synchronously', () => {
+  // Ring security finding #1 — the regression test that was "impossible by
+  // construction" under presence-detection. A present-but-REJECTING
+  // setAccessLevel must leave persistence DISABLED (fail-closed), not enabled.
+  it('FAIL-CLOSED on a setAccessLevel runtime rejection — persistence stays disabled, no throw', async () => {
     const local = makeLocal(true);
     const sal = local.setAccessLevel;
     if (!sal) throw new Error('test: setAccessLevel missing');
     sal.mockImplementationOnce(() => Promise.reject(new Error('boom')));
-    expect(() =>
-      applyLocalAccessGate(local as unknown as chrome.storage.LocalStorageArea),
-    ).not.toThrow();
+
+    const enabled = await applyLocalAccessGate(local as unknown as chrome.storage.LocalStorageArea);
+
+    expect(enabled).toBe(false);
+    expect(positionPersistenceEnabled()).toBe(false);
+  });
+
+  // Ring re-review — sync-throw path must fail closed, not crash SW startup.
+  it('FAIL-CLOSED + no throw when setAccessLevel throws SYNCHRONOUSLY', async () => {
+    const local = makeLocal(true);
+    const sal = local.setAccessLevel;
+    if (!sal) throw new Error('test: setAccessLevel missing');
+    sal.mockImplementationOnce(() => {
+      throw new Error('area locked');
+    });
+
+    const enabled = await applyLocalAccessGate(local as unknown as chrome.storage.LocalStorageArea);
+
+    expect(enabled).toBe(false);
+    expect(positionPersistenceEnabled()).toBe(false);
+  });
+
+  it('issues setAccessLevel SYNCHRONOUSLY (call-ordering: before the returned promise resolves)', () => {
+    const local = makeLocal(true);
+    const p = applyLocalAccessGate(local as unknown as chrome.storage.LocalStorageArea);
+    // The CALL is synchronous — observable before we ever await the result.
+    expect(local.setAccessLevel).toHaveBeenCalledTimes(1);
+    return p; // settle to avoid an unhandled promise.
+  });
+
+  it('enables persistence only AFTER resolution — never on mere presence', async () => {
+    const local = makeLocal(true);
+    let resolveCall: (() => void) | undefined;
+    local.setAccessLevel?.mockImplementationOnce(
+      () =>
+        new Promise<void>((res) => {
+          resolveCall = () => res();
+        }),
+    );
+
+    const gatePromise = applyLocalAccessGate(local as unknown as chrome.storage.LocalStorageArea);
+    // Call issued, but not yet resolved → persistence must still be disabled.
+    expect(local.setAccessLevel).toHaveBeenCalledTimes(1);
+    expect(positionPersistenceEnabled()).toBe(false);
+
+    resolveCall?.();
+    await gatePromise;
+    expect(positionPersistenceEnabled()).toBe(true);
   });
 });

--- a/src/chrome/background/position/__tests__/handlers.test.ts
+++ b/src/chrome/background/position/__tests__/handlers.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handlePosition, type PositionResponse } from '../handlers';
+import {
+  createReadingPositionStore,
+  positionKey,
+  type StorageAdapter,
+  type ReadingPositionStore,
+} from '../../../../core/storage/reading-position';
+
+const OWN_ID = 'abcdefghijklmnopabcdefghijklmnop';
+
+function spyAdapter() {
+  const map = new Map<string, unknown>();
+  const adapter: StorageAdapter = {
+    get: vi.fn(async (keys: string[]) => {
+      const out: Record<string, unknown> = {};
+      for (const k of keys) if (map.has(k)) out[k] = map.get(k);
+      return out;
+    }),
+    set: vi.fn(async (items: Record<string, unknown>) => {
+      for (const [k, v] of Object.entries(items)) map.set(k, v);
+    }),
+    remove: vi.fn(async (keys: string[]) => {
+      for (const k of keys) map.delete(k);
+    }),
+  };
+  return { adapter, map };
+}
+
+/** Resolve a position key, throwing on non-canonicalizable input (test helper). */
+function key(url: string): string {
+  const k = positionKey(url);
+  if (k === null) throw new Error(`test: ${url} did not canonicalize`);
+  return k;
+}
+
+function seed(map: Map<string, unknown>, url: string, wordIndex: number, totalWords: number): void {
+  const k = key(url);
+  map.set(k, { schemaVersion: 1, wordIndex, totalWords, lastReadAt: 1000 });
+  const idx = (map.get('position-index') as string[] | undefined) ?? [];
+  map.set('position-index', [...idx, k]);
+}
+
+function csSender(url: string | undefined): chrome.runtime.MessageSender {
+  return { id: OWN_ID, url, tab: { id: 7 } as chrome.tabs.Tab, frameId: 0 };
+}
+function popupSender(): chrome.runtime.MessageSender {
+  return { id: OWN_ID, url: `chrome-extension://${OWN_ID}/src/chrome/popup/index.html` };
+}
+
+function makeStoreOver(adapter: StorageAdapter): ReadingPositionStore {
+  return createReadingPositionStore({ adapter, now: () => 2000 });
+}
+
+async function call(
+  msg: Record<string, unknown> & { type: string },
+  sender: chrome.runtime.MessageSender,
+  store: ReadingPositionStore,
+): Promise<{ handled: boolean; resp: PositionResponse | undefined }> {
+  let resp: PositionResponse | undefined;
+  const sendResponse = (r: PositionResponse): void => {
+    resp = r;
+  };
+  const handled = handlePosition(msg, sender, sendResponse, { store });
+  // handlers resolve async; flush microtasks
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+  return { handled, resp };
+}
+
+describe('handlePosition — sender.url binding (the security invariant)', () => {
+  const SENDER_URL = 'https://sender.example/article';
+  const FORGED_URL = 'https://victim.example/secret';
+
+  it('MANDATORY forged-URL shape: position/get returns the SENDER record, NOT the forged one, and never touches the forged key', async () => {
+    const { adapter, map } = spyAdapter();
+    seed(map, SENDER_URL, 11, 200);
+    seed(map, FORGED_URL, 99, 500);
+    const store = makeStoreOver(adapter);
+
+    // CS sends position/get from sender.url===SENDER_URL, but smuggles a
+    // payload.url===FORGED_URL. CS wire shape has no url field — the handler
+    // MUST ignore it and bind to sender.url.
+    const { resp } = await call(
+      { type: 'position/get', url: FORGED_URL },
+      csSender(SENDER_URL),
+      store,
+    );
+
+    expect(resp?.ok).toBe(true);
+    if (!resp?.ok) throw new Error('unreachable');
+    // response IS the sender's record
+    expect(resp.data).toMatchObject({ wordIndex: 11, totalWords: 200 });
+    // AND is NOT the forged record
+    expect(resp.data).not.toMatchObject({ wordIndex: 99 });
+    // AND the forged key was never read or written
+    const forgedKey = key(FORGED_URL);
+    const touchedForged = (adapter.get as ReturnType<typeof vi.fn>).mock.calls.some(
+      (args) => Array.isArray(args[0]) && args[0].includes(forgedKey),
+    );
+    expect(touchedForged).toBe(false);
+    expect(adapter.set).not.toHaveBeenCalled();
+    expect(adapter.remove).not.toHaveBeenCalled();
+  });
+
+  it('position/set binds to sender.url, ignoring any smuggled payload url', async () => {
+    const { adapter, map } = spyAdapter();
+    const store = makeStoreOver(adapter);
+    await call(
+      { type: 'position/set', url: FORGED_URL, wordIndex: 3, totalWords: 80 },
+      csSender(SENDER_URL),
+      store,
+    );
+    // Wrote under the sender key, not the forged key.
+    expect(map.has(key(SENDER_URL))).toBe(true);
+    expect(map.has(key(FORGED_URL))).toBe(false);
+  });
+
+  it('position/clear binds to sender.url', async () => {
+    const { adapter, map } = spyAdapter();
+    seed(map, SENDER_URL, 11, 200);
+    seed(map, FORGED_URL, 99, 500);
+    const store = makeStoreOver(adapter);
+    await call({ type: 'position/clear', url: FORGED_URL }, csSender(SENDER_URL), store);
+    expect(map.has(key(SENDER_URL))).toBe(false);
+    expect(map.has(key(FORGED_URL))).toBe(true);
+  });
+});
+
+describe('handlePosition — null/opaque-origin reject, zero writes', () => {
+  it.each([
+    ['undefined sender.url', undefined],
+    ['about:blank', 'about:blank'],
+    ['data: URL', 'data:text/html,hi'],
+    ['chrome scheme', 'chrome://settings'],
+  ])('rejects %s for position/set with no write', async (_label, url) => {
+    const { adapter } = spyAdapter();
+    const store = makeStoreOver(adapter);
+    const { resp } = await call(
+      { type: 'position/set', wordIndex: 1, totalWords: 10 },
+      csSender(url),
+      store,
+    );
+    expect(resp).toEqual({ ok: false, error: { kind: 'invalid-payload' } });
+    expect(adapter.set).not.toHaveBeenCalled();
+    expect(adapter.remove).not.toHaveBeenCalled();
+  });
+
+  it('rejects opaque-origin for position/get with no read', async () => {
+    const { adapter } = spyAdapter();
+    const store = makeStoreOver(adapter);
+    const { resp } = await call({ type: 'position/get' }, csSender('about:blank'), store);
+    expect(resp).toEqual({ ok: false, error: { kind: 'invalid-payload' } });
+    expect(adapter.get).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid position/set payload with no write', async () => {
+    const { adapter } = spyAdapter();
+    const store = makeStoreOver(adapter);
+    const { resp } = await call(
+      { type: 'position/set', wordIndex: 'nope' },
+      csSender('https://ok.example/'),
+      store,
+    );
+    expect(resp).toEqual({ ok: false, error: { kind: 'invalid-payload' } });
+    expect(adapter.set).not.toHaveBeenCalled();
+  });
+});
+
+describe('handlePosition — popup history surface', () => {
+  it('position/list returns all entries, most-recent first', async () => {
+    const { adapter, map } = spyAdapter();
+    seed(map, 'https://a.example/', 1, 10);
+    seed(map, 'https://b.example/', 2, 20);
+    const store = makeStoreOver(adapter);
+    const { resp } = await call({ type: 'position/list' }, popupSender(), store);
+    expect(resp?.ok).toBe(true);
+    if (!resp?.ok) throw new Error('unreachable');
+    const data = resp.data as Array<{ url: string }>;
+    expect(data.map((e) => e.url)).toEqual(['https://b.example/', 'https://a.example/']);
+  });
+
+  it('position/delete removes the named url (trusted popup param)', async () => {
+    const { adapter, map } = spyAdapter();
+    seed(map, 'https://a.example/', 1, 10);
+    const store = makeStoreOver(adapter);
+    const { resp } = await call(
+      { type: 'position/delete', url: 'https://a.example/' },
+      popupSender(),
+      store,
+    );
+    expect(resp?.ok).toBe(true);
+    expect(map.has(key('https://a.example/'))).toBe(false);
+  });
+
+  it('position/delete rejects a malformed url payload', async () => {
+    const { adapter } = spyAdapter();
+    const store = makeStoreOver(adapter);
+    const { resp } = await call({ type: 'position/delete', url: '' }, popupSender(), store);
+    expect(resp).toEqual({ ok: false, error: { kind: 'invalid-payload' } });
+    expect(adapter.remove).not.toHaveBeenCalled();
+  });
+
+  it('position/clear-all wipes the store', async () => {
+    const { adapter, map } = spyAdapter();
+    seed(map, 'https://a.example/', 1, 10);
+    seed(map, 'https://b.example/', 2, 20);
+    const store = makeStoreOver(adapter);
+    const { resp } = await call({ type: 'position/clear-all' }, popupSender(), store);
+    expect(resp?.ok).toBe(true);
+    expect(map.has(key('https://a.example/'))).toBe(false);
+    expect(map.has(key('https://b.example/'))).toBe(false);
+    expect(map.has('position-index')).toBe(false);
+  });
+});
+
+describe('handlePosition — dispatch', () => {
+  it('returns false for a non-position type (lets the caller fall through)', () => {
+    const handled = handlePosition({ type: 'activate-reader' }, popupSender(), () => undefined, {
+      store: makeStoreOver(spyAdapter().adapter),
+    });
+    expect(handled).toBe(false);
+  });
+});

--- a/src/chrome/background/position/__tests__/store.test.ts
+++ b/src/chrome/background/position/__tests__/store.test.ts
@@ -29,7 +29,7 @@ describe('createGuardedPositionStore — fail-closed when persistence disabled',
     const { adapter } = spyAdapter();
     const makeStore = vi.fn(() => createReadingPositionStore({ adapter, now: () => 1000 }));
 
-    const store = createGuardedPositionStore(false, makeStore);
+    const store = createGuardedPositionStore(() => false, makeStore);
 
     // The fail-closed branch must NOT build the chrome-backed store at all.
     expect(makeStore).not.toHaveBeenCalled();
@@ -57,12 +57,39 @@ describe('createGuardedPositionStore — fail-closed when persistence disabled',
       return inner;
     });
 
-    const store = createGuardedPositionStore(true, makeStore);
-    expect(makeStore).toHaveBeenCalledTimes(1);
+    const store = createGuardedPositionStore(() => true, makeStore);
+    // Lazy: the real store is built on first enabled op, not at construction.
+    expect(makeStore).not.toHaveBeenCalled();
 
     await store.write('https://example.com/a', { wordIndex: 5, totalWords: 50 });
+    expect(makeStore).toHaveBeenCalledTimes(1);
     expect(adapter.set).toHaveBeenCalled();
     const got = await store.read('https://example.com/a');
     expect(got?.wordIndex).toBe(5);
+  });
+
+  // Ring security finding #1 — the live-signal contract: a write dispatched
+  // while the gate has NOT yet resolved (signal false) is dropped with zero
+  // adapter access; once the gate resolves (signal true) writes land. This is
+  // what makes the store fail-closed against a late-resolving / rejecting
+  // setAccessLevel instead of writing to an un-gated `local`.
+  it('consults the live signal per-op: drops writes while disabled, lands them once enabled', async () => {
+    const { adapter } = spyAdapter();
+    let enabled = false;
+    const makeStore = vi.fn(() => createReadingPositionStore({ adapter, now: () => 1000 }));
+    const store = createGuardedPositionStore(() => enabled, makeStore);
+
+    // Disabled window — dropped, no adapter touch, no store construction.
+    await store.write('https://example.com/a', { wordIndex: 5, totalWords: 50 });
+    expect(makeStore).not.toHaveBeenCalled();
+    expect(adapter.set).not.toHaveBeenCalled();
+    await expect(store.read('https://example.com/a')).resolves.toBeUndefined();
+
+    // Gate resolves → signal flips → subsequent writes land.
+    enabled = true;
+    await store.write('https://example.com/a', { wordIndex: 9, totalWords: 90 });
+    expect(adapter.set).toHaveBeenCalled();
+    const got = await store.read('https://example.com/a');
+    expect(got?.wordIndex).toBe(9);
   });
 });

--- a/src/chrome/background/position/__tests__/store.test.ts
+++ b/src/chrome/background/position/__tests__/store.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createGuardedPositionStore } from '../store';
+import {
+  createReadingPositionStore,
+  type ReadingPositionStore,
+  type StorageAdapter,
+} from '../../../../core/storage/reading-position';
+
+function spyAdapter() {
+  const map = new Map<string, unknown>();
+  const adapter: StorageAdapter = {
+    get: vi.fn(async (keys: string[]) => {
+      const out: Record<string, unknown> = {};
+      for (const k of keys) if (map.has(k)) out[k] = map.get(k);
+      return out;
+    }),
+    set: vi.fn(async (items: Record<string, unknown>) => {
+      for (const [k, v] of Object.entries(items)) map.set(k, v);
+    }),
+    remove: vi.fn(async (keys: string[]) => {
+      for (const k of keys) map.delete(k);
+    }),
+  };
+  return { adapter, map };
+}
+
+describe('createGuardedPositionStore — fail-closed when persistence disabled', () => {
+  it('does NOT construct the real store and performs ZERO position writes when disabled', async () => {
+    const { adapter } = spyAdapter();
+    const makeStore = vi.fn(() => createReadingPositionStore({ adapter, now: () => 1000 }));
+
+    const store = createGuardedPositionStore(false, makeStore);
+
+    // The fail-closed branch must NOT build the chrome-backed store at all.
+    expect(makeStore).not.toHaveBeenCalled();
+
+    // All mutating ops resolve as no-ops — and crucially touch no adapter.
+    await store.write('https://example.com/a', { wordIndex: 5, totalWords: 50 });
+    await store.touch('https://example.com/a');
+    await store.clear('https://example.com/a');
+    await store.clearAll();
+
+    expect(adapter.set).not.toHaveBeenCalled();
+    expect(adapter.remove).not.toHaveBeenCalled();
+    expect(adapter.get).not.toHaveBeenCalled();
+
+    // Reads degrade to "nothing persisted".
+    await expect(store.read('https://example.com/a')).resolves.toBeUndefined();
+    await expect(store.list()).resolves.toEqual([]);
+  });
+
+  it('delegates to the real store when enabled', async () => {
+    const { adapter } = spyAdapter();
+    let inner: ReadingPositionStore | undefined;
+    const makeStore = vi.fn(() => {
+      inner = createReadingPositionStore({ adapter, now: () => 1000 });
+      return inner;
+    });
+
+    const store = createGuardedPositionStore(true, makeStore);
+    expect(makeStore).toHaveBeenCalledTimes(1);
+
+    await store.write('https://example.com/a', { wordIndex: 5, totalWords: 50 });
+    expect(adapter.set).toHaveBeenCalled();
+    const got = await store.read('https://example.com/a');
+    expect(got?.wordIndex).toBe(5);
+  });
+});

--- a/src/chrome/background/position/access-gate.ts
+++ b/src/chrome/background/position/access-gate.ts
@@ -1,0 +1,77 @@
+/**
+ * SW access-gate for the reading-position store (#196).
+ *
+ * Closes the cross-origin reading-history enumeration threat (#195/S3) by
+ * removing `chrome.storage.local` from the content-script API surface. The SW
+ * — a trusted context — calls
+ * `chrome.storage.local.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' })`,
+ * after which a content script's `chrome.storage.local.get` / `get(null)` /
+ * `set` all fail. The data does not move; the door is locked. See
+ * `docs/superpowers/specs/2026-06-11-position-store-service-worker.md`.
+ *
+ * TWO LOAD-BEARING INVARIANTS (spec §Acceptance Criteria):
+ *
+ *  1. **No-`content_scripts` lazy-injection model is what closes the
+ *     re-assertion window.** The manifest declares no `content_scripts`
+ *     (`manifest.ts`); a CS exists only after a user gesture wakes the SW and
+ *     the SW injects it via `chrome.scripting`. The SW (and this gate, run at
+ *     module top-level on every wake) therefore always runs before any CS it
+ *     spawns. **Adding a declared `content_scripts` entry requires revisiting
+ *     §Lifecycle Hazards** — a document-start CS could read `local` ahead of
+ *     this gate on a fresh browser launch.
+ *
+ *  2. **`local` is now SW-trusted-only by design.** `setAccessLevel` is
+ *     area-global, not per-key. Any future content-script-side `local` need
+ *     MUST route through an SW RPC, never raw `chrome.storage.local` — a raw CS
+ *     `local` read or `local.onChanged` listener added after this ships will
+ *     silently get access-denied / no events. Reviewers of future CS changes
+ *     must treat raw `local` access as a design error.
+ *
+ * Re-assertion discipline: issued synchronously at module top-level on every
+ * SW wake (same as listener registration). `setAccessLevel` returns a Promise —
+ * only the CALL is synchronous; the change resolves on a microtask. This opens
+ * no exfiltration window: the CS's only route post-injection is the SW-side
+ * RPC, where access is always trusted (spec §Lifecycle Hazards fact 1).
+ *
+ * Min Chrome floor: `setAccessLevel` on the `local` area is Chrome 140+ (MDN
+ * browser-compat-data: "Supported by all storage areas from Chrome 140").
+ * `manifest.ts` pins `minimum_chrome_version` to 140 so the gate API is always
+ * present on supported Chrome. The feature-detect below is defense-in-depth.
+ */
+
+/**
+ * Feature-detect `setAccessLevel` and, when present, restrict `local` to
+ * trusted contexts. Returns whether position persistence is enabled.
+ *
+ * **FAIL-CLOSED (spec §The Core Decision, normative).** When `setAccessLevel`
+ * is absent (should be unreachable above the pinned floor), this returns
+ * `false` and the store MUST refuse to persist — it must NEVER fall back to
+ * writing `position:*` into an un-gated, content-script-readable `local`.
+ * Degraded-but-safe (no resume feature) is the only acceptable failure mode;
+ * reopening the enumeration threat is not.
+ *
+ * The call is fire-and-forget: a rejection is swallowed (logged) rather than
+ * thrown, so SW startup never crashes on it.
+ */
+export function applyLocalAccessGate(local: chrome.storage.LocalStorageArea | undefined): boolean {
+  if (!local || typeof local.setAccessLevel !== 'function') {
+    return false;
+  }
+  // Issued synchronously; the access-level change resolves on a microtask.
+  void Promise.resolve(local.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' })).catch(
+    (err: unknown) => {
+      console.warn('[speedreader] setAccessLevel(local, TRUSTED_CONTEXTS) failed', err);
+    },
+  );
+  return true;
+}
+
+/**
+ * Top-level, every-wake assertion. Whether position persistence is enabled for
+ * this SW lifetime. Consumed by `background/position/store.ts` to enforce
+ * fail-closed. `undefined` `chrome`/`storage.local` (non-MV3 test hosts)
+ * degrades to disabled.
+ */
+export const POSITION_PERSISTENCE_ENABLED: boolean = applyLocalAccessGate(
+  typeof chrome !== 'undefined' ? chrome.storage?.local : undefined,
+);

--- a/src/chrome/background/position/access-gate.ts
+++ b/src/chrome/background/position/access-gate.ts
@@ -40,38 +40,76 @@
  */
 
 /**
- * Feature-detect `setAccessLevel` and, when present, restrict `local` to
- * trusted contexts. Returns whether position persistence is enabled.
- *
- * **FAIL-CLOSED (spec §The Core Decision, normative).** When `setAccessLevel`
- * is absent (should be unreachable above the pinned floor), this returns
- * `false` and the store MUST refuse to persist — it must NEVER fall back to
- * writing `position:*` into an un-gated, content-script-readable `local`.
- * Degraded-but-safe (no resume feature) is the only acceptable failure mode;
- * reopening the enumeration threat is not.
- *
- * The call is fire-and-forget: a rejection is swallowed (logged) rather than
- * thrown, so SW startup never crashes on it.
+ * Live fail-closed signal. Persistence is enabled ONLY once `setAccessLevel`
+ * has actually RESOLVED — not merely when the API is present. The store
+ * consults this on every op (`store.ts`), so a `setAccessLevel` that is present
+ * but REJECTS at runtime leaves this `false` and the store refuses to persist,
+ * rather than write `position:*` into an `local` area that was never gated.
+ * (Ring security finding #1: presence-detection is fail-OPEN on a runtime
+ * rejection — the threat reopens because a CS retains raw `local` access when
+ * the gate call never took effect.)
  */
-export function applyLocalAccessGate(local: chrome.storage.LocalStorageArea | undefined): boolean {
-  if (!local || typeof local.setAccessLevel !== 'function') {
-    return false;
-  }
-  // Issued synchronously; the access-level change resolves on a microtask.
-  void Promise.resolve(local.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' })).catch(
-    (err: unknown) => {
-      console.warn('[speedreader] setAccessLevel(local, TRUSTED_CONTEXTS) failed', err);
-    },
-  );
-  return true;
+let persistenceEnabled = false;
+
+/** Whether position persistence is currently enabled (gate resolved OK). */
+export function positionPersistenceEnabled(): boolean {
+  return persistenceEnabled;
 }
 
 /**
- * Top-level, every-wake assertion. Whether position persistence is enabled for
- * this SW lifetime. Consumed by `background/position/store.ts` to enforce
- * fail-closed. `undefined` `chrome`/`storage.local` (non-MV3 test hosts)
- * degrades to disabled.
+ * Feature-detect `setAccessLevel` and, when present, restrict `local` to
+ * trusted contexts. Flips {@link positionPersistenceEnabled} to `true` ONLY
+ * after the call resolves. Returns a promise of the resolved enabled state.
+ *
+ * **FAIL-CLOSED (spec §The Core Decision, normative).** Persistence stays
+ * disabled when `setAccessLevel` is absent (should be unreachable above the
+ * pinned Chrome-140 floor) OR present-but-rejecting. The store MUST NEVER fall
+ * back to writing `position:*` into an un-gated, content-script-readable
+ * `local`. Degraded-but-safe (no resume feature) is the only acceptable
+ * failure mode; reopening the enumeration threat is not.
+ *
+ * The CALL is issued synchronously (call-ordering, not resolution-ordering, is
+ * what the SW-lifecycle discipline requires — spec §Lifecycle Hazards fact 1);
+ * a rejection is caught (logged), never thrown, so SW startup never crashes.
  */
-export const POSITION_PERSISTENCE_ENABLED: boolean = applyLocalAccessGate(
-  typeof chrome !== 'undefined' ? chrome.storage?.local : undefined,
-);
+export function applyLocalAccessGate(
+  local: chrome.storage.LocalStorageArea | undefined,
+): Promise<boolean> {
+  // Re-assert from a CLOSED state every time: persistence stays disabled until
+  // THIS application's setAccessLevel resolves OK. Without this reset, a prior
+  // enabled state would leak through the pending window (or a later rejection),
+  // defeating fail-closed.
+  persistenceEnabled = false;
+  if (!local || typeof local.setAccessLevel !== 'function') {
+    return Promise.resolve(false);
+  }
+  // Issued synchronously; the access-level change resolves on a microtask.
+  // Persistence is enabled only on RESOLUTION — never on mere API presence.
+  // The call is wrapped so a SYNCHRONOUS throw (bad-arg / area-locked on some
+  // Chrome build) fails closed (persistence stays disabled) rather than
+  // escaping as an uncaught exception at SW module-eval time (ring re-review:
+  // availability defect on the sync-throw path).
+  let pending: Promise<unknown>;
+  try {
+    pending = Promise.resolve(local.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' }));
+  } catch (err: unknown) {
+    console.warn('[speedreader] setAccessLevel(local, TRUSTED_CONTEXTS) threw', err);
+    return Promise.resolve(false);
+  }
+  return pending.then(
+    () => {
+      persistenceEnabled = true;
+      return true;
+    },
+    (err: unknown) => {
+      persistenceEnabled = false;
+      console.warn('[speedreader] setAccessLevel(local, TRUSTED_CONTEXTS) failed', err);
+      return false;
+    },
+  );
+}
+
+// Top-level, every-wake assertion. Issued synchronously at module load (before
+// the first await, same discipline as listener registration). `undefined`
+// `chrome`/`storage.local` (non-MV3 test hosts) degrades to disabled.
+void applyLocalAccessGate(typeof chrome !== 'undefined' ? chrome.storage?.local : undefined);

--- a/src/chrome/background/position/handlers.ts
+++ b/src/chrome/background/position/handlers.ts
@@ -1,0 +1,167 @@
+/**
+ * Position RPC handlers (#196). Six message types: three content-script-bound,
+ * three popup-only. See
+ * `docs/superpowers/specs/2026-06-11-position-store-service-worker.md`.
+ *
+ * SECURITY INVARIANT — sender.url binding (spec §Sender-URL Binding):
+ *   A content-script position RPC derives its URL from `sender.url`, NEVER from
+ *   the message payload. CS wire shapes carry no `url` field; this handler
+ *   never reads one for CS types. A hostile/compromised CS cannot ask for
+ *   another origin's position — its reach is structurally pinned to the page it
+ *   already runs on.
+ *
+ *   LOAD-BEARING GATE DEPENDENCY (do not refactor away): the `sender.url`
+ *   guarantee depends on two checks in `messaging/on-message.ts` running BEFORE
+ *   this handler — (a) the foreign-extension rejection
+ *   (`sender.id !== chrome.runtime.id`), without which `sender.url` could be
+ *   `undefined` for a cross-extension sender, and (b) the CS sender-shape gate
+ *   (`sender.tab?.id !== undefined && sender.frameId === 0`), which keeps
+ *   popup/options senders out of CS-typed handlers. Removing either silently
+ *   breaks the URL-binding invariant.
+ *
+ * NULL/OPAQUE-ORIGIN REJECT (spec §Sender-URL Binding): when `sender.url` is
+ * absent or canonicalizes to `null` (opaque origin like `about:blank`/`data:`,
+ * or a disallowed scheme), the CS handlers return an error and perform ZERO
+ * store access — guarding the `"position:undefined"`-key poisoning path.
+ */
+
+import type { ReadingPositionStore } from '../../../core/storage/reading-position';
+import { canonicalizeUrl } from '../../../core/url/canonicalize';
+import { validatePositionSet, validatePositionDelete } from '../../../core/messaging/validate';
+import {
+  CS_POSITION_TYPES,
+  POPUP_POSITION_TYPES,
+  type PositionMessageType,
+} from '../../../core/messaging/types';
+import type { OnMessageError } from '../messaging/on-message';
+import { positionStore } from './store';
+
+export type PositionResponse = { ok: true; data: unknown } | { ok: false; error: OnMessageError };
+
+export interface PositionHandlerDeps {
+  store: ReadingPositionStore;
+}
+
+const defaultDeps: PositionHandlerDeps = { store: positionStore };
+
+const ALL_POSITION_TYPES: ReadonlySet<string> = new Set<string>([
+  ...CS_POSITION_TYPES,
+  ...POPUP_POSITION_TYPES,
+]);
+
+function isPositionType(type: string): type is PositionMessageType {
+  return ALL_POSITION_TYPES.has(type);
+}
+
+function err(sendResponse: (r: PositionResponse) => void): void {
+  sendResponse({ ok: false, error: { kind: 'invalid-payload' } });
+}
+
+/**
+ * Dispatch a position message. Returns `true` when `msg.type` is one of the six
+ * position types (and was handled), `false` otherwise so the caller can fall
+ * through to its other routes.
+ *
+ * Each handler runs inside a `void (async () => { ...; sendResponse(...) })()`
+ * so the synchronous return value stays available for the caller's listener
+ * contract (the listener must return `true` synchronously to keep
+ * `sendResponse` alive; an async handler would drop it).
+ */
+export function handlePosition(
+  msg: { type: string } & Record<string, unknown>,
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (resp: PositionResponse) => void,
+  deps: PositionHandlerDeps = defaultDeps,
+): boolean {
+  if (!isPositionType(msg.type)) return false;
+  const { store } = deps;
+
+  switch (msg.type) {
+    case 'position/get': {
+      const url = csUrlOrReject(sender, sendResponse);
+      if (url === null) return true;
+      void (async () => {
+        const pos = await store.read(url);
+        sendResponse({ ok: true, data: pos ?? null });
+      })();
+      return true;
+    }
+
+    case 'position/set': {
+      const url = csUrlOrReject(sender, sendResponse);
+      if (url === null) return true;
+      const payload = validatePositionSet(msg);
+      if (payload === null) {
+        err(sendResponse);
+        return true;
+      }
+      void (async () => {
+        await store.write(url, { wordIndex: payload.wordIndex, totalWords: payload.totalWords });
+        sendResponse({ ok: true, data: undefined });
+      })();
+      return true;
+    }
+
+    case 'position/clear': {
+      const url = csUrlOrReject(sender, sendResponse);
+      if (url === null) return true;
+      void (async () => {
+        await store.clear(url);
+        sendResponse({ ok: true, data: undefined });
+      })();
+      return true;
+    }
+
+    case 'position/list': {
+      void (async () => {
+        const entries = await store.list();
+        sendResponse({ ok: true, data: entries });
+      })();
+      return true;
+    }
+
+    case 'position/delete': {
+      const payload = validatePositionDelete(msg);
+      if (payload === null) {
+        err(sendResponse);
+        return true;
+      }
+      void (async () => {
+        await store.clear(payload.url);
+        sendResponse({ ok: true, data: undefined });
+      })();
+      return true;
+    }
+
+    case 'position/clear-all': {
+      void (async () => {
+        await store.clearAll();
+        sendResponse({ ok: true, data: undefined });
+      })();
+      return true;
+    }
+  }
+}
+
+/**
+ * Resolve the canonical URL for a CS-bound position RPC from `sender.url`.
+ * Returns the canonical URL string, or `null` after sending the reject
+ * response (caller returns immediately, performing NO store access). `null`
+ * means: absent `sender.url`, opaque origin, or disallowed scheme.
+ */
+function csUrlOrReject(
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (resp: PositionResponse) => void,
+): string | null {
+  const raw = sender.url;
+  if (typeof raw !== 'string') {
+    err(sendResponse);
+    return null;
+  }
+  const canonical = canonicalizeUrl(raw);
+  if (canonical === null) {
+    err(sendResponse);
+    return null;
+  }
+  return canonical;
+}

--- a/src/chrome/background/position/handlers.ts
+++ b/src/chrome/background/position/handlers.ts
@@ -126,6 +126,11 @@ export function handlePosition(
         err(sendResponse);
         return true;
       }
+      // The popup-supplied `url` is trusted (popup is the user's own history
+      // surface) and is canonicalized by `store.clear` → `positionKey` before
+      // any key access; a non-canonicalizable url no-ops. Defense-in-depth note
+      // (ring security #3): if a future refactor moves canonicalization out of
+      // `store.clear`, this handler must canonicalize here instead.
       void (async () => {
         await store.clear(payload.url);
         sendResponse({ ok: true, data: undefined });

--- a/src/chrome/background/position/store.ts
+++ b/src/chrome/background/position/store.ts
@@ -1,0 +1,61 @@
+/**
+ * SW-side module-scope reading-position store (#196).
+ *
+ * Constructs ONE store wired to the EXISTING `chrome.storage.local` adapter
+ * (`src/chrome/storage/chrome-position-store.ts`, unchanged) — now running
+ * SW-side instead of CS-side. Every write from every tab serializes through
+ * this single instance's internal promise-queue, which (as a welcome
+ * side-effect, not a #196 deliverable) closes the cross-tab LRU-index race #48
+ * documented.
+ *
+ * **Fail-closed (spec §The Core Decision, normative).** When the access-gate
+ * could not restrict `local` to trusted contexts (`setAccessLevel` absent —
+ * should be unreachable above the pinned Chrome-140 floor), persistence is
+ * disabled and this store refuses to touch the adapter at all. It MUST NOT
+ * write `position:*` into an un-gated, content-script-readable `local`. The
+ * disabled store is a pure no-op: reads return empty, writes are dropped. No
+ * resume feature is the only acceptable degraded mode.
+ */
+
+import {
+  type ReadingPositionStore,
+  type WritableReadingPosition,
+  type ReadingPosition,
+} from '../../../core/storage/reading-position';
+import { createChromePositionStore } from '../../storage/chrome-position-store';
+import { POSITION_PERSISTENCE_ENABLED } from './access-gate';
+
+/**
+ * A store that touches no storage. Used when persistence is disabled
+ * (fail-closed). Every method resolves to the "nothing persisted" answer
+ * without constructing a chrome-backed adapter.
+ */
+const nullStore: ReadingPositionStore = {
+  read: (_url: string): Promise<ReadingPosition | undefined> => Promise.resolve(undefined),
+  write: (_url: string, _position: WritableReadingPosition): Promise<void> => Promise.resolve(),
+  touch: (_url: string): Promise<void> => Promise.resolve(),
+  clear: (_url: string): Promise<void> => Promise.resolve(),
+  list: (): Promise<Array<{ url: string; position: ReadingPosition }>> => Promise.resolve([]),
+  clearAll: (): Promise<void> => Promise.resolve(),
+};
+
+/**
+ * Returns the real chrome-backed store when `enabled`, else a no-op store.
+ * `makeStore` is only invoked in the enabled branch, so the disabled path
+ * never even constructs the `chrome.storage.local` adapter — guaranteeing zero
+ * `position:*` writes.
+ */
+export function createGuardedPositionStore(
+  enabled: boolean,
+  makeStore: () => ReadingPositionStore = createChromePositionStore,
+): ReadingPositionStore {
+  return enabled ? makeStore() : nullStore;
+}
+
+/**
+ * The single SW-lifetime store instance. Wired to the existing
+ * `chrome.storage.local` adapter, gated by the access-gate's fail-closed flag.
+ */
+export const positionStore: ReadingPositionStore = createGuardedPositionStore(
+  POSITION_PERSISTENCE_ENABLED,
+);

--- a/src/chrome/background/position/store.ts
+++ b/src/chrome/background/position/store.ts
@@ -23,7 +23,7 @@ import {
   type ReadingPosition,
 } from '../../../core/storage/reading-position';
 import { createChromePositionStore } from '../../storage/chrome-position-store';
-import { POSITION_PERSISTENCE_ENABLED } from './access-gate';
+import { positionPersistenceEnabled } from './access-gate';
 
 /**
  * A store that touches no storage. Used when persistence is disabled
@@ -40,22 +40,44 @@ const nullStore: ReadingPositionStore = {
 };
 
 /**
- * Returns the real chrome-backed store when `enabled`, else a no-op store.
- * `makeStore` is only invoked in the enabled branch, so the disabled path
- * never even constructs the `chrome.storage.local` adapter — guaranteeing zero
- * `position:*` writes.
+ * Returns a store that consults `isEnabled()` on EVERY op (not once at
+ * construction). When disabled, the op resolves to the "nothing persisted"
+ * answer and touches no adapter — guaranteeing zero `position:*` writes. The
+ * real chrome-backed store is lazily constructed on first enabled op, so a
+ * permanently-disabled SW lifetime never builds the `chrome.storage.local`
+ * adapter at all.
+ *
+ * Checking `isEnabled()` dynamically (vs a static boolean) is what makes the
+ * gate fail-closed against a `setAccessLevel` that RESOLVES LATE or REJECTS:
+ * the access-gate flips its signal only once the call resolves OK, so writes
+ * dispatched before resolution (or after a rejection) are dropped rather than
+ * landing in an un-gated `local` (ring security finding #1).
  */
 export function createGuardedPositionStore(
-  enabled: boolean,
+  isEnabled: () => boolean,
   makeStore: () => ReadingPositionStore = createChromePositionStore,
 ): ReadingPositionStore {
-  return enabled ? makeStore() : nullStore;
+  let real: ReadingPositionStore | null = null;
+  const live = (): ReadingPositionStore | null => {
+    if (!isEnabled()) return null;
+    real ??= makeStore();
+    return real;
+  };
+  return {
+    read: (url) => live()?.read(url) ?? nullStore.read(url),
+    write: (url, position) => live()?.write(url, position) ?? nullStore.write(url, position),
+    touch: (url) => live()?.touch(url) ?? nullStore.touch(url),
+    clear: (url) => live()?.clear(url) ?? nullStore.clear(url),
+    list: () => live()?.list() ?? nullStore.list(),
+    clearAll: () => live()?.clearAll() ?? nullStore.clearAll(),
+  };
 }
 
 /**
  * The single SW-lifetime store instance. Wired to the existing
- * `chrome.storage.local` adapter, gated by the access-gate's fail-closed flag.
+ * `chrome.storage.local` adapter, gated by the access-gate's live fail-closed
+ * signal (enabled only once `setAccessLevel` resolves OK).
  */
 export const positionStore: ReadingPositionStore = createGuardedPositionStore(
-  POSITION_PERSISTENCE_ENABLED,
+  positionPersistenceEnabled,
 );

--- a/src/chrome/background/route.ts
+++ b/src/chrome/background/route.ts
@@ -15,6 +15,7 @@
 import { dispatchActivation } from './activation/dispatch';
 import type { ActivationError, ActivationIntent } from './activation/types';
 import type { OnMessageError } from './messaging/on-message';
+import { handlePosition } from './position/handlers';
 
 export type RouteResponse = { ok: false; error: OnMessageError } | { ok: true; data: unknown };
 
@@ -50,6 +51,12 @@ export function route(
   sendResponse: (resp: RouteResponse) => void,
   deps: RouteDeps = defaultDeps,
 ): void {
+  // #196 — position RPCs. `handlePosition` returns true when it owns the type
+  // (and has taken responsibility for `sendResponse`); fall through otherwise.
+  // The sender-shape provenance gate in `handleOnMessage` has already enforced
+  // CS-only / popup-only membership for every position type before we get here.
+  if (handlePosition(msg, sender, sendResponse)) return;
+
   if (msg.type === 'activate-reader') {
     const tabId = sender.tab?.id;
     // The popup is the only legitimate sender of `activate-reader` over

--- a/src/chrome/content/__tests__/position-flush.test.ts
+++ b/src/chrome/content/__tests__/position-flush.test.ts
@@ -1,17 +1,18 @@
 /**
- * #48 — visibility / pagehide flush wiring (architect HOLD #3).
+ * #196 — visibility / pagehide flush wiring over the SW position RPC.
  *
- * The debounced position writer batches up to 1 s of word events. If
- * the user backgrounds the tab (`visibilitychange` → 'hidden') or
- * navigates away (`pagehide`) inside that window, the trailing-edge
- * timer never fires and the position is lost. The content script now
- * listens for both signals and forces a flush.
+ * The content script no longer touches `chrome.storage.local` directly (the
+ * SW's `setAccessLevel('TRUSTED_CONTEXTS')` revoked CS access). Reading and
+ * writing reading positions now flows through sender-bound `chrome.runtime`
+ * `sendMessage` RPCs: `position/get` on mount, `position/set` on each debounced
+ * advance, `position/clear` on start-over. These tests assert on those RPCs
+ * instead of on `storage.local`.
  *
- * Mutation safety net: removing either listener registration in
- * `index.ts` (the `addEventListener` calls under
- * `attachPositionFlushListeners`) drops these tests red — that's how
- * we know they're actually asserting on the production behaviour and
- * not just coincidentally passing.
+ * The debounced writer batches up to 1 s of word events. If the user
+ * backgrounds the tab (`visibilitychange` → 'hidden') or navigates away
+ * (`pagehide`) inside that window, the trailing-edge timer never fires and the
+ * position is lost. The content script listens for both signals and forces a
+ * flush (a `position/set`).
  */
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 
@@ -21,48 +22,40 @@ type Listener = (
   sendResponse: (r: unknown) => void,
 ) => unknown;
 
-interface ChromeRuntime {
-  id: string;
-  onMessage: { addListener: (l: Listener) => void };
-}
-interface FakeStorageLocal {
-  get: ReturnType<typeof vi.fn>;
-  set: ReturnType<typeof vi.fn>;
-  remove: ReturnType<typeof vi.fn>;
+type PositionMsg = { type: string; wordIndex?: number; totalWords?: number };
+
+interface ChromeStub {
+  sendMessage: ReturnType<typeof vi.fn>;
+  getListener: () => Listener;
 }
 
-function installChromeStub(): { local: FakeStorageLocal; getListener: () => Listener } {
-  const localMap = new Map<string, unknown>();
-  const local: FakeStorageLocal = {
-    get: vi.fn(async (keys: string[] | string | null) => {
-      const keyList = Array.isArray(keys) ? keys : keys === null ? [...localMap.keys()] : [keys];
-      const out: Record<string, unknown> = {};
-      for (const k of keyList) if (localMap.has(k)) out[k] = structuredClone(localMap.get(k));
-      return out;
-    }),
-    set: vi.fn(async (items: Record<string, unknown>) => {
-      for (const [k, v] of Object.entries(items)) localMap.set(k, structuredClone(v));
-    }),
-    remove: vi.fn(async (keys: string[] | string) => {
-      const keyList = Array.isArray(keys) ? keys : [keys];
-      for (const k of keyList) localMap.delete(k);
-    }),
-  };
+/**
+ * Install a chrome stub whose `runtime.sendMessage` answers the position RPCs.
+ * `savedRecord` is what a `position/get` resolves to (the SW-owned store's
+ * answer) — `null` means "nothing persisted". `position/set` / `position/clear`
+ * resolve ok and are recorded on the spy for flush assertions.
+ */
+function installChromeStub(savedRecord: unknown = null): ChromeStub {
+  const sendMessage = vi.fn(async (msg: PositionMsg) => {
+    if (msg.type === 'position/get') return { ok: true, data: savedRecord };
+    return { ok: true, data: undefined };
+  });
 
   let captured: Listener | undefined;
-  const runtime: ChromeRuntime = {
-    id: 'test-ext',
-    onMessage: {
-      addListener: (l) => {
-        captured = l;
-      },
-    },
-  };
-
   (globalThis as unknown as { chrome: unknown }).chrome = {
-    runtime,
+    runtime: {
+      id: 'test-ext',
+      onMessage: {
+        addListener: (l: Listener) => {
+          captured = l;
+        },
+      },
+      sendMessage,
+      getURL: (path: string) => `chrome-extension://test-ext/${path}`,
+    },
     storage: {
-      local,
+      // No `local` — the CS must not depend on it post-#196. Settings still
+      // live in `sync`; the overlay mount calls loadSettings().
       sync: {
         get: vi.fn().mockResolvedValue({}),
         set: vi.fn().mockResolvedValue(undefined),
@@ -72,12 +65,27 @@ function installChromeStub(): { local: FakeStorageLocal; getListener: () => List
   };
 
   return {
-    local,
+    sendMessage,
     getListener: () => {
       if (!captured) throw new Error('listener not registered');
       return captured;
     },
   };
+}
+
+/** wordIndex of the most-recent `position/set` RPC, or undefined if none. */
+function lastSetWordIndex(sendMessage: ReturnType<typeof vi.fn>): number | undefined {
+  const setCalls = sendMessage.mock.calls.filter(
+    (c) => (c[0] as PositionMsg | undefined)?.type === 'position/set',
+  );
+  const last = setCalls.length > 0 ? (setCalls[setCalls.length - 1][0] as PositionMsg) : undefined;
+  return typeof last?.wordIndex === 'number' ? last.wordIndex : undefined;
+}
+
+function setCallCount(sendMessage: ReturnType<typeof vi.fn>): number {
+  return sendMessage.mock.calls.filter(
+    (c) => (c[0] as PositionMsg | undefined)?.type === 'position/set',
+  ).length;
 }
 
 beforeEach(() => {
@@ -94,76 +102,40 @@ afterEach(() => {
   vi.resetModules();
 });
 
-describe('content script — visibility/pagehide flush wiring (#48)', () => {
-  async function mountOverlayWithPendingWrite(): Promise<{
-    local: FakeStorageLocal;
-    pageUrl: string;
-  }> {
-    const { local, getListener } = installChromeStub();
+describe('content script — visibility/pagehide flush wiring (#196 RPC transport)', () => {
+  async function mountOverlayWithPendingWrite(): Promise<ChromeStub> {
+    const stub = installChromeStub();
     await import('../index');
-    const listener = getListener();
+    const listener = stub.getListener();
     listener({ type: 'activate-reader' }, { id: 'test-ext' }, vi.fn());
     // Overlay mount is async — wait for it to finish.
     await new Promise((r) => setTimeout(r, 50));
-
-    // Drive a word-advance manually by calling the overlay's
-    // engine-emit path indirectly: simplest is to drop a synthetic
-    // position into the debounced-writer pending slot via the
-    // exported `onWordAdvance` invocation, which fires during
-    // engine.start(). We rely on the overlay having auto-started the
-    // engine. Fast-forward to confirm at least one advance fires:
+    // Let the engine advance a few words (default 600 wpm → ~2-3 events).
     await new Promise((r) => setTimeout(r, 250));
-
-    return { local, pageUrl: 'https://example.com/article-flush-test' };
+    return stub;
   }
 
-  /**
-   * Extracts the wordIndex written under the canonical `position:<url>`
-   * key from a `chrome.storage.local.set` call payload. The flush path
-   * writes the per-URL payload AND the LRU index; we only assert on
-   * the per-URL payload so the test is robust to index-key changes.
-   */
-  function payloadWordIndex(setArg: Record<string, unknown>, pageUrl: string): number | undefined {
-    const key = `position:${pageUrl}`;
-    const v = setArg[key];
-    if (v === null || typeof v !== 'object') return undefined;
-    const wi = (v as { wordIndex?: unknown }).wordIndex;
-    return typeof wi === 'number' ? wi : undefined;
-  }
-
-  test('visibilitychange → hidden flushes the pending write AND cancels the debounce timer', async () => {
-    // TG3 — spy clearTimeout BEFORE the import so the production code's
-    // calls are captured. `setTimeout` returns numeric IDs in jsdom;
-    // we capture the most-recently scheduled debounce timer ID and
-    // assert clearTimeout was called with it BEFORE local.set fires.
+  test('visibilitychange → hidden flushes the pending write (position/set) AND cancels the debounce timer', async () => {
     const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
 
-    const { local, pageUrl } = await mountOverlayWithPendingWrite();
-    local.set.mockClear();
+    const stub = await mountOverlayWithPendingWrite();
+    stub.sendMessage.mockClear();
     clearTimeoutSpy.mockClear();
 
-    // Default visibilityState in jsdom is 'visible' — override it.
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
       get: () => 'hidden',
     });
     document.dispatchEvent(new Event('visibilitychange'));
-
-    // The flush calls store.write → chrome.storage.local.set. Allow
-    // microtasks to settle.
     await new Promise((r) => setTimeout(r, 30));
 
-    // (a) clearTimeout was called as part of the flush — proves the
-    // debounce timer was cancelled, not raced against.
+    // (a) clearTimeout fired as part of the flush — the debounce timer was
+    // cancelled, not raced against.
     expect(clearTimeoutSpy).toHaveBeenCalled();
-
-    // (b) The first set call carries the per-URL payload with a
-    // non-zero wordIndex (engine has been running ~250 ms at 600 wpm
-    // → ~2-3 word events) — proves the pending write actually
-    // flushed, not just any storage call.
-    expect(local.set).toHaveBeenCalled();
-    const firstCall = local.set.mock.calls[0][0] as Record<string, unknown>;
-    const wi = payloadWordIndex(firstCall, pageUrl);
+    // (b) A position/set RPC carried a non-zero wordIndex — the pending write
+    // actually flushed.
+    expect(setCallCount(stub.sendMessage)).toBeGreaterThan(0);
+    const wi = lastSetWordIndex(stub.sendMessage);
     expect(wi).toBeDefined();
     expect(wi).toBeGreaterThan(0);
 
@@ -171,69 +143,48 @@ describe('content script — visibility/pagehide flush wiring (#48)', () => {
   });
 
   test('visibilitychange → visible does NOT trigger a flush', async () => {
-    const { local } = await mountOverlayWithPendingWrite();
-    local.set.mockClear();
+    const stub = await mountOverlayWithPendingWrite();
+    stub.sendMessage.mockClear();
 
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
       get: () => 'visible',
     });
     document.dispatchEvent(new Event('visibilitychange'));
-
     await new Promise((r) => setTimeout(r, 30));
 
-    // No flush should have happened — the only set calls would be
-    // the debounced timer, which we haven't allowed to fire (250 ms
-    // elapsed in mount, well under the 1 s debounce).
-    expect(local.set).not.toHaveBeenCalled();
+    expect(setCallCount(stub.sendMessage)).toBe(0);
   });
 
-  test('pagehide flushes the pending write with the most-recent wordIndex AND cancels the timer', async () => {
-    // TG3 — same tightening as the visibilitychange test: spy
-    // clearTimeout, assert the per-URL payload carries a non-zero
-    // wordIndex (NOT a stale or empty record).
+  test('pagehide flushes the pending write (position/set) with the most-recent wordIndex AND cancels the timer', async () => {
     const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
 
-    const { local, pageUrl } = await mountOverlayWithPendingWrite();
-    local.set.mockClear();
+    const stub = await mountOverlayWithPendingWrite();
+    stub.sendMessage.mockClear();
     clearTimeoutSpy.mockClear();
 
     window.dispatchEvent(new Event('pagehide'));
     await new Promise((r) => setTimeout(r, 30));
 
     expect(clearTimeoutSpy).toHaveBeenCalled();
-    expect(local.set).toHaveBeenCalled();
-    const firstCall = local.set.mock.calls[0][0] as Record<string, unknown>;
-    const wi = payloadWordIndex(firstCall, pageUrl);
+    expect(setCallCount(stub.sendMessage)).toBeGreaterThan(0);
+    const wi = lastSetWordIndex(stub.sendMessage);
     expect(wi).toBeDefined();
     expect(wi).toBeGreaterThan(0);
 
     clearTimeoutSpy.mockRestore();
   });
 
-  test('TG4 — re-mount: pagehide on second mount flushes the second URL with no stale first-mount payload', async () => {
-    // Mount → close → mount again with a DIFFERENT pageUrl → pagehide.
-    // Asserts:
-    //   (a) the pagehide flush carries the SECOND pageUrl's payload
-    //       (proves the second mount's onWordAdvance closure
-    //       captured the new pageUrl and that pendingWrite isn't
-    //       stuck on a first-mount snapshot).
-    //   (b) no first-mount payload lands during the second mount's
-    //       pagehide (proves onClose's own flushPendingPositionWrite
-    //       drained the first mount's pending state cleanly).
-    //
-    // Mutation honesty: the production handlers `onVisibilityChange`
-    // / `onPageHide` are MODULE-SCOPED functions, not per-mount
-    // closures, so removing `detachPositionFlushListeners()` in
-    // onClose does NOT make this test red on its own — there is
-    // only ever one handler pair. That detach contract is
-    // mutation-validated by the separate `listeners detach after
-    // overlay close` test above. This TG4 test sits one layer up
-    // as an integration check: the full close→remount→pagehide
-    // cycle leaves no payload referencing the prior mount.
-    const { local, getListener } = installChromeStub();
+  test('TG4 — re-mount: pagehide on second mount still flushes a position/set', async () => {
+    // Pre-#196 this test asserted the flush payload carried the SECOND
+    // pageUrl. The wire no longer carries any url (the SW binds it from
+    // sender.url), so cross-mount url-staleness is structurally impossible —
+    // there is no url to go stale. This test now asserts the weaker, still-
+    // meaningful property: a full mount→close→remount→pagehide cycle flushes
+    // the second mount's progress.
+    const stub = installChromeStub();
     await import('../index');
-    const listener = getListener();
+    const listener = stub.getListener();
 
     Object.defineProperty(globalThis, 'location', {
       configurable: true,
@@ -254,60 +205,39 @@ describe('content script — visibility/pagehide flush wiring (#48)', () => {
     await new Promise((r) => setTimeout(r, 50));
     await new Promise((r) => setTimeout(r, 250));
 
-    local.set.mockClear();
+    stub.sendMessage.mockClear();
     window.dispatchEvent(new Event('pagehide'));
     await new Promise((r) => setTimeout(r, 30));
 
-    const calls = local.set.mock.calls as Array<[Record<string, unknown>]>;
-    const firstUrlKey = 'position:https://example.com/first-article';
-    const secondUrlKey = 'position:https://example.com/second-article';
-    const secondPayloadCalls = calls.filter((c) =>
-      Object.prototype.hasOwnProperty.call(c[0], secondUrlKey),
-    );
-    const firstPayloadCalls = calls.filter((c) =>
-      Object.prototype.hasOwnProperty.call(c[0], firstUrlKey),
-    );
-    // (a) Second mount's payload landed.
-    expect(secondPayloadCalls.length).toBeGreaterThan(0);
-    // (b) No stale first-mount payload (the first mount's pendingWrite
-    // was flushed during its own onClose).
-    expect(firstPayloadCalls).toHaveLength(0);
+    expect(setCallCount(stub.sendMessage)).toBeGreaterThan(0);
+    const wi = lastSetWordIndex(stub.sendMessage);
+    expect(wi).toBeDefined();
+    expect(wi).toBeGreaterThan(0);
   });
 
   test('listeners detach after overlay close — removeEventListener called for both signals', async () => {
-    // Spy on add/remove BEFORE the import so the content script's
-    // attach calls go through the spy. Both signal types must be
-    // detached on close so the content script doesn't leak handler
-    // closures across mount cycles.
     const docAdd = vi.spyOn(document, 'addEventListener');
     const docRemove = vi.spyOn(document, 'removeEventListener');
     const winAdd = vi.spyOn(window, 'addEventListener');
     const winRemove = vi.spyOn(window, 'removeEventListener');
 
-    const { getListener } = installChromeStub();
+    const stub = installChromeStub();
     await import('../index');
-    const listener = getListener();
+    const listener = stub.getListener();
     listener({ type: 'activate-reader' }, { id: 'test-ext' }, vi.fn());
     await new Promise((r) => setTimeout(r, 50));
 
-    // Sanity — the attach must have happened.
     expect(docAdd).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
     expect(winAdd).toHaveBeenCalledWith('pagehide', expect.any(Function));
 
-    // Capture the exact handler references the content script
-    // attached so we can compare them to the ones it later removes.
     const visAttachCall = docAdd.mock.calls.find((c) => c[0] === 'visibilitychange');
     const hideAttachCall = winAdd.mock.calls.find((c) => c[0] === 'pagehide');
     if (!visAttachCall) throw new Error('visibilitychange attach not captured');
     if (!hideAttachCall) throw new Error('pagehide attach not captured');
 
-    // Trigger overlay close via Escape (captured by the overlay's
-    // capture-phase keydown handler on document).
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     await new Promise((r) => setTimeout(r, 30));
 
-    // The content script must have called removeEventListener for
-    // BOTH signals with the same handler references it attached.
     expect(docRemove).toHaveBeenCalledWith('visibilitychange', visAttachCall[1]);
     expect(winRemove).toHaveBeenCalledWith('pagehide', hideAttachCall[1]);
 
@@ -318,20 +248,13 @@ describe('content script — visibility/pagehide flush wiring (#48)', () => {
   });
 
   /**
-   * ME3 — contract test: every chrome.storage.local.set call from the
-   * position-flush path MUST carry exactly ONE argument (the items
-   * object). Guards against an accidental regression to the callback
-   * form of the API, which would silently drop writes in production
-   * because Chrome's Promise overload is not invoked when a second
-   * (callback) argument is passed.
-   *
-   * Mutation evidence: changing the argument count check from
-   * `toBe(1)` to `toBe(2)` flips this test red.
+   * ME3 (adapted) — every position RPC is sent with exactly ONE argument (the
+   * message object). Guards against an accidental second (callback) argument
+   * to `sendMessage`, which would change the call semantics.
    */
-  test('ME3 — all chrome.storage.local.set calls from flush path use exactly one argument', async () => {
-    const { local } = await mountOverlayWithPendingWrite();
+  test('ME3 — all position RPCs use exactly one sendMessage argument', async () => {
+    const stub = await mountOverlayWithPendingWrite();
 
-    // Trigger a flush via visibilitychange → hidden.
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
       get: () => 'hidden',
@@ -339,103 +262,30 @@ describe('content script — visibility/pagehide flush wiring (#48)', () => {
     document.dispatchEvent(new Event('visibilitychange'));
     await new Promise((r) => setTimeout(r, 30));
 
-    expect(local.set).toHaveBeenCalled();
-    for (const call of local.set.mock.calls) {
+    expect(stub.sendMessage).toHaveBeenCalled();
+    for (const call of stub.sendMessage.mock.calls) {
       expect((call as unknown[]).length).toBe(1);
     }
   });
 });
 
 /**
- * CR2 — persistent-resume sanity guard: if the saved `totalWords` diverges
- * from the freshly-tokenized word count by more than ±5%, the stored index
- * is treated as stale and the resume is skipped (fresh start). This matches
- * the `#25` mutation-fallback pattern in `session-position.ts`.
+ * CR2 — persistent-resume sanity guard (unchanged logic, RPC transport).
  *
- * OBSERVABLE under test: the resume toast. The overlay only renders the
- * `[data-sr-resume-toast]` chip when it ACTUALLY resumed at a saved index
- * (`resumedAt !== null && opts.resumeToast`), and `index.ts` only passes
- * `resumeToast` when `persistentResume !== undefined` — i.e. when the CR2
- * guard honored the saved position. Therefore:
- *   - toast PRESENT  ⇔ guard honored the resume (drift within tolerance)
- *   - toast ABSENT   ⇔ guard suppressed the resume (drift over tolerance)
+ * If the saved `totalWords` diverges from the freshly-tokenized word count by
+ * more than ±5%, the stored index is treated as stale and the resume is
+ * skipped. The guard lives in `content/index.ts` and is unchanged by #196 —
+ * only the SOURCE of the saved record moved from a `storage.local` read to a
+ * `position/get` RPC response.
  *
- * This is a real observable that flips under guard mutation. The earlier
- * version of these tests asserted only `local.get` was called (fires
- * regardless of resume) and seeded an OUT-OF-RANGE wordIndex (rejected by
- * the pre-existing `wordIndex < fullWords.length` guard before CR2 even
- * runs) — both made the tests pass green even with the CR2 guard deleted.
- * Each test below has been mutation-validated: deleting or inverting the
- * `countDrift <= tolerance` guard in `index.ts` flips the relevant
- * assertion red.
+ * OBSERVABLE: the resume toast. The overlay renders `[data-sr-resume-toast]`
+ * only when it actually resumed at a saved index, and `index.ts` passes
+ * `resumeToast` only when `persistentResume !== undefined` — i.e. when the CR2
+ * guard honored the saved position. toast PRESENT ⇔ resume honored.
+ * Mutation-validated: deleting/inverting `countDrift <= tolerance` flips the
+ * relevant assertion.
  */
-describe('content script — CR2 persistent-resume sanity guard', () => {
-  function installChromeStubWithSavedPosition(
-    pageUrl: string,
-    savedWordIndex: number,
-    savedTotalWords: number,
-  ): { local: FakeStorageLocal; getListener: () => Listener } {
-    // Pre-seed the storage map with a saved position record so that
-    // when the content script calls positionStore.read(pageUrl), it
-    // finds a saved entry with the specified word count mismatch.
-    const canonicalKey = `position:${pageUrl}`;
-    const indexKey = 'position-index';
-    const localMap = new Map<string, unknown>([
-      [
-        canonicalKey,
-        {
-          schemaVersion: 1,
-          wordIndex: savedWordIndex,
-          totalWords: savedTotalWords,
-          lastReadAt: Date.now() - 3_600_000, // 1 hour ago
-        },
-      ],
-      [indexKey, [canonicalKey]],
-    ]);
-    const local: FakeStorageLocal = {
-      get: vi.fn(async (keys: string[] | string | null) => {
-        const keyList = Array.isArray(keys) ? keys : keys === null ? [...localMap.keys()] : [keys];
-        const out: Record<string, unknown> = {};
-        for (const k of keyList) if (localMap.has(k)) out[k] = structuredClone(localMap.get(k));
-        return out;
-      }),
-      set: vi.fn(async (items: Record<string, unknown>) => {
-        for (const [k, v] of Object.entries(items)) localMap.set(k, structuredClone(v));
-      }),
-      remove: vi.fn(async (keys: string[] | string) => {
-        const keyList = Array.isArray(keys) ? keys : [keys];
-        for (const k of keyList) localMap.delete(k);
-      }),
-    };
-    let captured: Listener | undefined;
-    (globalThis as unknown as { chrome: unknown }).chrome = {
-      runtime: {
-        id: 'test-ext',
-        onMessage: {
-          addListener: (l: Listener) => {
-            captured = l;
-          },
-        },
-        getURL: (path: string) => `chrome-extension://test-ext/${path}`,
-      },
-      storage: {
-        local,
-        sync: {
-          get: vi.fn().mockResolvedValue({}),
-          set: vi.fn().mockResolvedValue(undefined),
-        },
-        onChanged: { addListener: vi.fn(), removeListener: vi.fn() },
-      },
-    };
-    return {
-      local,
-      getListener: () => {
-        if (!captured) throw new Error('listener not registered');
-        return captured;
-      },
-    };
-  }
-
+describe('content script — CR2 persistent-resume sanity guard (RPC transport)', () => {
   afterEach(() => {
     delete (globalThis as unknown as { chrome?: unknown }).chrome;
     document.body.innerHTML = '';
@@ -443,58 +293,41 @@ describe('content script — CR2 persistent-resume sanity guard', () => {
     vi.resetModules();
   });
 
-  /**
-   * Resolve the overlay's resume toast from the open shadow root. Returns
-   * null when no overlay is mounted OR the overlay mounted but did NOT
-   * resume (toast suppressed). This is the single OBSERVABLE the CR2 tests
-   * key on — its presence is the production signal that `persistentResume`
-   * was honored.
-   */
   function getResumeToast(): HTMLElement | null {
     const host = document.body.querySelector('[data-speedreader-overlay]');
     if (!(host instanceof HTMLElement) || !host.shadowRoot) return null;
     return host.shadowRoot.querySelector('[role="status"][data-sr-resume-toast]');
   }
 
-  /**
-   * Mount the overlay through the content-script activate path against a
-   * pre-seeded saved position, then settle the async mount. Returns the
-   * resolved toast (or null) plus the storage spy for completeness.
-   */
   async function mountWithSavedPosition(
     pageUrl: string,
     body: string,
     savedWordIndex: number,
     savedTotalWords: number,
-  ): Promise<{ local: FakeStorageLocal; toast: HTMLElement | null }> {
+  ): Promise<{ toast: HTMLElement | null }> {
     document.body.innerHTML = `<article>${body}</article>`;
     Object.defineProperty(globalThis, 'location', {
       configurable: true,
       value: { href: pageUrl },
     });
-    const { local, getListener } = installChromeStubWithSavedPosition(
-      pageUrl,
-      savedWordIndex,
-      savedTotalWords,
-    );
+    // The SW's position/get answer carries the seeded record.
+    const stub = installChromeStub({
+      schemaVersion: 1,
+      wordIndex: savedWordIndex,
+      totalWords: savedTotalWords,
+      lastReadAt: 1000,
+    });
     await import('../index');
-    const listener = getListener();
+    const listener = stub.getListener();
     listener({ type: 'activate-reader' }, { id: 'test-ext' }, vi.fn());
-    // Overlay mount is async (loadSettings + positionStore.read await).
+    // Overlay mount is async (loadSettings + position/get await).
     await new Promise((r) => setTimeout(r, 80));
-    return { local, toast: getResumeToast() };
+    return { toast: getResumeToast() };
   }
 
   test('CR2 — skips resume when saved totalWords diverges by more than 5% from current count', async () => {
-    // Body has 6 words. savedWordIndex=3 is IN-RANGE for the current body
-    // (0 < 3 < 6), so the PRE-EXISTING `wordIndex < fullWords.length` range
-    // guard does NOT reject it — the CR2 drift guard is what must fire.
-    // savedTotalWords=20 → tolerance = ceil(20*0.05) = 1; drift = |20-6| = 14
-    // (> tolerance). The CR2 guard must suppress the resume.
-    //
-    // OBSERVABLE: the resume toast must be ABSENT. If the guard is deleted
-    // (resume unconditional), `persistentResume` would be set, `resumeToast`
-    // passed, and the toast would render — flipping this assertion red.
+    // Body has 6 words. savedWordIndex=3 in-range; savedTotalWords=20 →
+    // tolerance = ceil(20*0.05) = 1; drift = |20-6| = 14 (> tolerance) → SKIP.
     const { toast } = await mountWithSavedPosition(
       'https://example.com/cr2-stale-count',
       'alpha beta gamma delta epsilon zeta.',
@@ -505,14 +338,8 @@ describe('content script — CR2 persistent-resume sanity guard', () => {
   });
 
   test('CR2 — allows resume when saved totalWords is within 5% tolerance of current count', async () => {
-    // Body: 102 words. Saved: wordIndex=30, totalWords=100. Range guard:
-    // 0 < 30 < 102 (passes). tolerance = ceil(100*0.05) = 5; drift =
-    // |100-102| = 2 (≤ tolerance). The CR2 guard must HONOR the resume.
-    //
-    // OBSERVABLE: the resume toast must be PRESENT, and its label must name
-    // the resumed index (30). If the guard is inverted (reject within
-    // tolerance) or `persistentResume` forced undefined, the toast would
-    // not render — flipping this assertion red.
+    // Body: 102 words. Saved: wordIndex=30, totalWords=100. tolerance=5;
+    // drift=|100-102|=2 (≤ tolerance) → HONOR.
     const body = Array.from({ length: 102 }, (_, i) => `word${i}`).join(' ') + '.';
     const savedWordIndex = 30;
     const { toast } = await mountWithSavedPosition(
@@ -522,19 +349,13 @@ describe('content script — CR2 persistent-resume sanity guard', () => {
       100,
     );
     expect(toast).not.toBeNull();
-    // The toast label is `resumeToast(resumedAt, totalWords)` — resumedAt is
-    // the honored saved index, so the visible text must mention it.
     expect(toast?.textContent).toContain(String(savedWordIndex));
   });
 
-  // FIX 3 — boundary cases at the `countDrift <= tolerance` seam.
-
   test('CR2 — resumes when drift EXACTLY equals tolerance (pins the <=)', async () => {
-    // Body: 95 words. Saved: totalWords=100 → tolerance = ceil(100*0.05) = 5.
-    // drift = |100-95| = 5 == tolerance → the `<=` must HONOR the resume.
-    // Mutating the guard to `<` (strict) flips this red.
+    // Body: 95 words. totalWords=100 → tolerance=5; drift=|100-95|=5 == tol → HONOR.
     const body = Array.from({ length: 95 }, (_, i) => `word${i}`).join(' ') + '.';
-    const savedWordIndex = 10; // 0 < 10 < 95 — passes the range guard
+    const savedWordIndex = 10;
     const { toast } = await mountWithSavedPosition(
       'https://example.com/cr2-drift-eq-tolerance',
       body,
@@ -546,9 +367,7 @@ describe('content script — CR2 persistent-resume sanity guard', () => {
   });
 
   test('CR2 — skips resume when drift equals tolerance + 1', async () => {
-    // Body: 94 words. Saved: totalWords=100 → tolerance = 5.
-    // drift = |100-94| = 6 == tolerance + 1 → just over the seam → SKIP.
-    // The toast must be ABSENT.
+    // Body: 94 words. tolerance=5; drift=|100-94|=6 == tol+1 → SKIP.
     const body = Array.from({ length: 94 }, (_, i) => `word${i}`).join(' ') + '.';
     const { toast } = await mountWithSavedPosition(
       'https://example.com/cr2-drift-over-tolerance',
@@ -560,22 +379,10 @@ describe('content script — CR2 persistent-resume sanity guard', () => {
   });
 
   test('CR2 — tolerance uses Math.ceil: small totalWords still admits ±1 drift', async () => {
-    // Edge of the Math.ceil rounding. The task brief asked for the
-    // savedTotalWords===0 case (tolerance = ceil(0) = 0), but that record is
-    // unreachable at the CR2 seam: the store's own invariant in
-    // `core/storage/reading-position.ts` (`makeReadingPosition`) rejects any
-    // saved record with `totalWords <= 0` and returns undefined, so
-    // `positionStore.read()` never surfaces it to the guard. A test seeded
-    // with totalWords=0 would pass for the WRONG reason (upstream rejection,
-    // not the CR2 guard) — i.e. it would be vacuous w.r.t. CR2, the exact
-    // defect class this PR fixes.
-    //
-    // The reachable low-end edge that genuinely pins the `Math.ceil` is
-    // totalWords=2: tolerance = ceil(2*0.05) = ceil(0.1) = 1. A `Math.floor`
-    // mutation would yield tolerance 0. Seed: body=3 words, wordIndex=1
-    // (range guard 0 < 1 < 3 passes), drift = |2-3| = 1 == tolerance.
-    //   - ceil (correct): drift 1 <= 1  → resume HONORED → toast PRESENT
-    //   - floor (mutant):  drift 1 >  0 → resume SKIPPED → toast absent
+    // Reachable low-end edge: totalWords=2 → tolerance = ceil(2*0.05) = 1.
+    // Body=3 words, wordIndex=1 (range guard 0 < 1 < 3 passes), drift=|2-3|=1.
+    //   - ceil (correct): 1 <= 1 → HONOR → toast PRESENT
+    //   - floor (mutant): 1 > 0  → SKIP   → toast absent
     const savedWordIndex = 1;
     const { toast } = await mountWithSavedPosition(
       'https://example.com/cr2-ceil-low-end',

--- a/src/chrome/content/__tests__/position-flush.test.ts
+++ b/src/chrome/content/__tests__/position-flush.test.ts
@@ -378,6 +378,21 @@ describe('content script — CR2 persistent-resume sanity guard (RPC transport)'
     expect(toast).toBeNull();
   });
 
+  test('range guard — skips resume when saved wordIndex is out of range for the current stream', async () => {
+    // Companion guard to CR2 (ring test-gap #5): totalWords matches the body
+    // (drift 0, within tolerance) so the CR2 drift guard would HONOR — but
+    // wordIndex=99 >= the 6-word stream, so the `wordIndex < fullWords.length`
+    // range guard must reject. Toast ABSENT. A mutant dropping the range check
+    // would resume into a stale offset and flip this red.
+    const { toast } = await mountWithSavedPosition(
+      'https://example.com/range-guard',
+      'alpha beta gamma delta epsilon zeta.',
+      99,
+      6,
+    );
+    expect(toast).toBeNull();
+  });
+
   test('CR2 — tolerance uses Math.ceil: small totalWords still admits ±1 drift', async () => {
     // Reachable low-end edge: totalWords=2 → tolerance = ceil(2*0.05) = 1.
     // Body=3 words, wordIndex=1 (range guard 0 < 1 < 3 passes), drift=|2-3|=1.

--- a/src/chrome/content/index.ts
+++ b/src/chrome/content/index.ts
@@ -36,27 +36,26 @@ import { loadSettings, saveSettings, subscribeSettings } from '../settings/stora
 import { tokenize } from '../../core/tokenize';
 import { recordClose, resumeIndex } from './session-position';
 import { resolveFontId } from '../../core/overlay/font-ids';
-import { createChromePositionStore } from '../storage/chrome-position-store';
+import { createContentPositionClient, type ContentPositionClient } from './position/client';
 
 console.log('[SpeedReader] Content script loaded');
 
 let activeOverlay: OverlayHandle | null = null;
 
-// #48 — persistent per-URL reading-position store. Injection-scoped —
-// one instance per content-script load; repeated activations on the
-// same tab share this instance via the `activeOverlay` guard. The
-// internal write-queue lives on this instance, so constructing a new
-// store per-mount would fragment the queue and reintroduce the
-// LRU read-modify-write race the queue exists to prevent.
-const positionStore = createChromePositionStore();
+// #196 — persistent per-URL reading-position client. The CS no longer touches
+// `chrome.storage.local` directly (the SW's `setAccessLevel('TRUSTED_CONTEXTS')`
+// revoked CS access); persistence now flows through sender-bound `sendMessage`
+// RPCs to the SW-owned store. The client is page-bound — it carries no `url`,
+// the SW derives it from `sender.url`. Injection-scoped — one client per
+// content-script load.
+const positionClient: ContentPositionClient = createContentPositionClient();
 
-// #48 — single module-load warn when the local-storage surface is
-// missing (test harnesses, non-MV3 hosts). Matches the
-// `chrome.runtime.getURL` branch below — emit ONCE so per-mount
-// retries don't spam the console.
-if (typeof chrome === 'undefined' || !chrome.storage?.local) {
+// #196 — single module-load warn when the messaging surface is missing
+// (test harnesses, non-MV3 hosts). Matches the `chrome.runtime.getURL`
+// branch below — emit ONCE so per-mount retries don't spam the console.
+if (typeof chrome === 'undefined' || !chrome.runtime?.sendMessage) {
   console.warn(
-    '[speedreader] chrome.storage.local unavailable, reading-position persistence disabled',
+    '[speedreader] chrome.runtime.sendMessage unavailable, reading-position persistence disabled',
   );
 }
 
@@ -80,7 +79,6 @@ if (typeof chrome === 'undefined' || !chrome.storage?.local) {
 const POSITION_WRITE_DEBOUNCE_MS = 1_000;
 
 interface PendingWrite {
-  url: string;
   wordIndex: number;
   totalWords: number;
 }
@@ -96,8 +94,8 @@ function schedulePositionWrite(write: PendingWrite): void {
     const w = pendingWrite;
     pendingWrite = null;
     if (!w) return;
-    positionStore
-      .write(w.url, { wordIndex: w.wordIndex, totalWords: w.totalWords })
+    positionClient
+      .write({ wordIndex: w.wordIndex, totalWords: w.totalWords })
       .catch((err: unknown) => {
         console.warn('[speedreader] reading-position write failed', err);
       });
@@ -112,8 +110,8 @@ function flushPendingPositionWrite(): void {
   const w = pendingWrite;
   pendingWrite = null;
   if (!w) return;
-  positionStore
-    .write(w.url, { wordIndex: w.wordIndex, totalWords: w.totalWords })
+  positionClient
+    .write({ wordIndex: w.wordIndex, totalWords: w.totalWords })
     .catch((err: unknown) => {
       console.warn('[speedreader] reading-position flush failed', err);
     });
@@ -243,21 +241,19 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
         // in-session sessionResume above still handles selection-scope
         // close/reopen within the same content-script lifetime.
         //
-        // The chrome.storage.local guard handles test harnesses + non-MV3
+        // #196 — the sendMessage guard handles test harnesses + non-MV3
         // host environments that stub a partial `chrome` surface without
-        // the local namespace; the persistence path silently degrades
-        // when storage is unavailable. The single module-load warn at
-        // the top of the file leaves a breadcrumb without spamming
-        // per-mount.
-        const pageUrl = window.location.href;
-        const persistAvailable = !!chrome.storage?.local;
+        // the messaging API; the persistence path silently degrades when
+        // the SW RPC is unavailable. The single module-load warn at the
+        // top of the file leaves a breadcrumb without spamming per-mount.
+        const persistAvailable = !!chrome.runtime?.sendMessage;
         if (persistAvailable && scope === 'full') {
           attachPositionFlushListeners();
         }
         let persistentResume: number | undefined;
         if (persistAvailable && scope === 'full' && sessionResume === undefined) {
           try {
-            const saved = await positionStore.read(pageUrl);
+            const saved = await positionClient.read();
             if (saved !== undefined && saved.wordIndex > 0 && saved.wordIndex < fullWords.length) {
               // CR2 — sanity guard: the saved record carries its own
               // `totalWords` snapshot from when the position was written.
@@ -382,7 +378,7 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
                       pendingTimer = null;
                     }
                     pendingWrite = null;
-                    positionStore.clear(pageUrl).catch((err: unknown) => {
+                    positionClient.clear().catch((err: unknown) => {
                       console.warn('[speedreader] reading-position clear failed', err);
                     });
                   },
@@ -398,7 +394,6 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
             persistAvailable && scope === 'full'
               ? ({ index, total }) => {
                   schedulePositionWrite({
-                    url: pageUrl,
                     wordIndex: index,
                     totalWords: total,
                   });
@@ -413,11 +408,9 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
             flushPendingPositionWrite();
             // Drop the visibility / pagehide listeners — the content
             // script outlives the overlay across close/reopen cycles,
-            // so leaving them attached would (a) hold dead closures
-            // referencing this mount's `pageUrl` and (b) re-fire the
-            // flush every time the user backgrounds the tab, even
-            // with no overlay active. They're re-attached on the next
-            // mount.
+            // so leaving them attached would re-fire the flush every
+            // time the user backgrounds the tab, even with no overlay
+            // active. They're re-attached on the next mount.
             detachPositionFlushListeners();
           },
           // Font-size stepper (#29) — overlay clamps to FONT_SIZE_MIN/MAX

--- a/src/chrome/content/position/__tests__/client.test.ts
+++ b/src/chrome/content/position/__tests__/client.test.ts
@@ -46,6 +46,24 @@ describe('ContentPositionClient — sender-bound RPCs (no url in any payload)', 
     await expect(client.write({ wordIndex: 1, totalWords: 2 })).rejects.toBeTruthy();
   });
 
+  it('write() rejects with no-response when the SW is asleep (sendMessage → undefined)', async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const client = createContentPositionClient(apiWith(sendMessage));
+    await expect(client.write({ wordIndex: 1, totalWords: 2 })).rejects.toThrow('no-response');
+  });
+
+  it('clear() rejects with no-response when the SW is asleep (sendMessage → undefined)', async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const client = createContentPositionClient(apiWith(sendMessage));
+    await expect(client.clear()).rejects.toThrow('no-response');
+  });
+
+  it('read() degrades to undefined when the SW is asleep (sendMessage → undefined)', async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const client = createContentPositionClient(apiWith(sendMessage));
+    await expect(client.read()).resolves.toBeUndefined();
+  });
+
   it('clear() sends position/clear with NO url', async () => {
     const sendMessage = vi.fn(async () => ({ ok: true, data: undefined }));
     const client = createContentPositionClient(apiWith(sendMessage));

--- a/src/chrome/content/position/__tests__/client.test.ts
+++ b/src/chrome/content/position/__tests__/client.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createContentPositionClient } from '../client';
+
+function apiWith(sendMessage: ReturnType<typeof vi.fn>): typeof chrome {
+  return { runtime: { sendMessage } } as unknown as typeof chrome;
+}
+
+describe('ContentPositionClient — sender-bound RPCs (no url in any payload)', () => {
+  it('read() sends position/get with NO url and returns the record', async () => {
+    const sendMessage = vi.fn(async () => ({
+      ok: true,
+      data: { wordIndex: 5, totalWords: 50, lastReadAt: 1000 },
+    }));
+    const client = createContentPositionClient(apiWith(sendMessage));
+    const pos = await client.read();
+    expect(sendMessage).toHaveBeenCalledWith({ type: 'position/get' });
+    expect(pos).toEqual({ wordIndex: 5, totalWords: 50, lastReadAt: 1000 });
+  });
+
+  it('read() returns undefined when the SW reports no record (data null)', async () => {
+    const sendMessage = vi.fn(async () => ({ ok: true, data: null }));
+    const client = createContentPositionClient(apiWith(sendMessage));
+    await expect(client.read()).resolves.toBeUndefined();
+  });
+
+  it('read() degrades to undefined on an error response (no throw)', async () => {
+    const sendMessage = vi.fn(async () => ({ ok: false, error: { kind: 'invalid-payload' } }));
+    const client = createContentPositionClient(apiWith(sendMessage));
+    await expect(client.read()).resolves.toBeUndefined();
+  });
+
+  it('write() sends position/set carrying ONLY wordIndex + totalWords (no url)', async () => {
+    const sendMessage = vi.fn(async () => ({ ok: true, data: undefined }));
+    const client = createContentPositionClient(apiWith(sendMessage));
+    await client.write({ wordIndex: 3, totalWords: 80 });
+    expect(sendMessage).toHaveBeenCalledWith({
+      type: 'position/set',
+      wordIndex: 3,
+      totalWords: 80,
+    });
+  });
+
+  it('write() rejects on an error response so callers can log', async () => {
+    const sendMessage = vi.fn(async () => ({ ok: false, error: { kind: 'invalid-payload' } }));
+    const client = createContentPositionClient(apiWith(sendMessage));
+    await expect(client.write({ wordIndex: 1, totalWords: 2 })).rejects.toBeTruthy();
+  });
+
+  it('clear() sends position/clear with NO url', async () => {
+    const sendMessage = vi.fn(async () => ({ ok: true, data: undefined }));
+    const client = createContentPositionClient(apiWith(sendMessage));
+    await client.clear();
+    expect(sendMessage).toHaveBeenCalledWith({ type: 'position/clear' });
+  });
+});

--- a/src/chrome/content/position/client.ts
+++ b/src/chrome/content/position/client.ts
@@ -1,0 +1,62 @@
+/**
+ * Content-script position client (#196).
+ *
+ * The CS is a thin, least-privilege client: it can read/write/clear the
+ * position for its OWN current page only. It has NO `chrome.storage.local`
+ * access (the SW's `setAccessLevel('TRUSTED_CONTEXTS')` revoked it) and NO
+ * message type that names a URL — the SW binds the URL from `sender.url`. The
+ * `url` parameter is deliberately absent from this interface: a url-accepting
+ * CS client would imply cross-URL reads work, the exact misconception the
+ * threat model forbids. See
+ * `docs/superpowers/specs/2026-06-11-position-store-service-worker.md`
+ * §"Thin-Client Interfaces".
+ */
+
+import type {
+  ReadingPosition,
+  WritableReadingPosition,
+} from '../../../core/storage/reading-position';
+
+export interface ContentPositionClient {
+  /** Read this page's saved position (position/get). */
+  read(): Promise<ReadingPosition | undefined>;
+  /** Persist this page's position (position/set). */
+  write(p: WritableReadingPosition): Promise<void>;
+  /** Drop this page's saved position (position/clear). */
+  clear(): Promise<void>;
+}
+
+type Response = { ok: true; data: unknown } | { ok: false; error: { kind: string } };
+
+export function createContentPositionClient(api: typeof chrome = chrome): ContentPositionClient {
+  return {
+    async read() {
+      const resp = (await api.runtime.sendMessage({ type: 'position/get' })) as
+        | Response
+        | undefined;
+      if (!resp || !resp.ok) return undefined;
+      // Handler returns `ReadingPosition | null`. Normalize null → undefined.
+      return (resp.data as ReadingPosition | null) ?? undefined;
+    },
+
+    async write(p) {
+      const resp = (await api.runtime.sendMessage({
+        type: 'position/set',
+        wordIndex: p.wordIndex,
+        totalWords: p.totalWords,
+      })) as Response | undefined;
+      if (!resp || !resp.ok) {
+        throw new Error(`position/set failed: ${resp ? resp.error.kind : 'no-response'}`);
+      }
+    },
+
+    async clear() {
+      const resp = (await api.runtime.sendMessage({ type: 'position/clear' })) as
+        | Response
+        | undefined;
+      if (!resp || !resp.ok) {
+        throw new Error(`position/clear failed: ${resp ? resp.error.kind : 'no-response'}`);
+      }
+    },
+  };
+}

--- a/src/chrome/manifest.ts
+++ b/src/chrome/manifest.ts
@@ -26,6 +26,26 @@ export default {
   version: '0.2.0',
   description: 'RSVP reading accessibility extension for Chrome',
 
+  // --- Minimum Chrome version ---------------------------------------------
+  // #196 — pinned to the floor where `chrome.storage.local.setAccessLevel` is
+  // available. The SW's access-gate calls
+  // `chrome.storage.local.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' })`
+  // to close the cross-origin reading-history enumeration threat; below this
+  // floor the API is absent and the store fails closed (no persistence) rather
+  // than reopen the threat.
+  //
+  // Floor = 140, per MDN browser-compat-data (webextensions/api/storage.json,
+  // `StorageArea.setAccessLevel`): "Supported by the `session` storage area
+  // from Chrome 96. Supported by ALL storage areas from Chrome 140." The
+  // `session` area got it at 96/102, but the `local` area — the one this spec
+  // gates — is 140. (The spec's "≥119 expected" was an untested guess flagged
+  // unconfirmed-from-below; this is the impl-PR confirmation it asked for.)
+  // 140 shipped 2025-09; Chrome auto-updates, so by ship date this excludes a
+  // negligible user slice. See
+  // `docs/superpowers/specs/2026-06-11-position-store-service-worker.md`
+  // §Acceptance Criteria (impl-PR merge precondition).
+  minimum_chrome_version: '140',
+
   // --- Background service worker ------------------------------------------
   // Holds persistent state and handles messaging between content scripts
   // and the popup/options page.  No UI — purely a message bus.

--- a/src/chrome/options/index.ts
+++ b/src/chrome/options/index.ts
@@ -6,16 +6,15 @@
  */
 import { bindOptionsForm } from './controller';
 import { loadSettings, saveSettings, flushSettings, subscribeSettings } from '../settings/storage';
-import { createChromePositionStore } from '../storage/chrome-position-store';
+import { createPopupHistoryClient } from '../popup/position/client';
 
 document.addEventListener('DOMContentLoaded', () => {
-  // #49 — singleton position store for the optional "Also clear existing
-  // entries" companion action on the historyEnabled toggle. Constructed
-  // at module scope so its internal write-queue serialises any clearAll
-  // call with itself; the popup constructs its own store, but they both
-  // hit `chrome.storage.local` and the per-instance queue is sufficient
-  // for the single user-initiated wipe here.
-  const positionStore = createChromePositionStore();
+  // #196 — the options page is a trusted context but MUST NOT be a direct
+  // `chrome.storage.local` writer (single-writer rule, spec §Thin-Client
+  // Interfaces). The "Also clear existing entries" companion action on the
+  // historyEnabled toggle routes through the SW-owned store via the same
+  // `position/clear-all` RPC the popup uses, keeping ONE writer.
+  const historyClient = createPopupHistoryClient(chrome);
   void bindOptionsForm(
     document,
     window,
@@ -27,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
     },
     (alsoClearEntries: boolean) => {
       if (!alsoClearEntries) return;
-      positionStore.clearAll().catch((err: unknown) => {
+      historyClient.clearAll().catch((err: unknown) => {
         console.error('[speedreader] options: clearAll on history-disable failed', err);
       });
     },

--- a/src/chrome/popup/__tests__/history-integration.test.ts
+++ b/src/chrome/popup/__tests__/history-integration.test.ts
@@ -5,8 +5,8 @@
  *   - `loadSettings()` for the historyEnabled flag
  *   - `ReadingPositionStore.list()` for entries
  *   - `chrome.tabs.create({ url })` for resume
- *   - `store.clear(url)` for delete (and the section re-renders without it)
- *   - `store.clearAll()` for clear-all (and the section shows the empty state)
+ *   - `client.delete(url)` for delete (and the section re-renders without it)
+ *   - `client.clearAll()` for clear-all (and the section shows the empty state)
  *   - `chrome.runtime.openOptionsPage()` for the Enable link
  *
  * Anti-tautology stance:
@@ -17,29 +17,28 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { bootstrapPopup } from '../index';
-import type { ReadingPositionStore } from '../../../core/storage/reading-position';
+import type { PopupHistoryClient } from '../position/client';
 
-interface StoreStub extends ReadingPositionStore {
+interface ClientStub extends PopupHistoryClient {
   __snapshot(): Array<{
     url: string;
     position: { wordIndex: number; totalWords: number; lastReadAt: number };
   }>;
 }
 
-function makeStoreStub(initial: Array<{ url: string; lastReadAt: number }>): StoreStub {
-  // Mutable backing list — list() reads it, clear/clearAll mutate it.
+// #196 — the popup reaches the SW-owned store through the RPC client
+// (list / delete / clear-all), not a direct ReadingPositionStore.
+function makeHistoryClientStub(initial: Array<{ url: string; lastReadAt: number }>): ClientStub {
+  // Mutable backing list — list() reads it, delete/clearAll mutate it.
   let entries = initial.map((e) => ({
     url: e.url,
     position: { wordIndex: 0, totalWords: 100, lastReadAt: e.lastReadAt },
   }));
   return {
-    read: vi.fn(async () => undefined),
-    write: vi.fn(async () => undefined),
-    touch: vi.fn(async () => undefined),
-    clear: vi.fn(async (url: string) => {
+    list: vi.fn(async () => entries.map((e) => ({ url: e.url, position: { ...e.position } }))),
+    delete: vi.fn(async (url: string) => {
       entries = entries.filter((e) => e.url !== url);
     }),
-    list: vi.fn(async () => entries.map((e) => ({ url: e.url, position: { ...e.position } }))),
     clearAll: vi.fn(async () => {
       entries = [];
     }),
@@ -107,19 +106,19 @@ afterEach(() => {
 describe('bootstrapPopup — history section disabled', () => {
   it('renders the "off" message when historyEnabled is false', async () => {
     const api = makeChromeStub();
-    const store = makeStoreStub([]);
+    const client = makeHistoryClientStub([]);
     await bootstrapPopup({
       api,
       doc: document,
       loadSettings: async () => ({ historyEnabled: false }),
-      store,
+      historyClient: client,
       now: () => NOW,
     });
 
     const container = document.getElementById('history-container') as HTMLElement;
     expect(container.textContent ?? '').toMatch(/Reading history is off/i);
-    // No store.list() call when disabled — privacy floor.
-    expect(store.list).not.toHaveBeenCalled();
+    // No client.list() call when disabled — privacy floor.
+    expect(client.list).not.toHaveBeenCalled();
   });
 
   it('Enable link click invokes chrome.runtime.openOptionsPage', async () => {
@@ -128,7 +127,7 @@ describe('bootstrapPopup — history section disabled', () => {
       api,
       doc: document,
       loadSettings: async () => ({ historyEnabled: false }),
-      store: makeStoreStub([]),
+      historyClient: makeHistoryClientStub([]),
       now: () => NOW,
     });
     const enableBtn = document
@@ -140,9 +139,9 @@ describe('bootstrapPopup — history section disabled', () => {
 });
 
 describe('bootstrapPopup — history section enabled', () => {
-  it('renders entries from store.list when enabled', async () => {
+  it('renders entries from client.list when enabled', async () => {
     const api = makeChromeStub();
-    const store = makeStoreStub([
+    const client = makeHistoryClientStub([
       { url: 'https://example.com/a', lastReadAt: NOW - 30 * 60_000 },
       { url: 'https://example.com/b', lastReadAt: NOW - 2 * 86_400_000 },
     ]);
@@ -150,7 +149,7 @@ describe('bootstrapPopup — history section enabled', () => {
       api,
       doc: document,
       loadSettings: async () => ({ historyEnabled: true }),
-      store,
+      historyClient: client,
       now: () => NOW,
     });
 
@@ -163,14 +162,14 @@ describe('bootstrapPopup — history section enabled', () => {
 
   it('clicking an entry calls chrome.tabs.create with that URL', async () => {
     const api = makeChromeStub();
-    const store = makeStoreStub([
+    const client = makeHistoryClientStub([
       { url: 'https://example.com/article-x', lastReadAt: NOW - 60_000 },
     ]);
     await bootstrapPopup({
       api,
       doc: document,
       loadSettings: async () => ({ historyEnabled: true }),
-      store,
+      historyClient: client,
       now: () => NOW,
     });
 
@@ -182,7 +181,7 @@ describe('bootstrapPopup — history section enabled', () => {
 
   it('clicking delete removes the row from the DOM after re-render', async () => {
     const api = makeChromeStub();
-    const store = makeStoreStub([
+    const client = makeHistoryClientStub([
       { url: 'https://example.com/a', lastReadAt: NOW - 60_000 },
       { url: 'https://example.com/b', lastReadAt: NOW - 120_000 },
     ]);
@@ -190,7 +189,7 @@ describe('bootstrapPopup — history section enabled', () => {
       api,
       doc: document,
       loadSettings: async () => ({ historyEnabled: true }),
-      store,
+      historyClient: client,
       now: () => NOW,
     });
     expect(document.querySelectorAll('[role="listitem"]').length).toBe(2);
@@ -200,11 +199,11 @@ describe('bootstrapPopup — history section enabled', () => {
     );
     if (!firstDelete) throw new Error('test: delete button missing');
     firstDelete.click();
-    // Wait for the async store.clear() + remount.
+    // Wait for the async client.delete() + remount.
     await vi.waitFor(() => {
       expect(document.querySelectorAll('[role="listitem"]').length).toBe(1);
     });
-    expect(store.clear).toHaveBeenCalledWith('https://example.com/a');
+    expect(client.delete).toHaveBeenCalledWith('https://example.com/a');
     // The REMAINING row is b, not a — observed state change, not call shape.
     expect(document.body.textContent).toContain('example.com / b');
     expect(document.body.textContent).not.toContain('example.com / a');
@@ -213,12 +212,14 @@ describe('bootstrapPopup — history section enabled', () => {
   it('clicking Clear all (with confirm=true) wipes the list and shows the empty state', async () => {
     vi.spyOn(window, 'confirm').mockReturnValue(true);
     const api = makeChromeStub();
-    const store = makeStoreStub([{ url: 'https://example.com/a', lastReadAt: NOW - 60_000 }]);
+    const client = makeHistoryClientStub([
+      { url: 'https://example.com/a', lastReadAt: NOW - 60_000 },
+    ]);
     await bootstrapPopup({
       api,
       doc: document,
       loadSettings: async () => ({ historyEnabled: true }),
-      store,
+      historyClient: client,
       now: () => NOW,
     });
 
@@ -228,7 +229,7 @@ describe('bootstrapPopup — history section enabled', () => {
     await vi.waitFor(() => {
       expect(document.body.textContent).toMatch(/No articles yet/);
     });
-    expect(store.clearAll).toHaveBeenCalledTimes(1);
+    expect(client.clearAll).toHaveBeenCalledTimes(1);
     expect(document.querySelector('[role="list"]')).toBeNull();
   });
 });
@@ -236,12 +237,12 @@ describe('bootstrapPopup — history section enabled', () => {
 describe('bootstrapPopup — history section graceful degradation', () => {
   it('settings load failure renders the disabled state, does NOT block primary buttons', async () => {
     const api = makeChromeStub();
-    const store = makeStoreStub([]);
+    const client = makeHistoryClientStub([]);
     await bootstrapPopup({
       api,
       doc: document,
       loadSettings: () => Promise.reject(new Error('storage unavailable')),
-      store,
+      historyClient: client,
       now: () => NOW,
     });
     // History section renders the disabled state on settings failure.
@@ -253,15 +254,15 @@ describe('bootstrapPopup — history section graceful degradation', () => {
     expect(articleBtn.disabled).toBe(false);
   });
 
-  // TG2 — store.list() rejection path: regression turning the try/catch
-  // around store.list() into a re-throw would crash popup boot, blocking
+  // TG2 — client.list() rejection path: regression turning the try/catch
+  // around client.list() into a re-throw would crash popup boot, blocking
   // the article button. Pin the graceful-degradation contract: empty-state
   // renders, primary button stays wired, console.error fired exactly once.
-  it('store.list() rejection renders the empty-state, does NOT block primary buttons', async () => {
+  it('client.list() rejection renders the empty-state, does NOT block primary buttons', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const api = makeChromeStub();
-    const failingStore = makeStoreStub([]);
-    failingStore.list = vi.fn(async () => {
+    const failingClient = makeHistoryClientStub([]);
+    failingClient.list = vi.fn(async () => {
       throw new Error('storage failed');
     });
 
@@ -269,7 +270,7 @@ describe('bootstrapPopup — history section graceful degradation', () => {
       api,
       doc: document,
       loadSettings: async () => ({ historyEnabled: true }),
-      store: failingStore,
+      historyClient: failingClient,
       now: () => NOW,
     });
 
@@ -286,22 +287,22 @@ describe('bootstrapPopup — history section graceful degradation', () => {
     expect(articleBtn.disabled).toBe(false);
     // console.error fired exactly once for the list() failure path.
     expect(consoleError).toHaveBeenCalledTimes(1);
-    expect(failingStore.list).toHaveBeenCalledTimes(1);
+    expect(failingClient.list).toHaveBeenCalledTimes(1);
   });
 });
 
 // TG1 (integration leg) — pin that the rendering layer TRUSTS the
-// ordering returned by `store.list()` rather than re-sorting in the
+// ordering returned by `client.list()` rather than re-sorting in the
 // popup. Feeding oldest-first must render oldest-first in the DOM —
 // proves a future popup-side `entries.sort(...)` would surface here.
-describe('bootstrapPopup — history section trusts store.list() ordering', () => {
-  it('renders entries in the order store.list() returns them (no client-side re-sort)', async () => {
+describe('bootstrapPopup — history section trusts client.list() ordering', () => {
+  it('renders entries in the order client.list() returns them (no client-side re-sort)', async () => {
     const api = makeChromeStub();
     // Store returns OLDEST-first deliberately. The contract (#48) is
     // newest-first, but the popup layer should not silently paper over
     // a regression in the store's ordering — if it did, oldest-first
     // would be rendered without anyone noticing.
-    const store = makeStoreStub([
+    const client = makeHistoryClientStub([
       { url: 'https://example.com/oldest', lastReadAt: NOW - 10 * 86_400_000 },
       { url: 'https://example.com/middle', lastReadAt: NOW - 5 * 86_400_000 },
       { url: 'https://example.com/newest', lastReadAt: NOW - 60_000 },
@@ -310,7 +311,7 @@ describe('bootstrapPopup — history section trusts store.list() ordering', () =
       api,
       doc: document,
       loadSettings: async () => ({ historyEnabled: true }),
-      store,
+      historyClient: client,
       now: () => NOW,
     });
 

--- a/src/chrome/popup/index.ts
+++ b/src/chrome/popup/index.ts
@@ -23,8 +23,7 @@ import {
   type PopupScope,
 } from './activate';
 import { renderHistorySection, type HistorySectionEntry } from '../../core/popup/history-section';
-import type { ReadingPositionStore } from '../../core/storage/reading-position';
-import { createChromePositionStore } from '../storage/chrome-position-store';
+import { createPopupHistoryClient, type PopupHistoryClient } from './position/client';
 import { loadSettings } from '../settings/storage';
 
 interface PopupBootstrapDeps {
@@ -32,8 +31,12 @@ interface PopupBootstrapDeps {
   readonly doc: Document;
   /** Injectable for tests; defaults to `loadSettings`. */
   readonly loadSettings?: () => Promise<{ historyEnabled: boolean }>;
-  /** Injectable for tests; defaults to `createChromePositionStore()`. */
-  readonly store?: ReadingPositionStore;
+  /**
+   * Injectable for tests; defaults to `createPopupHistoryClient(api)`. #196 —
+   * the popup reaches the SW-owned store via RPC, never a direct
+   * `chrome.storage.local` writer (single-writer rule).
+   */
+  readonly historyClient?: PopupHistoryClient;
   /** Injectable for tests; defaults to `Date.now`. */
   readonly now?: () => number;
 }
@@ -195,7 +198,7 @@ async function mountHistorySection(deps: PopupBootstrapDeps): Promise<void> {
   if (!container) return; // HTML drift; non-fatal — primary buttons still work.
 
   const loadFn = deps.loadSettings ?? loadSettings;
-  const store = deps.store ?? createChromePositionStore();
+  const client = deps.historyClient ?? createPopupHistoryClient(api);
   const now = deps.now ?? (() => Date.now());
 
   const remount = async (): Promise<void> => {
@@ -213,7 +216,7 @@ async function mountHistorySection(deps: PopupBootstrapDeps): Promise<void> {
 
     if (enabled) {
       try {
-        const list = await store.list();
+        const list = await client.list();
         entries = list.map((e) => ({ url: e.url, timestamp: e.position.lastReadAt }));
       } catch (err) {
         console.error('[speedreader] popup: history list() failed', err);
@@ -229,15 +232,15 @@ async function mountHistorySection(deps: PopupBootstrapDeps): Promise<void> {
         void api.tabs.create({ url });
       },
       onDelete: (url) => {
-        void store
-          .clear(url)
+        void client
+          .delete(url)
           .then(() => remount())
           .catch((err: unknown) => {
-            console.error('[speedreader] popup: history clear failed', err);
+            console.error('[speedreader] popup: history delete failed', err);
           });
       },
       onClearAll: () => {
-        void store
+        void client
           .clearAll()
           .then(() => remount())
           .catch((err: unknown) => {

--- a/src/chrome/popup/position/__tests__/client.test.ts
+++ b/src/chrome/popup/position/__tests__/client.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createPopupHistoryClient } from '../client';
+
+function apiWith(sendMessage: ReturnType<typeof vi.fn>): typeof chrome {
+  return { runtime: { sendMessage } } as unknown as typeof chrome;
+}
+
+describe('PopupHistoryClient — full-history management over RPC', () => {
+  it('list() sends position/list and returns the entries', async () => {
+    const entries = [
+      { url: 'https://a/', position: { wordIndex: 1, totalWords: 10, lastReadAt: 5 } },
+    ];
+    const sendMessage = vi.fn(async () => ({ ok: true, data: entries }));
+    const client = createPopupHistoryClient(apiWith(sendMessage));
+    await expect(client.list()).resolves.toEqual(entries);
+    expect(sendMessage).toHaveBeenCalledWith({ type: 'position/list' });
+  });
+
+  it('list() returns [] on an error response (graceful degradation)', async () => {
+    const sendMessage = vi.fn(async () => ({ ok: false, error: { kind: 'invalid-payload' } }));
+    const client = createPopupHistoryClient(apiWith(sendMessage));
+    await expect(client.list()).resolves.toEqual([]);
+  });
+
+  it('delete(url) sends position/delete with the trusted url param', async () => {
+    const sendMessage = vi.fn(async () => ({ ok: true, data: undefined }));
+    const client = createPopupHistoryClient(apiWith(sendMessage));
+    await client.delete('https://a/');
+    expect(sendMessage).toHaveBeenCalledWith({ type: 'position/delete', url: 'https://a/' });
+  });
+
+  it('delete() rejects on an error response', async () => {
+    const sendMessage = vi.fn(async () => ({ ok: false, error: { kind: 'invalid-payload' } }));
+    const client = createPopupHistoryClient(apiWith(sendMessage));
+    await expect(client.delete('https://a/')).rejects.toBeTruthy();
+  });
+
+  it('clearAll() sends position/clear-all', async () => {
+    const sendMessage = vi.fn(async () => ({ ok: true, data: undefined }));
+    const client = createPopupHistoryClient(apiWith(sendMessage));
+    await client.clearAll();
+    expect(sendMessage).toHaveBeenCalledWith({ type: 'position/clear-all' });
+  });
+
+  it('clearAll() rejects on an error response', async () => {
+    const sendMessage = vi.fn(async () => ({ ok: false, error: { kind: 'invalid-payload' } }));
+    const client = createPopupHistoryClient(apiWith(sendMessage));
+    await expect(client.clearAll()).rejects.toBeTruthy();
+  });
+});

--- a/src/chrome/popup/position/__tests__/client.test.ts
+++ b/src/chrome/popup/position/__tests__/client.test.ts
@@ -35,6 +35,24 @@ describe('PopupHistoryClient — full-history management over RPC', () => {
     await expect(client.delete('https://a/')).rejects.toBeTruthy();
   });
 
+  it('list() returns [] when the SW is asleep (sendMessage → undefined)', async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const client = createPopupHistoryClient(apiWith(sendMessage));
+    await expect(client.list()).resolves.toEqual([]);
+  });
+
+  it('delete() rejects with no-response when the SW is asleep (sendMessage → undefined)', async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const client = createPopupHistoryClient(apiWith(sendMessage));
+    await expect(client.delete('https://a/')).rejects.toThrow('no-response');
+  });
+
+  it('clearAll() rejects with no-response when the SW is asleep (sendMessage → undefined)', async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const client = createPopupHistoryClient(apiWith(sendMessage));
+    await expect(client.clearAll()).rejects.toThrow('no-response');
+  });
+
   it('clearAll() sends position/clear-all', async () => {
     const sendMessage = vi.fn(async () => ({ ok: true, data: undefined }));
     const client = createPopupHistoryClient(apiWith(sendMessage));

--- a/src/chrome/popup/position/client.ts
+++ b/src/chrome/popup/position/client.ts
@@ -1,0 +1,56 @@
+/**
+ * Popup history client (#196).
+ *
+ * The popup is a trusted context (`chrome-extension://<id>`) and RETAINS direct
+ * `chrome.storage.local` access even after `setAccessLevel`. It MUST NOT use it
+ * for writes anyway: `delete` and `clear-all` mutate the shared LRU index, and
+ * a trusted page writing directly would be a second writer racing the SW's
+ * module-scope queue — reintroducing the cross-tab LRU divergence the
+ * single-writer design exists to close. Every mutation (and, for one trust
+ * story, every read) routes through the SW RPC. See
+ * `docs/superpowers/specs/2026-06-11-position-store-service-worker.md`
+ * §"Thin-Client Interfaces" (single-writer rule).
+ */
+
+import type { PositionListEntry } from '../../../core/messaging/types';
+
+export interface PopupHistoryClient {
+  /** Full reading history, most-recent first (position/list). */
+  list(): Promise<PositionListEntry[]>;
+  /** Delete one entry by URL — trusted popup param (position/delete). */
+  delete(url: string): Promise<void>;
+  /** Wipe all entries (position/clear-all). */
+  clearAll(): Promise<void>;
+}
+
+type Response = { ok: true; data: unknown } | { ok: false; error: { kind: string } };
+
+export function createPopupHistoryClient(api: typeof chrome = chrome): PopupHistoryClient {
+  return {
+    async list() {
+      const resp = (await api.runtime.sendMessage({ type: 'position/list' })) as
+        | Response
+        | undefined;
+      if (!resp || !resp.ok) return [];
+      return (resp.data as PositionListEntry[]) ?? [];
+    },
+
+    async delete(url) {
+      const resp = (await api.runtime.sendMessage({ type: 'position/delete', url })) as
+        | Response
+        | undefined;
+      if (!resp || !resp.ok) {
+        throw new Error(`position/delete failed: ${resp ? resp.error.kind : 'no-response'}`);
+      }
+    },
+
+    async clearAll() {
+      const resp = (await api.runtime.sendMessage({ type: 'position/clear-all' })) as
+        | Response
+        | undefined;
+      if (!resp || !resp.ok) {
+        throw new Error(`position/clear-all failed: ${resp ? resp.error.kind : 'no-response'}`);
+      }
+    },
+  };
+}

--- a/src/core/messaging/__tests__/validate-position.test.ts
+++ b/src/core/messaging/__tests__/validate-position.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { validatePositionSet, validatePositionDelete } from '../validate';
+
+describe('validatePositionSet — wire shape gate', () => {
+  it('accepts a well-formed payload', () => {
+    expect(validatePositionSet({ wordIndex: 10, totalWords: 100 })).toEqual({
+      wordIndex: 10,
+      totalWords: 100,
+    });
+  });
+
+  it('ignores extra keys, returning only the typed fields', () => {
+    expect(validatePositionSet({ wordIndex: 1, totalWords: 2, url: 'evil', extra: true })).toEqual({
+      wordIndex: 1,
+      totalWords: 2,
+    });
+  });
+
+  it.each([
+    ['non-object', 'nope'],
+    ['null', null],
+    ['missing wordIndex', { totalWords: 5 }],
+    ['missing totalWords', { wordIndex: 5 }],
+    ['string wordIndex', { wordIndex: '5', totalWords: 5 }],
+    ['NaN wordIndex', { wordIndex: NaN, totalWords: 5 }],
+    ['Infinity totalWords', { wordIndex: 1, totalWords: Infinity }],
+  ])('rejects %s', (_label, raw) => {
+    expect(validatePositionSet(raw)).toBeNull();
+  });
+});
+
+describe('validatePositionDelete — wire shape gate', () => {
+  it('accepts a non-empty url string', () => {
+    expect(validatePositionDelete({ url: 'https://example.com/a' })).toEqual({
+      url: 'https://example.com/a',
+    });
+  });
+
+  it.each([
+    ['non-object', 42],
+    ['null', null],
+    ['missing url', {}],
+    ['empty url', { url: '' }],
+    ['non-string url', { url: 123 }],
+  ])('rejects %s', (_label, raw) => {
+    expect(validatePositionDelete(raw)).toBeNull();
+  });
+});

--- a/src/core/messaging/types.ts
+++ b/src/core/messaging/types.ts
@@ -1,0 +1,88 @@
+/**
+ * Position-store RPC message registry (#196).
+ *
+ * Additive to the messaging-contract spec (`2026-05-08-messaging-contract.md`).
+ * These are the six one-shot `sendMessage` RPCs the SW-owned reading-position
+ * store exposes. The split into content-script-only and popup-only types is the
+ * security invariant made syntactic: **no content-script message type carries a
+ * `url`** — the SW derives the URL from `sender.url` for CS senders. See
+ * `docs/superpowers/specs/2026-06-11-position-store-service-worker.md`
+ * §"Sender-URL Binding".
+ *
+ * `src/core/` boundary: pure type/data, no `chrome.*`. The provenance sets
+ * (`CS_POSITION_TYPES` / `POPUP_POSITION_TYPES`) are the single source of truth
+ * consumed by `background/messaging/on-message.ts` so handler wiring and gate
+ * membership cannot drift apart (the spec's "atomic registration" rule).
+ */
+
+import type { ReadingPosition } from '../storage/reading-position';
+
+/**
+ * Content-script-originated position types. Each is sender-bound: the SW reads
+ * the page URL from `sender.url`, never from the payload. None carries a `url`.
+ */
+export const CS_POSITION_TYPES = ['position/get', 'position/set', 'position/clear'] as const;
+
+/**
+ * Popup-originated position types. These manage the full history surface and
+ * MAY carry a `url` (trusted) or address all entries.
+ */
+export const POPUP_POSITION_TYPES = [
+  'position/list',
+  'position/delete',
+  'position/clear-all',
+] as const;
+
+export type CsPositionType = (typeof CS_POSITION_TYPES)[number];
+export type PopupPositionType = (typeof POPUP_POSITION_TYPES)[number];
+export type PositionMessageType = CsPositionType | PopupPositionType;
+
+// --- CS-side wire shapes (no `url`) ---------------------------------------
+
+/** `position/get` — read the sender's own page position. URL from `sender.url`. */
+export interface PositionGetMessage {
+  readonly type: 'position/get';
+}
+
+/** `position/set` — persist the sender's own page position. URL from `sender.url`. */
+export interface PositionSetMessage {
+  readonly type: 'position/set';
+  readonly wordIndex: number;
+  readonly totalWords: number;
+}
+
+/** `position/clear` — delete the sender's own page position. URL from `sender.url`. */
+export interface PositionClearMessage {
+  readonly type: 'position/clear';
+}
+
+// --- Popup-side wire shapes ----------------------------------------------
+
+/** `position/list` — full history, popup-only. */
+export interface PositionListMessage {
+  readonly type: 'position/list';
+}
+
+/** `position/delete` — delete one entry by URL, popup-only (trusted url). */
+export interface PositionDeleteMessage {
+  readonly type: 'position/delete';
+  readonly url: string;
+}
+
+/** `position/clear-all` — wipe all entries, popup-only. */
+export interface PositionClearAllMessage {
+  readonly type: 'position/clear-all';
+}
+
+export type CsPositionMessage = PositionGetMessage | PositionSetMessage | PositionClearMessage;
+export type PopupPositionMessage =
+  | PositionListMessage
+  | PositionDeleteMessage
+  | PositionClearAllMessage;
+export type PositionMessage = CsPositionMessage | PopupPositionMessage;
+
+/** Response payload for `position/list`. */
+export interface PositionListEntry {
+  readonly url: string;
+  readonly position: ReadingPosition;
+}

--- a/src/core/messaging/validate.ts
+++ b/src/core/messaging/validate.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { SettingsSchemaV5 } from '../settings/schema';
+import type { PositionSetMessage, PositionDeleteMessage } from './types';
 
 /**
  * Per-activation override payload — applied by the CS as one-shot deltas
@@ -75,4 +76,46 @@ export function pickValidOverrides(raw: Overrides): Overrides {
     out.startFromWordOne = raw.startFromWordOne;
   }
   return out;
+}
+
+/**
+ * Wire-shape narrowing for the #196 position RPCs (per the messaging-contract
+ * spec's payload-validation discipline). These are shape gates only —
+ * primitive-type checks on the payload fields. Range/cross-field bounds for
+ * `wordIndex`/`totalWords` are enforced downstream by the core store's smart
+ * constructor (`reading-position.ts` `makeReadingPosition`), the single source
+ * of truth for that invariant; duplicating it here would risk drift.
+ *
+ * The `url`-less CS types (`position/get`, `position/clear`) and the param-less
+ * popup types (`position/list`, `position/clear-all`) need no payload narrowing
+ * — their wire shape is just `{ type }` — so they have no validator here.
+ */
+
+function isObject(raw: unknown): raw is Record<string, unknown> {
+  return typeof raw === 'object' && raw !== null;
+}
+
+/**
+ * Narrows a `position/set` payload. Returns the typed fields when `wordIndex`
+ * and `totalWords` are both finite numbers; `null` otherwise. The handler
+ * forwards these to the store, whose bounds gate drops out-of-range values.
+ */
+export function validatePositionSet(
+  raw: unknown,
+): Pick<PositionSetMessage, 'wordIndex' | 'totalWords'> | null {
+  if (!isObject(raw)) return null;
+  if (typeof raw.wordIndex !== 'number' || !Number.isFinite(raw.wordIndex)) return null;
+  if (typeof raw.totalWords !== 'number' || !Number.isFinite(raw.totalWords)) return null;
+  return { wordIndex: raw.wordIndex, totalWords: raw.totalWords };
+}
+
+/**
+ * Narrows a `position/delete` payload. Returns the `url` when it is a non-empty
+ * string; `null` otherwise. The store canonicalizes the url and no-ops on a
+ * non-canonicalizable value, so this gate only rejects the obviously-malformed.
+ */
+export function validatePositionDelete(raw: unknown): Pick<PositionDeleteMessage, 'url'> | null {
+  if (!isObject(raw)) return null;
+  if (typeof raw.url !== 'string' || raw.url.length === 0) return null;
+  return { url: raw.url };
 }

--- a/tests/e2e/position-isolation.spec.ts
+++ b/tests/e2e/position-isolation.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * position-isolation.spec.ts — #196 headline E2E: the runtime proof that a
+ * content script CANNOT reach `chrome.storage.local` after the SW gates it,
+ * inside the REAL extension (not just the `experiments/idb-isolation-check`
+ * reproducer harness).
+ *
+ * Acceptance criterion (spec §Acceptance Criteria / §Test Strategy):
+ *   after the SW has gated `local`, from a CS context attempt
+ *   `chrome.storage.local.get(null)` and `chrome.storage.local.get('position:…')`
+ *   — confirm BOTH fail (access denied, no records), so neither this page's nor
+ *   any other origin's position is reachable; and confirm the trusted SW
+ *   context still reads the seeded record.
+ *
+ * Bypass mechanism: the e2e build (`dist-e2e-ext/`) adds
+ * `host_permissions: ['<all_urls>']` so `executeScript` succeeds without a
+ * gesture (CDP cannot dispatch gesture-provenance). The SW's top-level
+ * access-gate (`setAccessLevel('TRUSTED_CONTEXTS')`) is identical to production.
+ *
+ * Requires the Chrome-140+ `local.setAccessLevel` floor — Playwright's bundled
+ * Chrome for Testing (148) satisfies it.
+ *
+ * Run on demand (opt-in; not part of the standard CI gate — same convention as
+ * the other extension-loading specs):
+ *   npm run build:e2e-ext
+ *   RUN_POSITION_ISOLATION=1 npx playwright test tests/e2e/position-isolation.spec.ts
+ */
+import { test, expect, chromium, type BrowserContext, type Worker } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { spawn, type ChildProcess } from 'node:child_process';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const extensionPath = resolve(here, '..', '..', 'dist-e2e-ext');
+
+test.skip(
+  !process.env.RUN_POSITION_ISOLATION,
+  'Extension-loading isolation spec — set RUN_POSITION_ISOLATION=1 to run (needs `npm run build:e2e-ext`)',
+);
+
+const PORT = 5174;
+const PAGE_URL = `http://127.0.0.1:${PORT}/article.html`;
+
+function findContentScriptLoader(): string {
+  const assetsDir = join(extensionPath, 'assets');
+  const files = readdirSync(assetsDir).filter((f) => /^index\.ts-loader-.*\.js$/.test(f));
+  if (files.length !== 1) {
+    throw new Error(`Expected exactly one CS loader, found ${files.length}: ${files.join(', ')}`);
+  }
+  return `assets/${files[0]}`;
+}
+
+let context: BrowserContext | undefined;
+let sw: Worker | undefined;
+let userDataDir: string | undefined;
+let server: ChildProcess | undefined;
+let csFile: string;
+
+test.describe('#196 — CS cannot reach chrome.storage.local after the SW gate', () => {
+  test.beforeAll(async () => {
+    if (!existsSync(extensionPath)) {
+      throw new Error(`${extensionPath} missing. Run \`npm run build:e2e-ext\` first.`);
+    }
+    csFile = findContentScriptLoader();
+
+    server = spawn(process.execPath, [resolve(here, 'fixtures', 'serve.mjs')], {
+      env: { ...process.env, PORT: String(PORT) },
+      stdio: 'ignore',
+    });
+    // Give the static server a beat to bind.
+    await new Promise((r) => setTimeout(r, 500));
+
+    userDataDir = mkdtempSync(resolve(tmpdir(), 'speedreader-isolation-'));
+    context = await chromium.launchPersistentContext(userDataDir, {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+        '--no-first-run',
+        '--no-default-browser-check',
+      ],
+    });
+    const existing = context.serviceWorkers();
+    sw = existing[0] ?? (await context.waitForEvent('serviceworker'));
+  });
+
+  test.afterAll(async () => {
+    await context?.close().catch(() => undefined);
+    server?.kill();
+    if (userDataDir) rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  test('CS keyed-get + get(null) enumeration BOTH fail; trusted SW read survives', async () => {
+    if (!context || !sw) throw new Error('context not initialized');
+    test.setTimeout(60_000);
+
+    // 1. Seed a position record from the trusted SW context (which keeps
+    //    full access after setAccessLevel). This is the record the CS must
+    //    NOT be able to read or enumerate.
+    const positionKey = `position:${PAGE_URL}`;
+    await sw.evaluate(
+      async ({ key }) => {
+        await chrome.storage.local.set({
+          [key]: { schemaVersion: 1, wordIndex: 7, totalWords: 100, lastReadAt: Date.now() },
+        });
+      },
+      { key: positionKey },
+    );
+
+    // 2. The trusted SW context CAN read it back (inverse of check 5c).
+    const swSees = await sw.evaluate(async ({ key }) => {
+      const got = await chrome.storage.local.get(key);
+      return (got[key] as { wordIndex?: number } | undefined)?.wordIndex ?? null;
+    }, { key: positionKey });
+    expect(swSees).toBe(7);
+
+    // 3. Open the page and inject the CS via the production loader.
+    const page = await context.newPage();
+    await page.goto(PAGE_URL, { waitUntil: 'domcontentloaded', timeout: 15_000 });
+    const tabId = await sw.evaluate(async () => {
+      const tabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+      const id = tabs[0]?.id;
+      if (typeof id !== 'number') throw new Error('no active tab id');
+      return id;
+    });
+    await sw.evaluate(
+      async ({ tabId, file }) => {
+        await chrome.scripting.executeScript({ target: { tabId }, files: [file] });
+      },
+      { tabId, file: csFile },
+    );
+    await page.waitForTimeout(500);
+
+    // 4. Run the isolation probe IN THE CS ISOLATED WORLD via executeScript.
+    //    After the SW's setAccessLevel('TRUSTED_CONTEXTS'), every CS local op
+    //    must fail with "Access to storage is not allowed from this context."
+    const [probe] = await sw.evaluate(
+      async ({ tabId, key }) => {
+        return chrome.scripting.executeScript({
+          target: { tabId },
+          func: async (positionKey: string) => {
+            const result = {
+              keyedFailed: false,
+              enumFailed: false,
+              sawAnyPosition: false,
+            };
+            try {
+              const got = await chrome.storage.local.get(positionKey);
+              // If it resolved, isolation FAILED unless empty AND no record.
+              result.keyedFailed = got[positionKey] === undefined && !chrome.runtime.lastError;
+              // A resolved keyed get that returned the record is the failure.
+              if (got[positionKey] !== undefined) result.keyedFailed = false;
+              else result.keyedFailed = true;
+            } catch {
+              result.keyedFailed = true;
+            }
+            try {
+              const all = await chrome.storage.local.get(null);
+              const keys = Object.keys(all);
+              result.sawAnyPosition = keys.some((k) => k.startsWith('position:'));
+              // Enumeration that resolves AND exposes position keys is the
+              // failure; a denied enumeration throws (caught below).
+              result.enumFailed = !result.sawAnyPosition && keys.length === 0;
+            } catch {
+              result.enumFailed = true;
+            }
+            return result;
+          },
+          args: [key],
+        });
+      },
+      { tabId, key: positionKey },
+    );
+
+    const probeResult = probe?.result as
+      | { keyedFailed: boolean; enumFailed: boolean; sawAnyPosition: boolean }
+      | undefined;
+    if (!probeResult) throw new Error('CS probe returned no result');
+
+    // The CS must NOT have seen any position key …
+    expect(probeResult.sawAnyPosition).toBe(false);
+    // … and both the keyed read and the enumeration must have failed (access
+    // denied — the door is locked).
+    expect(probeResult.keyedFailed).toBe(true);
+    expect(probeResult.enumFailed).toBe(true);
+
+    await page.close();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
       'src/chrome/background/commands/**/__tests__/**/*.test.ts',
       'src/chrome/background/context-menu/**/__tests__/**/*.test.ts',
       'src/chrome/background/messaging/**/__tests__/**/*.test.ts',
+      'src/chrome/background/position/**/__tests__/**/*.test.ts',
       'src/chrome/background/state/**/__tests__/**/*.test.ts',
       'src/chrome/background/welcome/**/__tests__/**/*.test.ts',
       'src/chrome/content/**/__tests__/**/*.test.ts',


### PR DESCRIPTION
## Summary

Implements #196 — the SW-owned reading-position store. Closes the cross-origin
reading-history enumeration threat (#195/S3) flagged by PR #195's ring: a content
script could call `chrome.storage.local.get(null)` and exfiltrate every
`position:<url>` key. The SW now calls
`chrome.storage.local.setAccessLevel({accessLevel:"TRUSTED_CONTEXTS"})` at module
top-level on every wake, removing `local` from the CS API surface. CS/popup/options
become thin clients reaching the SW-owned store via sender-bound `sendMessage` RPCs.

**No data migration** — positions stay in `chrome.storage.local`; the existing
`chrome-position-store.ts` adapter is reused unchanged, now SW-side.

Spec (merged, Accepted): `docs/superpowers/specs/2026-06-11-position-store-service-worker.md`

### Key decisions
- **`minimum_chrome_version` = 140**, not the spec's untested "≥119 expected". MDN
  browser-compat-data is explicit: `setAccessLevel` on the `local` area is
  "Supported by all storage areas from Chrome 140" (session got it at 96/102).
  This is the impl-PR floor confirmation the spec delegated. Fail-closed
  feature-detection means security holds at any version regardless of the pin.
- **Fail-closed**, never permissive: if `setAccessLevel` is absent, the store
  refuses to persist (no resume) rather than write `position:*` to un-gated `local`.
- **Single-writer rule**: no trusted context (popup OR options) remains a direct
  `chrome.storage.local` writer — all mutations route through the SW RPC.
- **Fail-closed gate default**: a message type in neither provenance set is
  rejected (`invalid-payload`), not forwarded to the router by sender shape alone.

## Test Plan

- [x] `npm run lint` — clean (0 warnings, `--max-warnings=0`)
- [x] `npm run format:check` — clean
- [x] `npm test` — 1450 passed (incl. forged-URL mandatory-shape, null/opaque
      reject-no-write, all-6-types provenance rejection, fail-closed zero-writes,
      access-gate ordering/feature-detect, CR2 resume over RPC)
- [x] `npm run build` — tsc + vite clean; `minimum_chrome_version: "140"` in dist manifest
- [x] E2E isolation assertion on the REAL loaded extension (Chrome 148):
      `RUN_POSITION_ISOLATION=1 npx playwright test tests/e2e/position-isolation.spec.ts`
      → 1 passed. CS keyed-get + `get(null)` enumeration BOTH fail; trusted SW read
      survives (wordIndex 7); CS saw zero position keys. Non-vacuous (seeded key
      would surface if the gate were absent).
- [ ] **Manual, once-per-Chrome-major (non-blocking, deferred):** confirm the
      eviction-persistence (check 6) under NATURAL idle-eviction (~30-40s, no CDP)
      on the min-supported Chrome (140). Cannot be automated in CI; flagged per
      spec §Empirical Precondition check-3 faithfulness caveat.

## Notes
- Reproducer (`experiments/idb-isolation-check/`) already proved checks 5/2/6
  (13/13). This PR adds the runtime proof inside the production extension.
- E2E specs are opt-in (`RUN_POSITION_ISOLATION=1` + `npm run build:e2e-ext`),
  matching the repo convention for extension-loading specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
