### PR TITLE
fix(overlay): RSVP word size governed by responsive clamp + vertically centered

### DIFF
--- a/src/core/overlay/__tests__/font-size-stepper.test.ts
+++ b/src/core/overlay/__tests__/font-size-stepper.test.ts
@@ -190,22 +190,30 @@ describe('createOverlay — font-size stepper (#29)', () => {
     overlay.unmount();
   });
 
-  test('modal reflects initial fontSize via --rsvp-font-size custom property (cascades to word-region)', () => {
-    // Review M3 — the property is written on `modal` (ancestor) so the
-    // hot `word` element stays free of inline-style invalidation on
-    // every RSVP tick. `.word-region` reads it via CSS cascade.
+  test('#241 — initial fontSize does NOT pin --rsvp-font-size; the responsive clamp governs', () => {
+    // #241 — the body `fontSize` setting (default 20) previously drove
+    // `--rsvp-font-size: 20px` onto `.modal`, which overrode the designed
+    // responsive `clamp(40px, 8.5cqi + 0.5rem, 54px)` on `.word-region` and
+    // rendered the streaming word at 20px. Decoupled: mount no longer writes
+    // the custom property from fontSize, so the clamp is the live value.
     const overlay = createOverlay(
       defaultOpts({ initialSettings: defaultSettings({ fontSize: 32 }) }),
     );
     overlay.mount();
-    expect(getModal().style.getPropertyValue('--rsvp-font-size')).toBe('32px');
-    // word-region MUST NOT have an inline custom-prop write — the hot path
-    // must stay clean. This is the mutation guard for fix M3.
+    // Neither the modal ancestor nor the word region may carry an inline
+    // `--rsvp-font-size` write driven by the body fontSize — otherwise the
+    // clamp is dead fallback again. This is the discriminating assertion for
+    // the decouple: re-adding the setProperty in applyFontSize flips it RED.
+    expect(getModal().style.getPropertyValue('--rsvp-font-size')).toBe('');
     expect(getWordRegion().style.getPropertyValue('--rsvp-font-size')).toBe('');
     overlay.unmount();
   });
 
-  test('subscribeSettings emission with new fontSize updates the modal property', () => {
+  test('subscribeSettings emission refreshes stepper boundary state without pinning --rsvp-font-size (#241)', () => {
+    // #241 — fontSize no longer drives the custom property, so a settings
+    // emission must NOT write `--rsvp-font-size` (that would re-pin the word
+    // and override the responsive clamp). The boundary aria-disabled refresh
+    // — the still-live consequence of a fontSize change — keeps working.
     let notify: SettingsSubscriber = () => undefined;
     const overlay = createOverlay(
       defaultOpts({
@@ -218,46 +226,30 @@ describe('createOverlay — font-size stepper (#29)', () => {
     );
     overlay.mount();
     const modal = getModal();
-    expect(modal.style.getPropertyValue('--rsvp-font-size')).toBe('20px');
+    expect(modal.style.getPropertyValue('--rsvp-font-size')).toBe('');
     notify({ theme: 'system', wpm: 300, fontSize: 36 });
-    expect(modal.style.getPropertyValue('--rsvp-font-size')).toBe('36px');
-    // Stepper boundary state also refreshes on emission.
+    expect(modal.style.getPropertyValue('--rsvp-font-size')).toBe('');
+    // Stepper boundary state still refreshes on emission.
     notify({ theme: 'system', wpm: 300, fontSize: FONT_SIZE_MAX });
     expect(getIncBtn().getAttribute('aria-disabled')).toBe('true');
     overlay.unmount();
   });
 
-  test('mount-time clamps non-finite initial fontSize (M4 — POSITIVE_INFINITY → MIN)', () => {
-    // Review M4 — initialSettings flows in from the caller unclamped.
-    // subscribeSettings clamps but mount doesn't, so a malformed value
-    // (NaN, Infinity, negative) would write garbage CSS. Non-finite
-    // falls back to FONT_SIZE_MIN; finite-out-of-range clamps normally.
-    const overlay = createOverlay(
-      defaultOpts({
-        initialSettings: defaultSettings({ fontSize: Number.POSITIVE_INFINITY }),
-      }),
-    );
-    overlay.mount();
-    expect(getModal().style.getPropertyValue('--rsvp-font-size')).toBe(`${FONT_SIZE_MIN}px`);
-    overlay.unmount();
-  });
-
-  test('mount-time clamps negative initial fontSize to FONT_SIZE_MIN', () => {
-    const overlay = createOverlay(
-      defaultOpts({ initialSettings: defaultSettings({ fontSize: -50 }) }),
-    );
-    overlay.mount();
-    expect(getModal().style.getPropertyValue('--rsvp-font-size')).toBe(`${FONT_SIZE_MIN}px`);
-    overlay.unmount();
-  });
-
-  test('mount-time clamps over-large initial fontSize to FONT_SIZE_MAX', () => {
-    const overlay = createOverlay(
-      defaultOpts({ initialSettings: defaultSettings({ fontSize: 10_000 }) }),
-    );
-    overlay.mount();
-    expect(getModal().style.getPropertyValue('--rsvp-font-size')).toBe(`${FONT_SIZE_MAX}px`);
-    overlay.unmount();
+  test('mount-time non-finite/out-of-range fontSize never writes garbage --rsvp-font-size (#241)', () => {
+    // #241 — fontSize no longer drives the custom property at all, so even a
+    // malformed initial value cannot leak garbage CSS onto the modal. (Pre-#241
+    // the M4 clamp existed to stop NaN/Infinity/negative reaching setProperty;
+    // the decouple removes that write entirely, so the invariant is simply
+    // "no `--rsvp-font-size` is ever pinned from fontSize".)
+    for (const fontSize of [Number.POSITIVE_INFINITY, -50, 10_000]) {
+      const overlay = createOverlay(
+        defaultOpts({ initialSettings: defaultSettings({ fontSize }) }),
+      );
+      overlay.mount();
+      expect(getModal().style.getPropertyValue('--rsvp-font-size')).toBe('');
+      overlay.unmount();
+      document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+    }
   });
 
   test('omitting onFontSizeChange keeps the buttons clickable (no throw) but does not crash', () => {

--- a/src/core/overlay/__tests__/styles.test.ts
+++ b/src/core/overlay/__tests__/styles.test.ts
@@ -95,6 +95,37 @@ describe('OVERLAY_CSS word-region vertical centering (issue #241)', () => {
     expect(block, 'expected the default .word-region rule').not.toBeUndefined();
     expect(block).toMatch(/font-size:[^;]*clamp\(40px,\s*8\.5cqi \+ 0\.5rem,\s*54px\)/);
   });
+
+  // #241 (a11y ring MED) — the accent focus-ticks must anchor to the region's
+  // vertical CENTER, not its top/bottom EDGES. With the word now centered
+  // (align-items: center) and the region free to grow (touch flex: 1 1 auto,
+  // tall viewports), edge-anchored ticks (top: 18px / bottom: 6px) drift away
+  // from the centered word, breaking the equidistant gaze-anchor. Center
+  // anchoring (top: 50% + a vertical translate on each tick) keeps the two
+  // ticks symmetric about the word at ANY region height.
+  //
+  // Mutation check: reverting ::before to `top: 18px` / ::after to
+  // `bottom: 6px` (dropping the top: 50% center anchor) flips these RED.
+  test('::before focus-tick anchors to vertical center (top: 50% + translate), not the top edge', () => {
+    // Bind to the STANDALONE ::before rule, whose body opens directly with
+    // `top:` (only whitespace after `{`). The shared `::before, ::after`
+    // baseline block opens with `content:`, so anchoring the regex to
+    // `{\s*top:` excludes it (and its comment, which mentions "top: 50%").
+    const block = OVERLAY_CSS.match(/\.word-region::before\s*\{\s*top:[^}]*\}/)?.[0];
+    expect(block, 'expected the standalone ::before tick rule').not.toBeUndefined();
+    expect(block).toMatch(/top:\s*50%/);
+    expect(block).toMatch(/transform:\s*translate\(-50%,/);
+    expect(block).not.toMatch(/top:\s*18px/);
+  });
+
+  test('::after focus-tick anchors to vertical center (top: 50% + translate), not the bottom edge', () => {
+    // See ::before note — bind to the standalone rule via its `{\s*top:` open.
+    const block = OVERLAY_CSS.match(/\.word-region::after\s*\{\s*top:[^}]*\}/)?.[0];
+    expect(block, 'expected the standalone ::after tick rule').not.toBeUndefined();
+    expect(block).toMatch(/top:\s*50%/);
+    expect(block).toMatch(/transform:\s*translate\(-50%,/);
+    expect(block).not.toMatch(/bottom:\s*6px/);
+  });
 });
 
 describe('OVERLAY_CSS resume-toast is out of flow (issue #218)', () => {

--- a/src/core/overlay/__tests__/styles.test.ts
+++ b/src/core/overlay/__tests__/styles.test.ts
@@ -62,6 +62,41 @@ describe('OVERLAY_CSS theme-slot consumers (issue #150)', () => {
   });
 });
 
+describe('OVERLAY_CSS word-region vertical centering (issue #241)', () => {
+  // #241 — the default (non-touch) `.word-region` previously used
+  // `align-items: baseline`, so the streaming RSVP word hugged the top of
+  // the region while the accent focus-ticks (anchored to the region's
+  // vertical center) pointed at empty space. The fix centers the word at
+  // the default breakpoint so the word and the ticks share one axis.
+  //
+  // The default rule is the one carrying `font-family: var(--font-mono)`
+  // (the touch `@media (pointer: coarse)` `.word-region` override does not
+  // restate font-family), so the regex binds to that block specifically to
+  // avoid passing merely because the touch block already centers.
+  test('default .word-region uses align-items: center (not baseline)', () => {
+    const block = OVERLAY_CSS.match(
+      /\.word-region\s*\{[^}]*font-family:\s*var\(--font-mono[^}]*\}/,
+    )?.[0];
+    expect(block, 'expected the default .word-region rule').not.toBeUndefined();
+    expect(block).toMatch(/align-items:\s*center/);
+    expect(block).not.toMatch(/align-items:\s*baseline/);
+  });
+
+  // #241 — the responsive word size is governed by the clamp; the body
+  // `fontSize` setting must NOT pin `--rsvp-font-size` to a default-driven
+  // value (20px) that would override the clamp. The clamp must remain the
+  // value the word region actually resolves to. This guards the CSS source
+  // half of the decouple; the JS half (applyFontSize no longer writes the
+  // property) is covered in font-size-stepper.test.ts.
+  test('default .word-region keeps the responsive clamp as its font-size', () => {
+    const block = OVERLAY_CSS.match(
+      /\.word-region\s*\{[^}]*font-family:\s*var\(--font-mono[^}]*\}/,
+    )?.[0];
+    expect(block, 'expected the default .word-region rule').not.toBeUndefined();
+    expect(block).toMatch(/font-size:[^;]*clamp\(40px,\s*8\.5cqi \+ 0\.5rem,\s*54px\)/);
+  });
+});
+
 describe('OVERLAY_CSS resume-toast is out of flow (issue #218)', () => {
   // The resume toast (#48) is inserted in flow directly above the word
   // region and removed on its 5 s auto-dismiss / Start Over. While it was

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -841,13 +841,14 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     };
     const applyFontSize = (n: number): void => {
       currentFontSize = n;
-      // Write the custom property on the modal ancestor rather than the
-      // hot `word` element (review M3). `.word-region` reads
-      // `var(--rsvp-font-size)` via CSS custom-property inheritance, so
-      // moving the write up one level keeps the cascade working while
-      // avoiding inline-style invalidation on every RSVP tick (~10 Hz
-      // at 600 wpm).
-      modal.style.setProperty('--rsvp-font-size', `${n}px`);
+      // #241 — the streaming RSVP word is sized by the responsive
+      // `clamp(40px, 8.5cqi + 0.5rem, 54px)` on `.word-region` (styles.ts),
+      // NOT by the body `fontSize` setting. Writing `--rsvp-font-size` here
+      // pinned the word to the 20px default and made the clamp dead fallback,
+      // rendering the word tiny. So this no longer touches the custom property;
+      // it only keeps `currentFontSize` and the stepper boundary state in sync.
+      // (The A−/A+ stepper consequently no longer resizes the streaming word —
+      // accepted behavior change; it stays wired to onFontSizeChange/persistence.)
       // #215 — aria-disabled (not native `disabled`) so the buttons stay in
       // the tab chain at MIN/MAX (WCAG 2.4.3); the click handlers short-circuit
       // on it. Mirrors the #214 WPM-stepper treatment.

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -244,7 +244,10 @@ export const OVERLAY_CSS = `
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  align-items: baseline;
+  /* #241 — center the word vertically so it shares an axis with the accent
+   * focus-ticks (anchored to the region vertical center). baseline made the
+   * word hug the top while the ticks pointed at empty space. */
+  align-items: center;
   gap: 0 0.4ch;
   padding: 36px 24px 20px;
   font-family: var(--font-mono);

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -267,8 +267,17 @@ export const OVERLAY_CSS = `
   content: '';
   position: absolute;
   inset-inline-start: 50%;
-  transform: translateX(-50%);
+  /* #241 — anchor both ticks to the region's vertical CENTER (top: 50%) so
+   * they track the now-centered word at ANY region height (touch full-height
+   * flex: 1 1 auto, tall viewports) — not just at min-block-size. The
+   * per-tick transform carries BOTH the horizontal centering (-50% X, was the
+   * shared translateX) and the vertical offset above/below center. Each tick
+   * is 14px tall and sits with its inner edge 26px from center (a ~52px gap
+   * straddling the word line), so the two ticks stay symmetric about the
+   * gaze anchor as the region grows. Previously edge-anchored
+   * (top: 18px / bottom: 6px), which drifted off the centered word. */
   width: 1.5px;
+  height: 14px;
   background: var(--accent, #1a73e8);
   opacity: 0.85;
   border-radius: 1px;
@@ -276,13 +285,13 @@ export const OVERLAY_CSS = `
 }
 
 .word-region::before {
-  top: 18px;
-  height: 14px;
+  top: 50%;
+  transform: translate(-50%, -40px);
 }
 
 .word-region::after {
-  bottom: 6px;
-  height: 14px;
+  top: 50%;
+  transform: translate(-50%, 26px);
 }
 
 .word-region .focus {


### PR DESCRIPTION
## Summary
- Stop driving `--rsvp-font-size` from the body `fontSize` setting (default 20) — the designed `clamp(40px, 8.5cqi + 0.5rem, 54px)` on `.word-region` becomes the live value instead of dead fallback. The streaming RSVP word now renders at the responsive 40–54px instead of 20px.
- Switch default `.word-region` `align-items: baseline` → `center` so the word sits at the fixed gaze point, sharing the vertical axis with the center-anchored accent focus-ticks (instead of hugging the top).

Closes #241

## Behavior change
A−/A+ font steppers stay wired (cache, aria-disabled boundary state, `onFontSizeChange` persistence) but no longer resize the streaming word — accepted consequence of decoupling. Likely follow-up: repurpose (clamp multiplier) or remove the stepper UI.

## Test plan
- [x] `npm run lint` — exit 0
- [x] `npm run format:check` — clean
- [x] `npm run test` — 93 files / 1485 passed
- [x] `npm run build` — built
- [x] Mutation-verified: re-adding `setProperty` write → 3 font-size-stepper tests RED; reverting `center`→`baseline` → align-items test RED
