### PR TITLE
fix(activation): scoped cold-start handoff retry for first-run 'Lost connection'

### DIFF
--- a/src/chrome/background/activation/__tests__/dispatch.test.ts
+++ b/src/chrome/background/activation/__tests__/dispatch.test.ts
@@ -456,4 +456,101 @@ describe('dispatchActivation', () => {
     });
     expect(stub.tabs.sendMessage).not.toHaveBeenCalled();
   });
+
+  // Issue #243 — first-run cold-start handoff race. With lazy injection
+  // (#142) the just-injected content-script listener may not yet be
+  // registered when step-5 `chrome.tabs.sendMessage` fires, so the very
+  // first activation rejects with "Could not establish connection". This
+  // is a deterministic internal cold-start race, not a real lost
+  // connection. The handoff step retries a bounded number of times with a
+  // short backoff before surfacing `handoff-failed`.
+  //
+  // `sleep` is injected so the retry backoff is deterministic in tests —
+  // no fake timers, no wall-clock delay.
+  describe('#243 cold-start handoff retry', () => {
+    it('absorbs a sendMessage that rejects once then succeeds (overall ok)', async () => {
+      stub = installChromeStub({});
+      let calls = 0;
+      stub.tabs.sendMessage = vi.fn(() => {
+        calls += 1;
+        if (calls === 1) return Promise.reject(new Error('Could not establish connection'));
+        return Promise.resolve({ ok: true });
+      });
+      const sleep = vi.fn(() => Promise.resolve());
+      const { dispatchActivation } = await import('../dispatch');
+      const intent: ActivationIntent = { source: 'popup', tabId: 51, scope: 'full' };
+
+      const result = await dispatchActivation(intent, { sleep });
+
+      expect(result).toEqual({ ok: true, data: undefined });
+      // Exactly two attempts: the rejected one + the retry that succeeds.
+      expect(stub.tabs.sendMessage).toHaveBeenCalledTimes(2);
+      // One backoff between the two attempts.
+      expect(sleep).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries at most the bounded number of times, then surfaces handoff-failed', async () => {
+      stub = installChromeStub({
+        sendMessageRejects: new Error('Could not establish connection'),
+      });
+      const sleep = vi.fn(() => Promise.resolve());
+      const { dispatchActivation, HANDOFF_MAX_ATTEMPTS } = await import('../dispatch');
+      const intent: ActivationIntent = { source: 'popup', tabId: 52, scope: 'full' };
+
+      const result = await dispatchActivation(intent, { sleep });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.error.kind).toBe('handoff-failed');
+      // Bounded: total attempts === the ceiling (initial + retries), and
+      // the backoff fired exactly once per retry (attempts - 1).
+      expect(stub.tabs.sendMessage).toHaveBeenCalledTimes(HANDOFF_MAX_ATTEMPTS);
+      expect(sleep).toHaveBeenCalledTimes(HANDOFF_MAX_ATTEMPTS - 1);
+    });
+
+    it('does NOT retry restricted-page — surfaces immediately with no sendMessage, no sleep', async () => {
+      stub = installChromeStub({ tabUrl: 'chrome://settings' });
+      const sleep = vi.fn(() => Promise.resolve());
+      const { dispatchActivation } = await import('../dispatch');
+      const intent: ActivationIntent = { source: 'command', tabId: 53 };
+
+      const result = await dispatchActivation(intent, { sleep });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.error.kind).toBe('restricted-page');
+      expect(stub.tabs.sendMessage).not.toHaveBeenCalled();
+      expect(sleep).not.toHaveBeenCalled();
+    });
+
+    it('does NOT retry inject-failed — surfaces immediately with no sendMessage, no sleep', async () => {
+      stub = installChromeStub({
+        executeScriptRejects: new Error('Cannot access contents of url'),
+      });
+      const sleep = vi.fn(() => Promise.resolve());
+      const { dispatchActivation } = await import('../dispatch');
+      const intent: ActivationIntent = { source: 'command', tabId: 54 };
+
+      const result = await dispatchActivation(intent, { sleep });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('unreachable');
+      expect(result.error.kind).toBe('inject-failed');
+      expect(stub.tabs.sendMessage).not.toHaveBeenCalled();
+      expect(sleep).not.toHaveBeenCalled();
+    });
+
+    it('happy path hands off on the first attempt with no retry / no backoff', async () => {
+      stub = installChromeStub({});
+      const sleep = vi.fn(() => Promise.resolve());
+      const { dispatchActivation } = await import('../dispatch');
+      const intent: ActivationIntent = { source: 'popup', tabId: 55, scope: 'full' };
+
+      const result = await dispatchActivation(intent, { sleep });
+
+      expect(result).toEqual({ ok: true, data: undefined });
+      expect(stub.tabs.sendMessage).toHaveBeenCalledTimes(1);
+      expect(sleep).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/chrome/background/activation/__tests__/dispatch.test.ts
+++ b/src/chrome/background/activation/__tests__/dispatch.test.ts
@@ -169,7 +169,9 @@ describe('dispatchActivation', () => {
     const { dispatchActivation } = await import('../dispatch');
     const intent: ActivationIntent = { source: 'popup', tabId: 5, scope: 'full' };
 
-    const result = await dispatchActivation(intent);
+    // Inject a no-op sleep so the bounded #243 retry backoff runs
+    // deterministically here instead of eating real wall-clock delay.
+    const result = await dispatchActivation(intent, { sleep: vi.fn(() => Promise.resolve()) });
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('unreachable');

--- a/src/chrome/background/activation/dispatch.ts
+++ b/src/chrome/background/activation/dispatch.ts
@@ -392,11 +392,53 @@ function intentToActivatePayload(intent: ActivationIntent): ActivateReaderMessag
 }
 
 /**
+ * Issue #243 — bounded cold-start handoff retry.
+ *
+ * With lazy injection (#142) the content script is injected only on the
+ * activating dispatch, so on a cold start the just-injected CS message
+ * listener may not yet be registered when step-5
+ * `chrome.tabs.sendMessage` fires. The send then rejects with
+ * "Could not establish connection" and the funnel returns
+ * `handoff-failed` — alarming and unactionable for what is a
+ * deterministic internal race, not a real lost connection.
+ *
+ * The handoff (and ONLY the handoff) is retried a bounded number of
+ * times with a short backoff. `HANDOFF_MAX_ATTEMPTS` is the TOTAL number
+ * of `sendMessage` attempts (initial + retries); the backoff fires
+ * between attempts (`HANDOFF_MAX_ATTEMPTS - 1` times). The retry is
+ * scoped to the `sendMessage` reject path at step 5 — `restricted-page`
+ * (steps 2/4) and `inject-failed` (step 3) are earlier and still surface
+ * immediately with no retry.
+ *
+ * A full CS-ready handshake / messaging-contract redesign is the durable
+ * fix and is deferred; this bounded retry absorbs the cold-start window
+ * without that redesign.
+ */
+export const HANDOFF_MAX_ATTEMPTS = 3;
+const HANDOFF_BACKOFF_MS = 200;
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Options for {@link dispatchActivation}. `sleep` is injectable so the
+ * cold-start retry backoff is deterministic under test (no fake timers,
+ * no wall-clock delay). Production callers omit it and get the real
+ * `setTimeout`-backed backoff.
+ */
+export interface DispatchOptions {
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
  * Dispatch an activation intent. Returns a `Result` — never throws.
  */
 export async function dispatchActivation(
   intent: ActivationIntent,
+  options: DispatchOptions = {},
 ): Promise<Result<void, ActivationError>> {
+  const sleep = options.sleep ?? defaultSleep;
   // 1. Resolve the tab URL. tabs.get can reject (closed tab, race).
   let tab: chrome.tabs.Tab;
   try {
@@ -445,12 +487,29 @@ export async function dispatchActivation(
   // 5. Hand off to the CS via the `activate-reader` one-shot RPC. The
   //    `rsvp-session` Port is opened separately by the popup / CS per
   //    the messaging-contract spec.
+  //
+  //    Issue #243 — bounded cold-start retry. On a cold start the
+  //    just-injected CS listener (#142 lazy injection) may not yet be
+  //    registered, so the first `sendMessage` rejects with "Could not
+  //    establish connection". Retry the handoff up to
+  //    `HANDOFF_MAX_ATTEMPTS` total attempts with a short backoff before
+  //    surfacing `handoff-failed`. ONLY this reject path retries — the
+  //    earlier restricted/inject steps already returned above.
   const payload = intentToActivatePayload(intent);
-  try {
-    await chrome.tabs.sendMessage(intent.tabId, payload);
-  } catch (details) {
-    return { ok: false, error: { kind: 'handoff-failed', tabId: intent.tabId, details } };
+  let lastDetails: unknown;
+  for (let attempt = 1; attempt <= HANDOFF_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await chrome.tabs.sendMessage(intent.tabId, payload);
+      return { ok: true, data: undefined };
+    } catch (details) {
+      lastDetails = details;
+      if (attempt < HANDOFF_MAX_ATTEMPTS) {
+        await sleep(HANDOFF_BACKOFF_MS);
+      }
+    }
   }
-
-  return { ok: true, data: undefined };
+  return {
+    ok: false,
+    error: { kind: 'handoff-failed', tabId: intent.tabId, details: lastDetails },
+  };
 }

--- a/src/chrome/content/__tests__/index.test.ts
+++ b/src/chrome/content/__tests__/index.test.ts
@@ -44,4 +44,42 @@ describe('content script wiring', () => {
     await new Promise((r) => setTimeout(r, 50));
     expect(document.querySelector('[data-speedreader-overlay]')).toBeTruthy();
   });
+
+  // Issue #243 — the step-5 handoff retry can deliver `activate-reader`
+  // to this listener more than once (the SW retries `chrome.tabs.sendMessage`
+  // on a cold-start "Could not establish connection" reject, and the first
+  // attempt may in fact have arrived). Double-delivery must NOT double-mount
+  // the overlay. The safety rests entirely on the CS idempotency guard
+  // (`if (activeOverlay && activeOverlay.status === 'mounted') return;`):
+  // mirror the real retry timing — second delivery lands AFTER the first
+  // mount completes — and assert exactly one overlay host in the DOM.
+  test('#243: double-delivered activate-reader mounts the overlay exactly once', async () => {
+    type Listener = (
+      msg: unknown,
+      sender: { id?: string },
+      sendResponse: (r: unknown) => void,
+    ) => unknown;
+    let listener: Listener | undefined;
+    (
+      globalThis as unknown as {
+        chrome: { runtime: { id: string; onMessage: { addListener: (l: Listener) => void } } };
+      }
+    ).chrome.runtime.onMessage.addListener = (l: Listener) => {
+      listener = l;
+    };
+    await import('../index');
+    if (!listener) throw new Error('listener not registered');
+
+    // First delivery — let the async mount fully settle so `activeOverlay`
+    // is set to a mounted handle before the retry arrives.
+    listener({ type: 'activate-reader' }, { id: 'test-ext' }, vi.fn());
+    await new Promise((r) => setTimeout(r, 50));
+    expect(document.querySelectorAll('[data-speedreader-overlay]')).toHaveLength(1);
+
+    // Second (retried) delivery — the `:223` guard must short-circuit before
+    // a second overlay host is created.
+    listener({ type: 'activate-reader' }, { id: 'test-ext' }, vi.fn());
+    await new Promise((r) => setTimeout(r, 50));
+    expect(document.querySelectorAll('[data-speedreader-overlay]')).toHaveLength(1);
+  });
 });

--- a/src/chrome/popup/__tests__/index.test.ts
+++ b/src/chrome/popup/__tests__/index.test.ts
@@ -202,8 +202,10 @@ describe('bootstrapPopup — button clicks', () => {
       match: /Could not inject SpeedReader/i,
     },
     {
+      // Issue #243 — cold-start handoff copy must be non-alarming and
+      // name the next action ("press Read again"), not "Lost connection".
       inner: 'handoff-failed' as const,
-      match: /Lost connection to the page/i,
+      match: /still starting up — press Read again/i,
     },
     {
       inner: 'tab-unavailable' as const,

--- a/src/chrome/popup/index.ts
+++ b/src/chrome/popup/index.ts
@@ -173,7 +173,11 @@ function formatActivationError(resp: ActivationResponse | undefined): string {
       return 'SpeedReader cannot run on this page (restricted URL).';
     }
     if (inner === 'inject-failed') return 'Could not inject SpeedReader into this page.';
-    if (inner === 'handoff-failed') return 'Lost connection to the page. Try again.';
+    // Issue #243 — `handoff-failed` after the bounded cold-start retry
+    // (see dispatch.ts step 5) is almost always the first-run injection
+    // race, not a real lost connection. Use non-alarming copy that names
+    // the next action.
+    if (inner === 'handoff-failed') return 'SpeedReader is still starting up — press Read again.';
     if (inner === 'tab-unavailable') return 'Tab is no longer available.';
     return `Activation failed (${inner}).`;
   }


### PR DESCRIPTION
## Summary
- Add a bounded cold-start retry of the step-5 `chrome.tabs.sendMessage` handoff in `dispatch.ts` — up to `HANDOFF_MAX_ATTEMPTS` (3) total attempts with 200ms backoff. Scoped to the `sendMessage` reject path only; `restricted-page` and `inject-failed` (earlier steps) still surface immediately with no retry. Backoff sleep injectable via a new optional `DispatchOptions` param for deterministic tests; public callers unchanged.
- Rewrite the popup `handoff-failed` copy to non-alarming, action-naming: "SpeedReader is still starting up — press Read again."

Closes #243

## Out of scope
CS-ready-handshake / messaging-contract redesign (the durable fix) — deferred follow-up.

## Test plan
- [x] `npm run lint` — exit 0
- [x] `npm run format:check` — clean
- [x] `npm run test` — 93 files / 1490 passed
- [x] `npm run build` — built
- [x] Mutation-verified: removed retry → 2 dispatch tests RED; widened scope to inject-failed → 2 RED; reverted copy → 1 popup test RED
