### PR TITLE
feat(#197): clearAll() orphan-sweep for unindexed position:* keys

### DIFF
--- a/src/chrome/background/position/__tests__/handlers.test.ts
+++ b/src/chrome/background/position/__tests__/handlers.test.ts
@@ -23,6 +23,11 @@ function spyAdapter() {
     remove: vi.fn(async (keys: string[]) => {
       for (const k of keys) map.delete(k);
     }),
+    getAll: vi.fn(async () => {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of map.entries()) out[k] = v;
+      return out;
+    }),
   };
   return { adapter, map };
 }

--- a/src/chrome/background/position/__tests__/handlers.test.ts
+++ b/src/chrome/background/position/__tests__/handlers.test.ts
@@ -23,11 +23,7 @@ function spyAdapter() {
     remove: vi.fn(async (keys: string[]) => {
       for (const k of keys) map.delete(k);
     }),
-    getAll: vi.fn(async () => {
-      const out: Record<string, unknown> = {};
-      for (const [k, v] of map.entries()) out[k] = v;
-      return out;
-    }),
+    getKeys: vi.fn(async () => [...map.keys()]),
   };
   return { adapter, map };
 }

--- a/src/chrome/background/position/__tests__/store.test.ts
+++ b/src/chrome/background/position/__tests__/store.test.ts
@@ -20,11 +20,7 @@ function spyAdapter() {
     remove: vi.fn(async (keys: string[]) => {
       for (const k of keys) map.delete(k);
     }),
-    getAll: vi.fn(async () => {
-      const out: Record<string, unknown> = {};
-      for (const [k, v] of map.entries()) out[k] = v;
-      return out;
-    }),
+    getKeys: vi.fn(async () => [...map.keys()]),
   };
   return { adapter, map };
 }

--- a/src/chrome/background/position/__tests__/store.test.ts
+++ b/src/chrome/background/position/__tests__/store.test.ts
@@ -20,6 +20,11 @@ function spyAdapter() {
     remove: vi.fn(async (keys: string[]) => {
       for (const k of keys) map.delete(k);
     }),
+    getAll: vi.fn(async () => {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of map.entries()) out[k] = v;
+      return out;
+    }),
   };
   return { adapter, map };
 }

--- a/src/chrome/storage/__tests__/chrome-position-store.test.ts
+++ b/src/chrome/storage/__tests__/chrome-position-store.test.ts
@@ -13,6 +13,7 @@ interface FakeLocalStorage {
   get: ReturnType<typeof vi.fn>;
   set: ReturnType<typeof vi.fn>;
   remove: ReturnType<typeof vi.fn>;
+  getKeys: ReturnType<typeof vi.fn>;
 }
 
 let fakeStore: Map<string, unknown>;
@@ -39,6 +40,7 @@ beforeEach(() => {
       const keyList = Array.isArray(keys) ? keys : [keys];
       for (const k of keyList) fakeStore.delete(k);
     }),
+    getKeys: vi.fn(async () => [...fakeStore.keys()]),
   };
   originalChrome = globalThis.chrome;
   // Minimal cast — we only stub the surface the adapter uses.
@@ -94,5 +96,31 @@ describe('chrome-position-store adapter', () => {
     for (const call of local.set.mock.calls) {
       expect(call.length).toBe(1);
     }
+  });
+
+  /**
+   * #197 — the adapter's `getKeys()` maps to `chrome.storage.local.getKeys()`,
+   * the only production wiring of the orphan-sweep enumeration. The core
+   * store's tests use hand-rolled fakes, so this is the sole guard that the
+   * real adapter reaches the right Chrome API. Mutation evidence: changing
+   * `chrome.storage.local.getKeys()` to `.get(null)` (or dropping the await)
+   * leaves the orphan unswept and flips this test red.
+   */
+  test('clearAll() orphan sweep round-trips through chrome.storage.local.getKeys()', async () => {
+    const store = createChromePositionStore();
+    // An orphan position:* key the LRU index never tracked.
+    fakeStore.set('position:https://orphan.example.com/', {
+      schemaVersion: 1,
+      wordIndex: 1,
+      totalWords: 10,
+    });
+    // A non-position key that must survive.
+    fakeStore.set('settings.theme', { value: 'dark' });
+
+    await store.clearAll();
+
+    expect(local.getKeys).toHaveBeenCalled();
+    expect(fakeStore.has('position:https://orphan.example.com/')).toBe(false);
+    expect(fakeStore.get('settings.theme')).toEqual({ value: 'dark' });
   });
 });

--- a/src/chrome/storage/chrome-position-store.ts
+++ b/src/chrome/storage/chrome-position-store.ts
@@ -52,11 +52,13 @@ function chromeStorageAdapter(): StorageAdapter {
     async remove(keys) {
       await chrome.storage.local.remove(keys);
     },
-    async getAll() {
-      // `get(null)` returns the ENTIRE `chrome.storage.local` namespace.
-      // Used only by the core store's `clearAll()` orphan sweep — a rare,
-      // user-initiated path. Do NOT call on read/write/touch hot paths.
-      return (await chrome.storage.local.get(null)) as Record<string, unknown>;
+    async getKeys() {
+      // `getKeys()` returns every key NAME in `chrome.storage.local`
+      // WITHOUT deserializing values (Chrome 130+; this extension pins a
+      // 140 floor). Used only by the core store's `clearAll()` orphan
+      // sweep — a rare, user-initiated path. Do NOT call on
+      // read/write/touch hot paths.
+      return chrome.storage.local.getKeys();
     },
   };
 }

--- a/src/chrome/storage/chrome-position-store.ts
+++ b/src/chrome/storage/chrome-position-store.ts
@@ -52,6 +52,12 @@ function chromeStorageAdapter(): StorageAdapter {
     async remove(keys) {
       await chrome.storage.local.remove(keys);
     },
+    async getAll() {
+      // `get(null)` returns the ENTIRE `chrome.storage.local` namespace.
+      // Used only by the core store's `clearAll()` orphan sweep — a rare,
+      // user-initiated path. Do NOT call on read/write/touch hot paths.
+      return (await chrome.storage.local.get(null)) as Record<string, unknown>;
+    },
   };
 }
 

--- a/src/core/storage/__tests__/reading-position.test.ts
+++ b/src/core/storage/__tests__/reading-position.test.ts
@@ -53,6 +53,11 @@ function createMemoryAdapter(): StorageAdapter & { snapshot(): Record<string, un
         map.delete(k);
       }
     },
+    async getAll() {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of map.entries()) out[k] = structuredClone(v);
+      return out;
+    },
     snapshot() {
       return Object.fromEntries(map.entries());
     },
@@ -411,6 +416,12 @@ describe('reading-position store — concurrent writes serialize through the que
       async remove(keys) {
         for (const k of keys) map.delete(k);
       },
+      async getAll() {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of map.entries()) out[k] = structuredClone(v);
+        return out;
+      },
       snapshot() {
         return Object.fromEntries(map.entries());
       },
@@ -513,6 +524,11 @@ describe('reading-position store — concurrent writes serialize through the que
       async remove(keys) {
         for (const k of keys) map.delete(k);
       },
+      async getAll() {
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of map.entries()) out[k] = structuredClone(v);
+        return out;
+      },
     };
     const flakeyStore = createReadingPositionStore({
       adapter: flakeyAdapter,
@@ -613,27 +629,64 @@ describe('reading-position store — makeReadingPosition smart constructor (via 
   });
 });
 
-describe('reading-position store — clearAll() orphan-key contract', () => {
-  test('orphan position:* keys NOT referenced by the index are LEFT in place', async () => {
-    // Document the pragmatic boundary of `clearAll`: it removes only
-    // what the LRU index tracks. Orphans from a crashed write that
-    // updated the payload but not the index survive — sweeping them
-    // would require a full `get(null)` over chrome.storage.local on a
-    // user-facing hot path. Pinning this so a future "extend clearAll
-    // to also sweep orphans" change has to flip an explicit test.
-    const orphanKey = `${'position:'}https://orphan.example.com/`;
+describe('reading-position store — clearAll() orphan sweep (#197)', () => {
+  // Inverts the prior negative-pin (#195 TG6): clearAll() now SWEEPS
+  // orphaned `position:*` keys that the LRU index never tracked, in
+  // addition to the index-keyed removal. Orphans arise from a crashed
+  // write that landed the payload but lost the index update.
+  //
+  // Mutation evidence: delete the `getAll()` sweep block in
+  // `clearAll()` (so it removes only `index`) and the "orphan + index"
+  // and "only orphan" cases below go red — the orphan survives.
+
+  test('removes BOTH an indexed entry and an unindexed orphan', async () => {
+    const orphanKey = `position:https://orphan.example.com/`;
     await adapter.set({ [orphanKey]: { schemaVersion: 1, wordIndex: 1, totalWords: 10 } });
-    // Plus a tracked entry to prove clearAll DID run.
     await store.write('https://example.com/tracked', { wordIndex: 1, totalWords: 10 });
 
     await store.clearAll();
 
     const snap = adapter.snapshot();
-    // Tracked entry and index are gone.
     expect(snap[keyOf('https://example.com/tracked')]).toBeUndefined();
     expect(snap[POSITION_INDEX_KEY]).toBeUndefined();
-    // Orphan remains — documented behavior.
-    expect(snap[orphanKey]).toEqual({ schemaVersion: 1, wordIndex: 1, totalWords: 10 });
+    // Orphan is now swept — the discriminating assertion.
+    expect(snap[orphanKey]).toBeUndefined();
+  });
+
+  test('removes an orphan even when the index is absent (empty-index crash case)', async () => {
+    // The orphan-producing failure mode: write() landed the payload but
+    // the index update was lost, so there is NO index at all. A sweep
+    // gated on a non-empty index would miss this exact key.
+    const orphanKey = `position:https://orphan.example.com/`;
+    await adapter.set({ [orphanKey]: { schemaVersion: 1, wordIndex: 1, totalWords: 10 } });
+
+    await store.clearAll();
+
+    expect(adapter.snapshot()[orphanKey]).toBeUndefined();
+  });
+
+  test('does NOT remove non-position keys (settings.*, font:*, etc.)', async () => {
+    // Explicit regression: a sweep that nukes everything must fail this.
+    await adapter.set({
+      'settings.theme': { value: 'dark' },
+      'font:default': { family: 'OpenDyslexic' },
+      'session-state': { lastTab: 7 },
+    });
+    const orphanKey = `position:https://orphan.example.com/`;
+    await adapter.set({ [orphanKey]: { schemaVersion: 1, wordIndex: 1, totalWords: 10 } });
+
+    await store.clearAll();
+
+    const snap = adapter.snapshot();
+    expect(snap[orphanKey]).toBeUndefined();
+    expect(snap['settings.theme']).toEqual({ value: 'dark' });
+    expect(snap['font:default']).toEqual({ family: 'OpenDyslexic' });
+    expect(snap['session-state']).toEqual({ lastTab: 7 });
+  });
+
+  test('empty store with no orphans → no-op (still scans, does not throw)', async () => {
+    await expect(store.clearAll()).resolves.toBeUndefined();
+    expect(Object.keys(adapter.snapshot())).toHaveLength(0);
   });
 });
 

--- a/src/core/storage/__tests__/reading-position.test.ts
+++ b/src/core/storage/__tests__/reading-position.test.ts
@@ -53,10 +53,8 @@ function createMemoryAdapter(): StorageAdapter & { snapshot(): Record<string, un
         map.delete(k);
       }
     },
-    async getAll() {
-      const out: Record<string, unknown> = {};
-      for (const [k, v] of map.entries()) out[k] = structuredClone(v);
-      return out;
+    async getKeys() {
+      return [...map.keys()];
     },
     snapshot() {
       return Object.fromEntries(map.entries());
@@ -416,11 +414,9 @@ describe('reading-position store — concurrent writes serialize through the que
       async remove(keys) {
         for (const k of keys) map.delete(k);
       },
-      async getAll() {
+      async getKeys() {
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
-        const out: Record<string, unknown> = {};
-        for (const [k, v] of map.entries()) out[k] = structuredClone(v);
-        return out;
+        return [...map.keys()];
       },
       snapshot() {
         return Object.fromEntries(map.entries());
@@ -524,10 +520,8 @@ describe('reading-position store — concurrent writes serialize through the que
       async remove(keys) {
         for (const k of keys) map.delete(k);
       },
-      async getAll() {
-        const out: Record<string, unknown> = {};
-        for (const [k, v] of map.entries()) out[k] = structuredClone(v);
-        return out;
+      async getKeys() {
+        return [...map.keys()];
       },
     };
     const flakeyStore = createReadingPositionStore({
@@ -635,9 +629,9 @@ describe('reading-position store — clearAll() orphan sweep (#197)', () => {
   // addition to the index-keyed removal. Orphans arise from a crashed
   // write that landed the payload but lost the index update.
   //
-  // Mutation evidence: delete the `getAll()` sweep block in
-  // `clearAll()` (so it removes only `index`) and the "orphan + index"
-  // and "only orphan" cases below go red — the orphan survives.
+  // Mutation evidence: revert the `getKeys()` sweep in `clearAll()` to
+  // an index-only removal and the "orphan + index" and "only orphan"
+  // cases below go red — the orphan survives.
 
   test('removes BOTH an indexed entry and an unindexed orphan', async () => {
     const orphanKey = `position:https://orphan.example.com/`;

--- a/src/core/storage/reading-position.ts
+++ b/src/core/storage/reading-position.ts
@@ -99,6 +99,14 @@ export interface StorageAdapter {
   get(keys: string[]): Promise<Record<string, unknown>>;
   set(items: Record<string, unknown>): Promise<void>;
   remove(keys: string[]): Promise<void>;
+  /**
+   * Returns EVERY key/value in the backing store (maps to
+   * `chrome.storage.local.get(null)`). The store uses this only on the
+   * `clearAll()` orphan sweep — a rare, user-initiated destructive path
+   * where a one-time full scan is acceptable. It is NEVER called on the
+   * write/touch/read hot path. Keep it off hot paths in any new caller.
+   */
+  getAll(): Promise<Record<string, unknown>>;
 }
 
 export interface ReadingPositionStore {
@@ -132,19 +140,22 @@ export interface ReadingPositionStore {
    */
   list(): Promise<Array<{ url: string; position: ReadingPosition }>>;
   /**
-   * Removes every position currently tracked in the LRU index, plus
-   * the index itself. Exposed for #49 (popup "clear reading history"
-   * affordance). Non-position keys in the adapter are left untouched.
+   * Removes every `position:*` key — both those tracked by the LRU
+   * index AND orphans not referenced by it — plus the index itself.
+   * Exposed for #49 (popup "clear reading history" affordance).
+   * Non-position keys in the adapter are left untouched.
    *
-   * Orphaned `position:*` keys that are NOT referenced by the index
-   * (e.g. from a crashed write that updated the payload but not the
-   * index) are NOT cleaned by this call — they remain dormant in
-   * `chrome.storage.local` and are only recovered when their URL is
-   * next written. `chrome.storage.local` has no prefix-scan API; a
-   * full sweep would require `get(null)` which loads the entire
-   * extension storage (settings, session state, future feature
-   * payloads) into memory on a hot user-facing path. Tracked as a
-   * separate maintenance follow-up.
+   * Orphans arise when a `write()` lands the payload (step 1) but the
+   * subsequent index update (step 2) is lost to an SW kill, browser
+   * hard-quit, or mid-write quota trip. `chrome.storage.local` has no
+   * prefix-scan API, so the sweep performs one `getAll()`
+   * (`chrome.storage.local.get(null)`) to enumerate every key, filters
+   * the `position:` prefix, and removes the union with the index. Cost:
+   * exactly one full-storage scan per `clearAll()` — acceptable on this
+   * rare, user-initiated destructive path. The sweep runs
+   * unconditionally (NOT gated on a non-empty index), because the
+   * orphan-producing failure mode can leave the index empty while a
+   * payload survives (#197).
    */
   clearAll(): Promise<void>;
 }
@@ -356,7 +367,18 @@ export function createReadingPositionStore(
     clearAll() {
       return enqueue(async () => {
         const index = await readIndex();
-        if (index.length > 0) await adapter.remove(index);
+        // Orphan sweep (#197): enumerate ALL keys and remove every
+        // `position:*` one, not just those the index tracks. Runs
+        // unconditionally — an orphan-producing crash can leave the
+        // index empty while a stranded payload survives, so gating on
+        // `index.length > 0` would miss exactly the keys this exists to
+        // collect. Union with `index` so an index entry whose payload
+        // was lost (the opposite failure) is still de-listed; removing
+        // an absent key is a harmless no-op.
+        const all = await adapter.getAll();
+        const positionKeys = Object.keys(all).filter((k) => k.startsWith(POSITION_KEY_PREFIX));
+        const toRemove = Array.from(new Set([...index, ...positionKeys]));
+        if (toRemove.length > 0) await adapter.remove(toRemove);
         await adapter.remove([POSITION_INDEX_KEY]);
       });
     },

--- a/src/core/storage/reading-position.ts
+++ b/src/core/storage/reading-position.ts
@@ -100,13 +100,15 @@ export interface StorageAdapter {
   set(items: Record<string, unknown>): Promise<void>;
   remove(keys: string[]): Promise<void>;
   /**
-   * Returns EVERY key/value in the backing store (maps to
-   * `chrome.storage.local.get(null)`). The store uses this only on the
-   * `clearAll()` orphan sweep — a rare, user-initiated destructive path
-   * where a one-time full scan is acceptable. It is NEVER called on the
-   * write/touch/read hot path. Keep it off hot paths in any new caller.
+   * Returns EVERY key name in the backing store (maps to
+   * `chrome.storage.local.getKeys()`). Keys only — NOT values — because
+   * the sole caller (`clearAll()`'s orphan sweep) discards values; this
+   * avoids deserializing the entire namespace's payloads just to read
+   * their key names. Used only on the `clearAll()` orphan sweep — a
+   * rare, user-initiated destructive path. NEVER called on the
+   * write/touch/read hot path; keep it off hot paths in any new caller.
    */
-  getAll(): Promise<Record<string, unknown>>;
+  getKeys(): Promise<string[]>;
 }
 
 export interface ReadingPositionStore {
@@ -148,14 +150,14 @@ export interface ReadingPositionStore {
    * Orphans arise when a `write()` lands the payload (step 1) but the
    * subsequent index update (step 2) is lost to an SW kill, browser
    * hard-quit, or mid-write quota trip. `chrome.storage.local` has no
-   * prefix-scan API, so the sweep performs one `getAll()`
-   * (`chrome.storage.local.get(null)`) to enumerate every key, filters
-   * the `position:` prefix, and removes the union with the index. Cost:
-   * exactly one full-storage scan per `clearAll()` — acceptable on this
-   * rare, user-initiated destructive path. The sweep runs
-   * unconditionally (NOT gated on a non-empty index), because the
-   * orphan-producing failure mode can leave the index empty while a
-   * payload survives (#197).
+   * prefix-scan API, so the sweep performs one `getKeys()`
+   * (`chrome.storage.local.getKeys()`) to enumerate every key NAME
+   * (not value — the sweep discards values), then removes every
+   * `position:`-prefixed key. Cost: exactly one key-name enumeration
+   * per `clearAll()` — acceptable on this rare, user-initiated
+   * destructive path. The sweep runs unconditionally (NOT gated on a
+   * non-empty index), because the orphan-producing failure mode can
+   * leave the index empty while a payload survives (#197).
    */
   clearAll(): Promise<void>;
 }
@@ -366,19 +368,18 @@ export function createReadingPositionStore(
 
     clearAll() {
       return enqueue(async () => {
-        const index = await readIndex();
         // Orphan sweep (#197): enumerate ALL keys and remove every
-        // `position:*` one, not just those the index tracks. Runs
-        // unconditionally — an orphan-producing crash can leave the
-        // index empty while a stranded payload survives, so gating on
-        // `index.length > 0` would miss exactly the keys this exists to
-        // collect. Union with `index` so an index entry whose payload
-        // was lost (the opposite failure) is still de-listed; removing
-        // an absent key is a harmless no-op.
-        const all = await adapter.getAll();
-        const positionKeys = Object.keys(all).filter((k) => k.startsWith(POSITION_KEY_PREFIX));
-        const toRemove = Array.from(new Set([...index, ...positionKeys]));
-        if (toRemove.length > 0) await adapter.remove(toRemove);
+        // `position:*` one, not just those the index tracks. `getKeys()`
+        // returns every key in the namespace, so this set already
+        // contains both index-tracked keys AND orphans — no need to read
+        // or union the index (a stranded index entry can only reference a
+        // key that either already appears here or no longer exists). Runs
+        // unconditionally: an orphan-producing crash can leave the index
+        // empty while a stranded payload survives, so any index-gated
+        // short-circuit would miss exactly the keys this exists to clear.
+        const allKeys = await adapter.getKeys();
+        const positionKeys = allKeys.filter((k) => k.startsWith(POSITION_KEY_PREFIX));
+        if (positionKeys.length > 0) await adapter.remove(positionKeys);
         await adapter.remove([POSITION_INDEX_KEY]);
       });
     },


### PR DESCRIPTION
## Summary

Closes #197. `clearAll()` now sweeps orphaned `position:*` keys that the LRU index never tracked, in addition to the existing index-keyed removal. Orphans arise when a `write()` lands the payload but loses the subsequent index update to an SW kill, browser hard-quit, or mid-write quota trip.

## Design decision

- **Opportunistic sweep folded into `clearAll()`** (not a separate maintenance call or `chrome.alarms` schedule) — per #197 v1. `clearAll` is already the rare, user-initiated destructive path (popup/options "clear history"), so one storage enumeration there is acceptable and adds zero background work. Hot write/touch/read paths are untouched.
- **Seam:** `StorageAdapter` gains a required `getKeys()` -> `chrome.storage.local.getKeys()` (Chrome 130+; this extension pins a 140 floor). Keys **only**, not values — the sweep discards values, so enumerating key names avoids deserializing the whole namespace just to read its keys (O(key count), not O(total bytes)). `src/core` stays chrome-free; the chrome adapter owns the `chrome.*` call.
- **Always scans, never gated on a non-empty index** — the orphan-producing failure can leave the index empty while a stranded payload survives, so gating on `index.length > 0` would miss exactly the keys the sweep exists to clear. Because `getKeys()` enumerates the whole namespace, the position-prefixed subset already covers every removable key — no index read or union needed.

## Ring (perf + test-gap, medium tier)

- **perf:** initial draft used `get(null)` (deserializes every payload); switched to `getKeys()` to enumerate key names only — the load-bearing fix the critic flagged, free given the 140 floor.
- **test-gap:** added a chrome-adapter round-trip test pinning the real `getKeys()` wiring (core tests use fakes; this is the only production mapping to the Chrome API).

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm test` — 1485 pass
- [x] `npm run build` succeeds
- [x] Unit: orphan + indexed entry both removed
- [x] Unit: orphan removed even with NO index (empty-index crash case — discriminating)
- [x] Unit: non-position keys (`settings.*`, `font:*`, `session-state`) untouched
- [x] Unit: empty store -> no-op, no throw
- [x] Unit (chrome adapter): `clearAll()` round-trips through `chrome.storage.local.getKeys()`; orphan gone, non-position key survives
- [x] Mutation evidence: reverting the sweep to index-only turns the 3 orphan cases (core) + the chrome round-trip red

🤖 Generated with [Claude Code](https://claude.com/claude-code)
