### PR TITLE
chore: bump manifest version to 0.3.0

### DIFF
--- a/src/chrome/manifest.ts
+++ b/src/chrome/manifest.ts
@@ -23,7 +23,7 @@
 export default {
   manifest_version: 3,
   name: 'SpeedReader',
-  version: '0.2.0',
+  version: '0.3.0',
   description: 'RSVP reading accessibility extension for Chrome',
 
   // --- Minimum Chrome version ---------------------------------------------


### PR DESCRIPTION
## Summary
Bump `manifest.ts` version `0.2.0` → `0.3.0` to match `package.json` (v0.3.0 was already cut). The build hardcoded the version in `manifest.ts`, so shipped `dist/manifest.json` reported a stale `0.2.0`.

## Test plan
- [x] `npm run build` → `dist/manifest.json` reports `0.3.0`
- [x] `tsc --noEmit` clean
- [x] `vitest run manifest` — 5 pass (no version assertion affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
