### PR TITLE
feat(#117): coordinator-side isolated worktrees for parallel builders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,23 @@ For routine extension work, prefer hierarchical dispatch, ~6 agents, Queen: `ext
 
 Spawn on-demand; do not preallocate. Reap idle agents after task completion.
 
+### Parallel builder isolation (#117)
+
+Do **not** rely on the `Agent` tool's `isolation: "worktree"` for parallel
+builders — the harness `WorktreeCreate` hook does not reroot a subagent's Bash
+CWD, so siblings share one working tree and a builder's `git checkout` clobbers
+another's uncommitted work. Instead the coordinator pre-creates one isolated
+worktree per builder with [`bin/swarm-worktrees.sh`](bin/swarm-worktrees.sh):
+
+```
+bin/swarm-worktrees.sh add <task> <branchA> <branchB> ...   # prints one checkout path per line
+bin/swarm-worktrees.sh list <task>
+bin/swarm-worktrees.sh cleanup <task>                        # removes checkouts; keeps branches
+```
+
+Dispatch each builder with an explicit `cd .worktrees/<task>/<branch>` and grant
+its Bash perms that path. Coordinator (not subagents) does commit/push/PR.
+
 ## Key references
 
 - [`docs/superpowers/specs/2026-04-19-chrome-port-backlog-design.md`](docs/superpowers/specs/2026-04-19-chrome-port-backlog-design.md) — approved design for this initial phase.

--- a/bin/__tests__/swarm-worktrees.test.ts
+++ b/bin/__tests__/swarm-worktrees.test.ts
@@ -147,6 +147,42 @@ describe('swarm-worktrees.sh — list / cleanup', () => {
   });
 });
 
+describe('swarm-worktrees.sh — path containment (security regression for #117 review)', () => {
+  it('refuses a traversing task name and performs NO rm outside .worktrees/', () => {
+    // A sibling of the repo that must survive — proves cleanup cannot rm-rf out
+    // of the .worktrees/ subtree via a `..` task.
+    const victimName = `victim-${process.pid}`;
+    const victim = join(repo, '..', victimName);
+    writeFileSync(victim, 'keep');
+    try {
+      const res = run(repo, ['cleanup', `../${victimName}`]);
+      expect(res.status).toBe(2);
+      // The destructive path never ran — sibling intact.
+      expect(existsSync(victim)).toBe(true);
+    } finally {
+      rmSync(victim, { force: true });
+    }
+  });
+
+  it('refuses task = ".." (would target the repo root)', () => {
+    const res = run(repo, ['cleanup', '..']);
+    expect(res.status).toBe(2);
+    // Repo working tree intact.
+    expect(existsSync(join(repo, 'README.md'))).toBe(true);
+  });
+
+  it('refuses a task containing a slash', () => {
+    expect(run(repo, ['add', 'a/b', 'br']).status).toBe(2);
+  });
+
+  it('refuses a branch name that escapes via ..', () => {
+    const res = run(repo, ['add', 'tasksec', '../../evil']);
+    expect(res.status).toBe(2);
+    // No worktree was created (validation runs before any add).
+    expect(existsSync(join(repo, '.worktrees/tasksec'))).toBe(false);
+  });
+});
+
 describe('swarm-worktrees.sh — usage', () => {
   it('exits 2 with no command', () => {
     expect(run(repo, []).status).toBe(2);

--- a/bin/__tests__/swarm-worktrees.test.ts
+++ b/bin/__tests__/swarm-worktrees.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Tests for bin/swarm-worktrees.sh (issue #117).
+ *
+ * The script is the coordinator-side workaround for the broken Agent
+ * `isolation: "worktree"` hook: it pre-creates one isolated git worktree per
+ * builder under `.worktrees/<task>/<branch>` so parallel builders never share a
+ * checkout. These tests run the script against a THROWAWAY temp git repo so no
+ * worktree op touches the real working tree.
+ */
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const SCRIPT = join(REPO_ROOT, 'bin', 'swarm-worktrees.sh');
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+function run(cwd: string, args: string[]): RunResult {
+  try {
+    const stdout = execFileSync('bash', [SCRIPT, ...args], {
+      cwd,
+      env: { ...process.env },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    return {
+      status: e.status ?? 1,
+      stdout: e.stdout?.toString() ?? '',
+      stderr: e.stderr?.toString() ?? '',
+    };
+  }
+}
+
+let repo: string;
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), 'swarm-wt-'));
+  git(repo, 'init', '-q', '-b', 'main');
+  git(repo, 'config', 'user.email', 'test@example.com');
+  git(repo, 'config', 'user.name', 'Test');
+  writeFileSync(join(repo, 'README.md'), '# fixture\n');
+  git(repo, 'add', 'README.md');
+  git(repo, 'commit', '-q', '-m', 'init');
+});
+
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+describe('swarm-worktrees.sh — add', () => {
+  it('creates one isolated worktree per branch, each checked out on its own branch', () => {
+    const res = run(repo, ['add', 'task1', 'b1', 'b2']);
+    expect(res.status).toBe(0);
+
+    const p1 = join(repo, '.worktrees/task1/b1');
+    const p2 = join(repo, '.worktrees/task1/b2');
+    // Prints one created path per line.
+    expect(res.stdout).toContain(p1);
+    expect(res.stdout).toContain(p2);
+    expect(existsSync(p1)).toBe(true);
+    expect(existsSync(p2)).toBe(true);
+
+    // Each worktree is a DISTINCT checkout on its OWN branch — the isolation
+    // the broken hook failed to provide.
+    expect(git(p1, 'branch', '--show-current').trim()).toBe('b1');
+    expect(git(p2, 'branch', '--show-current').trim()).toBe('b2');
+    // Main tree is untouched (still on main).
+    expect(git(repo, 'branch', '--show-current').trim()).toBe('main');
+  });
+
+  it('supports nested branch names (feature/x)', () => {
+    const res = run(repo, ['add', 'task2', 'feature/x']);
+    expect(res.status).toBe(0);
+    const p = join(repo, '.worktrees/task2/feature/x');
+    expect(existsSync(p)).toBe(true);
+    expect(git(p, 'branch', '--show-current').trim()).toBe('feature/x');
+  });
+
+  it('attaches an EXISTING branch instead of failing with -b', () => {
+    git(repo, 'branch', 'preexisting');
+    const res = run(repo, ['add', 'task3', 'preexisting']);
+    expect(res.status).toBe(0);
+    expect(git(join(repo, '.worktrees/task3/preexisting'), 'branch', '--show-current').trim()).toBe(
+      'preexisting',
+    );
+  });
+
+  it('refuses to overwrite an existing worktree path (discriminating: non-zero exit)', () => {
+    expect(run(repo, ['add', 'task4', 'dup']).status).toBe(0);
+    const second = run(repo, ['add', 'task4', 'dup']);
+    expect(second.status).not.toBe(0);
+    expect(second.stderr).toMatch(/already exists/);
+  });
+
+  it('errors when add is given no branches', () => {
+    const res = run(repo, ['add', 'task5']);
+    expect(res.status).toBe(2);
+  });
+});
+
+describe('swarm-worktrees.sh — list / cleanup', () => {
+  it('lists the worktrees for a task', () => {
+    run(repo, ['add', 'taskL', 'b1', 'b2']);
+    const res = run(repo, ['list', 'taskL']);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('.worktrees/taskL/b1');
+    expect(res.stdout).toContain('.worktrees/taskL/b2');
+  });
+
+  it('cleanup removes every worktree for the task and reclaims the dir', () => {
+    run(repo, ['add', 'taskC', 'b1', 'feature/y']);
+    expect(existsSync(join(repo, '.worktrees/taskC/b1'))).toBe(true);
+
+    const res = run(repo, ['cleanup', 'taskC']);
+    expect(res.status).toBe(0);
+
+    // Dir gone, and git no longer tracks the worktrees.
+    expect(existsSync(join(repo, '.worktrees/taskC'))).toBe(false);
+    const wtList = git(repo, 'worktree', 'list', '--porcelain');
+    expect(wtList).not.toContain('.worktrees/taskC/');
+    // Branches survive cleanup (may hold unmerged work / open PRs).
+    expect(git(repo, 'branch', '--list', 'b1').trim()).toContain('b1');
+  });
+
+  it('cleanup is a safe no-op for an unknown task', () => {
+    expect(run(repo, ['cleanup', 'never-existed']).status).toBe(0);
+  });
+});
+
+describe('swarm-worktrees.sh — usage', () => {
+  it('exits 2 with no command', () => {
+    expect(run(repo, []).status).toBe(2);
+  });
+  it('exits 2 on an unknown command', () => {
+    expect(run(repo, ['frobnicate', 'task']).status).toBe(2);
+  });
+});

--- a/bin/swarm-worktrees.sh
+++ b/bin/swarm-worktrees.sh
@@ -12,10 +12,11 @@
 #
 #   add <task> <branch>...   Create a worktree per branch under
 #                            .worktrees/<task>/<branch>. New branches are cut
-#                            from WORKTREE_BASE (default HEAD); existing
-#                            branches are attached as-is. Prints one created
-#                            path per line (consumed by the coordinator to
-#                            `cd` each builder into its own checkout).
+#                            from HEAD (sync `main` before dispatch if you need
+#                            a fresher base); existing branches are attached
+#                            as-is. Prints one created path per line (consumed
+#                            by the coordinator to `cd` each builder into its
+#                            own checkout).
 #   list <task>              List the registered worktrees for <task>.
 #   cleanup <task>           Remove every worktree under .worktrees/<task> and
 #                            prune. Does NOT delete the branches (they may hold
@@ -32,7 +33,6 @@ set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 WT_DIR=".worktrees"
-BASE="${WORKTREE_BASE:-HEAD}"
 
 usage() {
   echo "usage: swarm-worktrees.sh <add|list|cleanup> <task> [branch...]" >&2
@@ -46,6 +46,21 @@ task="${1:-}"
 [ -n "$task" ] || usage
 shift || true
 
+# CONTAINMENT (security): `task` is a single path segment under .worktrees/. It
+# flows into `git worktree add` paths and `rm -rf` (cleanup), so a `/` or `..`
+# would let those escape the .worktrees/ subtree and delete/clobber arbitrary
+# dirs (e.g. `cleanup ..` → rm -rf the repo root). Restrict to a flat slug.
+case "$task" in
+  . | ..)
+    echo "swarm-worktrees: invalid task name: '$task'" >&2
+    exit 2
+    ;;
+  *[!A-Za-z0-9._-]*)
+    echo "swarm-worktrees: task must be a flat slug [A-Za-z0-9._-] (no '/' or '..'): '$task'" >&2
+    exit 2
+    ;;
+esac
+
 base_path="$ROOT/$WT_DIR/$task"
 
 case "$cmd" in
@@ -54,6 +69,14 @@ case "$cmd" in
       echo "swarm-worktrees: 'add' needs at least one branch" >&2
       exit 2
     }
+    # Validate EVERY branch up front (security: a `..`-bearing ref would escape
+    # the task subtree; also makes the loop fail before creating partial state).
+    for br in "$@"; do
+      if ! git check-ref-format "refs/heads/$br"; then
+        echo "swarm-worktrees: invalid branch name: '$br'" >&2
+        exit 2
+      fi
+    done
     for br in "$@"; do
       path="$base_path/$br"
       if [ -e "$path" ]; then
@@ -64,8 +87,8 @@ case "$cmd" in
         # Branch exists — attach it (cannot be checked out in another worktree).
         git -C "$ROOT" worktree add "$path" "$br" >&2
       else
-        # New branch cut from the base ref.
-        git -C "$ROOT" worktree add "$path" -b "$br" "$BASE" >&2
+        # New branch cut from HEAD.
+        git -C "$ROOT" worktree add "$path" -b "$br" HEAD >&2
       fi
       echo "$path"
     done

--- a/bin/swarm-worktrees.sh
+++ b/bin/swarm-worktrees.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# swarm-worktrees.sh — isolated git worktrees for parallel builder dispatch (#117).
+#
+# Workaround for the broken Agent `isolation: "worktree"` mechanism (the
+# harness `WorktreeCreate` hook fails to reroot a subagent's Bash CWD, so
+# parallel builders share one working tree and one builder's `git checkout`
+# clobbers a sibling's uncommitted work). The coordinator calls this tool to
+# pre-create ONE worktree per builder under `.worktrees/<task>/<branch>`, so
+# each builder has an isolated checkout that no sibling can switch out from
+# under it.
+#
+#   add <task> <branch>...   Create a worktree per branch under
+#                            .worktrees/<task>/<branch>. New branches are cut
+#                            from WORKTREE_BASE (default HEAD); existing
+#                            branches are attached as-is. Prints one created
+#                            path per line (consumed by the coordinator to
+#                            `cd` each builder into its own checkout).
+#   list <task>              List the registered worktrees for <task>.
+#   cleanup <task>           Remove every worktree under .worktrees/<task> and
+#                            prune. Does NOT delete the branches (they may hold
+#                            unmerged work / open PRs); only the checkouts and
+#                            disk are reclaimed.
+#
+# Run from anywhere inside the repo. Exits 0 on success; non-zero with a
+# diagnostic on any failure. POSIX-bash compatible (dev macOS, Ubuntu CI).
+#
+# `.worktrees/` is gitignored, so the linked checkouts never show as untracked
+# in the main tree. See CLAUDE.md swarm config + issue #117.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+WT_DIR=".worktrees"
+BASE="${WORKTREE_BASE:-HEAD}"
+
+usage() {
+  echo "usage: swarm-worktrees.sh <add|list|cleanup> <task> [branch...]" >&2
+  exit 2
+}
+
+cmd="${1:-}"
+[ -n "$cmd" ] || usage
+shift
+task="${1:-}"
+[ -n "$task" ] || usage
+shift || true
+
+base_path="$ROOT/$WT_DIR/$task"
+
+case "$cmd" in
+  add)
+    [ "$#" -ge 1 ] || {
+      echo "swarm-worktrees: 'add' needs at least one branch" >&2
+      exit 2
+    }
+    for br in "$@"; do
+      path="$base_path/$br"
+      if [ -e "$path" ]; then
+        echo "swarm-worktrees: path already exists: $path" >&2
+        exit 1
+      fi
+      if git -C "$ROOT" show-ref --verify --quiet "refs/heads/$br"; then
+        # Branch exists — attach it (cannot be checked out in another worktree).
+        git -C "$ROOT" worktree add "$path" "$br" >&2
+      else
+        # New branch cut from the base ref.
+        git -C "$ROOT" worktree add "$path" -b "$br" "$BASE" >&2
+      fi
+      echo "$path"
+    done
+    ;;
+
+  list)
+    # Porcelain path lines that live under this task's subtree.
+    git -C "$ROOT" worktree list --porcelain \
+      | awk '/^worktree /{print $2}' \
+      | grep -F "/$WT_DIR/$task/" || true
+    ;;
+
+  cleanup)
+    # Remove each registered worktree under the task subtree (handles nested
+    # branch names like feature/x), then reclaim disk and prune stale refs.
+    while IFS= read -r path; do
+      [ -n "$path" ] || continue
+      git -C "$ROOT" worktree remove --force "$path" 2>/dev/null || true
+    done < <(
+      git -C "$ROOT" worktree list --porcelain \
+        | awk '/^worktree /{print $2}' \
+        | grep -F "/$WT_DIR/$task/" || true
+    )
+    rm -rf "$base_path"
+    git -C "$ROOT" worktree prune
+    ;;
+
+  *)
+    usage
+    ;;
+esac


### PR DESCRIPTION
## Summary

Closes the impact of #117 — `Agent(isolation:"worktree")` does not isolate
parallel builders. Re-verified this session: two parallel `isolation:"worktree"`
probes HARD-FAILED ("WorktreeCreate hook returned a path that is not a
directory"). The hook lives in the claude-code-harness plugin (compiled Go),
so it is upstream and not patchable from this repo.

In-repo mitigation: `bin/swarm-worktrees.sh` — the coordinator pre-creates one
isolated git worktree per builder under `.worktrees/<task>/<branch>` so parallel
builders never share a checkout.

```
bin/swarm-worktrees.sh add <task> <branchA> <branchB> ...  # prints checkout paths
bin/swarm-worktrees.sh list <task>
bin/swarm-worktrees.sh cleanup <task>   # removes checkouts; keeps branches
```

## Test Plan

- [x] `npm test` — 1477 passed, incl. 10 new spawn-tests for the script
      (isolation per branch, nested names, existing-branch attach, dup-path
      refusal → non-zero, list, cleanup reclaims dir + keeps branches, usage)
- [x] `npm run lint` / `format:check` / `build` — green
- [x] Real-repo smoke: `add smoke117 probe-a probe-b` → 2 worktrees on distinct
      branches, main tree stayed on `main`; `cleanup` reclaimed the dir

## Notes
- Touches `CLAUDE.md` (agent-routing note: prefer this over `isolation:"worktree"`).
- `.worktrees/` already gitignored.
- `cleanup` keeps branches by design (they may hold unmerged work / open PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
