### PR TITLE
fix(overlay): reserve context-preview slot (no reflow) + gate on contextLine

### DIFF
--- a/src/chrome/content/__tests__/context-line-wire.test.ts
+++ b/src/chrome/content/__tests__/context-line-wire.test.ts
@@ -1,0 +1,207 @@
+/**
+ * context-line-wire.test.ts — issue #242 (CS-glue boundary)
+ *
+ * End-to-end wire from `chrome.storage.sync.get` → loadSettings →
+ * createOverlay (`initialSettings.contextLine` slot) → subscribeSettings
+ * push → overlay context-preview visibility. The unit tests in
+ * `core/overlay/__tests__/context-preview.test.ts` pin the overlay's local
+ * gate behaviour; this file pins the chrome-glue boundary so a regression
+ * that drops `contextLine: settings.contextLine` from the CS payload or the
+ * subscribe wiring lands as a test failure rather than a silent default at
+ * the boundary.
+ *
+ * Same defect class as the "alignment dead since V3" bug: the schema slot
+ * exists but no boundary code reads it. The unit tests can't detect that the
+ * CS doesn't forward — only this boundary test can. `content/index.ts` is the
+ * ONLY path that can enable the preview, so it is the only place this wire
+ * can break.
+ *
+ * Mutation guards:
+ *   - Dropping `contextLine: settings.contextLine` from the initial-mount
+ *     payload fails the first test (the overlay would default the gate to off
+ *     and keep the preview invisible despite stored `true`).
+ *   - Dropping `contextLine: s.contextLine` from the subscribe payload fails
+ *     the live-push test (the live enable would have no effect on the preview).
+ */
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { DEFAULT_SETTINGS } from '../../../core/settings/defaults';
+import type { SettingsV7 } from '../../../core/settings/schema';
+import { OVERLAY_CLASS } from '../../../core/overlay/constants';
+
+const SETTINGS_KEY = 'speedreader.settings';
+const EXT_ID = 'test-ext';
+
+type Listener = (
+  msg: unknown,
+  sender: { id?: string },
+  sendResponse: (r: unknown) => void,
+) => unknown;
+
+type StorageChangedListener = (
+  changes: Record<string, { newValue?: unknown; oldValue?: unknown }>,
+  area: string,
+) => void;
+
+interface ChromeMock {
+  runtime: {
+    id: string;
+    onMessage: { addListener: (l: Listener) => void };
+    getURL: ReturnType<typeof vi.fn>;
+  };
+  storage: {
+    sync: {
+      get: ReturnType<typeof vi.fn>;
+      set: ReturnType<typeof vi.fn>;
+    };
+    onChanged: {
+      addListener: ReturnType<typeof vi.fn>;
+      removeListener: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+function installChromeMock(stored: SettingsV7): {
+  getListener: () => Listener;
+  emitStorageChange: (next: SettingsV7) => void;
+} {
+  let capturedListener: Listener | undefined;
+  const storageListeners: StorageChangedListener[] = [];
+  const mock: ChromeMock = {
+    runtime: {
+      id: EXT_ID,
+      onMessage: {
+        addListener: (l: Listener) => {
+          capturedListener = l;
+        },
+      },
+      getURL: vi.fn((path: string) => `chrome-extension://${EXT_ID}/${path}`),
+    },
+    storage: {
+      sync: {
+        get: vi.fn().mockResolvedValue({ [SETTINGS_KEY]: stored }),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      onChanged: {
+        addListener: vi.fn((l: StorageChangedListener) => {
+          storageListeners.push(l);
+        }),
+        removeListener: vi.fn(),
+      },
+    },
+  };
+  (globalThis as unknown as { chrome: ChromeMock }).chrome = mock;
+  return {
+    getListener: () => {
+      if (!capturedListener) throw new Error('content script never registered listener');
+      return capturedListener;
+    },
+    emitStorageChange: (next: SettingsV7) => {
+      for (const l of storageListeners) {
+        l({ [SETTINGS_KEY]: { newValue: next, oldValue: stored } }, 'sync');
+      }
+    },
+  };
+}
+
+function getShadow(): ShadowRoot {
+  const host = document.body.querySelector('[data-speedreader-overlay]');
+  if (!(host instanceof HTMLElement) || !host.shadowRoot) {
+    throw new Error('overlay host missing or no shadow root');
+  }
+  return host.shadowRoot;
+}
+
+function getPreview(): HTMLElement {
+  const el = getShadow().querySelector<HTMLElement>(`.${OVERLAY_CLASS.CONTEXT_PREVIEW}`);
+  if (!el) throw new Error('overlay shadow: missing .context-preview');
+  return el;
+}
+
+// #242 — the preview slot stays in flow at all times (no `display:none`, no
+// `hidden` attribute); visibility is carried by `visibility`/`opacity`. Mirror
+// the same read used by the overlay unit tests so the wire-test and the local
+// gate test agree on what "visible" means.
+function isPreviewVisible(preview: HTMLElement): boolean {
+  return preview.style.visibility !== 'hidden' && preview.style.opacity !== '0';
+}
+
+function pause(): void {
+  const btn = getShadow().querySelector<HTMLButtonElement>(`.${OVERLAY_CLASS.PLAY_PAUSE_BTN}`);
+  if (!btn) throw new Error('overlay shadow: missing play-pause-btn');
+  btn.click();
+}
+
+async function mountOverlay(getListener: () => Listener): Promise<void> {
+  document.body.innerHTML = '<article>The quick brown fox jumps over the lazy dog.</article>';
+  await import('../index');
+  const listener = getListener();
+  const respond = vi.fn();
+  listener({ type: 'activate-reader' }, { id: EXT_ID }, respond);
+  expect(respond).toHaveBeenCalledWith({ ok: true });
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('content script — contextLine wire boundary (#242)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (globalThis as unknown as { chrome?: unknown }).chrome;
+    document.body.innerHTML = '';
+    document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+    vi.resetModules();
+  });
+
+  test('stored contextLine=true → preview visible on pause (decoration opt-in wired)', async () => {
+    // The preview only shows while paused. With contextLine opted in at the
+    // boundary, pausing must reveal it. A regression that drops contextLine
+    // from the mount payload defaults the gate to off and keeps the preview
+    // invisible — failing this test.
+    const { getListener } = installChromeMock({
+      ...DEFAULT_SETTINGS,
+      contextLine: true,
+    });
+    await mountOverlay(getListener);
+    pause();
+    expect(isPreviewVisible(getPreview())).toBe(true);
+  });
+
+  test('stored contextLine=false → preview stays invisible on pause (off-by-default also passes the boundary)', async () => {
+    const { getListener } = installChromeMock({
+      ...DEFAULT_SETTINGS,
+      contextLine: false,
+    });
+    await mountOverlay(getListener);
+    pause();
+    expect(isPreviewVisible(getPreview())).toBe(false);
+  });
+
+  test('subscribeSettings push delivers contextLine change — live enable reveals the preview without remount', async () => {
+    // Start with the decoration off (preview invisible even when paused). Push
+    // the opt-in; the overlay subscribe handler MUST receive it and reveal the
+    // preview against the SAME DOM node. Dropping `contextLine: s.contextLine`
+    // from the subscribe payload leaves the preview invisible and fails this
+    // test.
+    const { getListener, emitStorageChange } = installChromeMock({
+      ...DEFAULT_SETTINGS,
+      contextLine: false,
+    });
+    await mountOverlay(getListener);
+    pause();
+    const preview = getPreview();
+    expect(isPreviewVisible(preview)).toBe(false);
+
+    emitStorageChange({ ...DEFAULT_SETTINGS, contextLine: true });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Same node (no remount) and now visible.
+    expect(getPreview()).toBe(preview);
+    expect(isPreviewVisible(preview)).toBe(true);
+  });
+});

--- a/src/chrome/content/index.ts
+++ b/src/chrome/content/index.ts
@@ -309,6 +309,11 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
             // subscribeSettings below so a user can toggle the position
             // anchor mid-session without a remount.
             scrubberAutoHide: settings.scrubberAutoHide,
+            // #242 — surrounding-sentence context preview toggle (wires the
+            // #72 `contextLine` setting). Off by default; the overlay
+            // reserves the slot regardless so toggling play/pause never
+            // reflows. Live-updated via subscribeSettings below.
+            contextLine: settings.contextLine,
           },
           subscribeSettings: (listener) =>
             subscribeSettings((s) =>
@@ -321,6 +326,7 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage?.addListener) {
                 chunkSize: s.chunkSize,
                 alignment: s.alignment,
                 scrubberAutoHide: s.scrubberAutoHide,
+                contextLine: s.contextLine,
               }),
             ),
           // OpenDyslexic font URL (#27, #10). `core/` cannot call

--- a/src/core/overlay/__tests__/chunk-render.test.ts
+++ b/src/core/overlay/__tests__/chunk-render.test.ts
@@ -126,18 +126,27 @@ describe('createOverlay — chunk event rendering (#51)', () => {
     const overlay = createOverlay(
       defaultOpts({
         words: ['The', 'quick', 'brown', 'fox', 'jumps', 'over', 'lazy', 'dog.'],
-        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, chunkSize: 2 },
+        // #242 — preview only shows when `contextLine` is enabled.
+        initialSettings: {
+          theme: 'system',
+          wpm: 300,
+          fontSize: 20,
+          chunkSize: 2,
+          contextLine: true,
+        },
       }),
     );
     overlay.mount();
     const root = getShadow();
     const preview = getEl<HTMLElement>(root, `.${OVERLAY_CLASS.CONTEXT_PREVIEW}`);
-    // Preview is hidden while playing.
-    expect(preview.hidden).toBe(true);
+    // #242 — preview not visible while playing; slot stays in flow (no
+    // `hidden` attribute / no display:none → no reflow on toggle).
+    expect(preview.style.visibility).toBe('hidden');
+    expect(preview.hasAttribute('hidden')).toBe(false);
 
     // Pause via space key — togglePlayPause renders the preview.
     document.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
-    expect(preview.hidden).toBe(false);
+    expect(preview.style.visibility).toBe('visible');
     // Preview text contains the current chunk word (rendered as the
     // `<strong>` child).
     const current = preview.querySelector('strong');

--- a/src/core/overlay/__tests__/context-preview.test.ts
+++ b/src/core/overlay/__tests__/context-preview.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import { buildSentenceContext } from '../sentence-context';
 import type { SentenceContext } from '../sentence-context';
 import { createOverlay } from '../overlay';
-import type { OverlayOptions } from '../types';
+import type { OverlayOptions, OverlaySettings } from '../types';
 import { createRsvpEngine } from '../../rsvp-engine';
 
 function expectCtx(ctx: SentenceContext | null): SentenceContext {
@@ -99,11 +99,22 @@ function defaultOpts(overrides: Partial<OverlayOptions> = {}): OverlayOptions {
   return {
     doc: document,
     words: ['the', 'quick', 'brown', 'fox.', 'jumped', 'over.', 'the', 'lazy', 'dog.'],
-    initialSettings: { theme: 'system', wpm: 300, fontSize: 20 },
+    // #242 — preview only shows when `contextLine` is enabled. These
+    // legacy integration tests assert the show-on-pause behaviour, so they
+    // opt the decoration in. The off-by-default path has its own block.
+    initialSettings: { theme: 'system', wpm: 300, fontSize: 20, contextLine: true },
     subscribeSettings: () => () => undefined,
     engineFactory: createRsvpEngine,
     ...overrides,
   };
+}
+
+// #242 — the preview slot stays in flow at all times (no `display:none`,
+// no `hidden` attribute) so toggling play/pause no longer reflows the
+// modal. Visibility is carried by `visibility`/`opacity`. These helpers
+// read the inline style the overlay writes.
+function isPreviewVisible(preview: HTMLElement): boolean {
+  return preview.style.visibility !== 'hidden' && preview.style.opacity !== '0';
 }
 
 function getShadow(): ShadowRoot {
@@ -151,11 +162,14 @@ describe('createOverlay — context preview (#20)', () => {
     overlay.unmount();
   });
 
-  test('hidden while playing (initial state)', () => {
+  test('not visible while playing (initial state) — slot reserved, no hidden attribute', () => {
     const overlay = createOverlay(defaultOpts());
     overlay.mount();
     const preview = getPreview();
-    expect(preview.hidden).toBe(true);
+    // #242 — slot stays in flow; the `hidden` attribute must never be used
+    // (it pulls the element out of flow → the reflow this fix kills).
+    expect(preview.hasAttribute('hidden')).toBe(false);
+    expect(isPreviewVisible(preview)).toBe(false);
     expect(preview.textContent).toBe('');
     overlay.unmount();
   });
@@ -167,7 +181,7 @@ describe('createOverlay — context preview (#20)', () => {
     getPlayPauseBtn().click();
 
     const preview = getPreview();
-    expect(preview.hidden).toBe(false);
+    expect(isPreviewVisible(preview)).toBe(true);
     const strong = getCurrentStrong(preview);
     expect(strong.textContent).toBe('the');
     // Semantic emphasis — must be <strong>, not <b> / <span class=…>.
@@ -189,10 +203,12 @@ describe('createOverlay — context preview (#20)', () => {
     const btn = getPlayPauseBtn();
     btn.click(); // pause
     const preview = getPreview();
-    expect(preview.hidden).toBe(false);
+    expect(isPreviewVisible(preview)).toBe(true);
 
     btn.click(); // resume
-    expect(preview.hidden).toBe(true);
+    // #242 — visibility carries the play state; the slot stays in flow.
+    expect(isPreviewVisible(preview)).toBe(false);
+    expect(preview.hasAttribute('hidden')).toBe(false);
     expect(preview.textContent).toBe('');
     overlay.unmount();
   });
@@ -231,11 +247,12 @@ describe('createOverlay — context preview (#20)', () => {
     const btn = getPlayPauseBtn();
     btn.click(); // pause — preview now visible
     const preview = getPreview();
-    expect(preview.hidden).toBe(false);
+    expect(isPreviewVisible(preview)).toBe(true);
     btn.click(); // resume
     // Advance past the single word so the engine ticks to done.
     vi.advanceTimersByTime(60000 / 300 + 5);
-    expect(preview.hidden).toBe(true);
+    expect(isPreviewVisible(preview)).toBe(false);
+    expect(preview.hasAttribute('hidden')).toBe(false);
     expect(preview.textContent).toBe('');
     overlay.unmount();
   });
@@ -289,6 +306,112 @@ describe('createOverlay — context preview (#20)', () => {
     expect(preview.querySelector('script')).toBeNull();
     const strong = getCurrentStrong(preview);
     expect(strong.textContent).toBe('<script>x</script>');
+    overlay.unmount();
+  });
+});
+
+describe('createOverlay — context preview reflow + contextLine gate (#242)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+  });
+
+  test('play→pause→resume never toggles the hidden attribute or display:none (slot stays in flow)', () => {
+    const overlay = createOverlay(defaultOpts());
+    overlay.mount();
+    const btn = getPlayPauseBtn();
+    const preview = getPreview();
+
+    // Initial (playing): slot reserved, no hidden attr, display untouched.
+    expect(preview.hasAttribute('hidden')).toBe(false);
+    expect(preview.style.display).not.toBe('none');
+
+    btn.click(); // pause — visible
+    expect(preview.hasAttribute('hidden')).toBe(false);
+    expect(preview.style.display).not.toBe('none');
+    expect(isPreviewVisible(preview)).toBe(true);
+
+    btn.click(); // resume — hidden via visibility, NOT the hidden attribute
+    expect(preview.hasAttribute('hidden')).toBe(false);
+    expect(preview.style.display).not.toBe('none');
+    expect(isPreviewVisible(preview)).toBe(false);
+
+    overlay.unmount();
+  });
+
+  test('contextLine: false → preview never visible even when paused', () => {
+    const overlay = createOverlay(
+      defaultOpts({
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, contextLine: false },
+      }),
+    );
+    overlay.mount();
+    const preview = getPreview();
+    expect(isPreviewVisible(preview)).toBe(false);
+
+    getPlayPauseBtn().click(); // pause
+    // The decoration is off → no preview content, slot stays invisible.
+    expect(isPreviewVisible(preview)).toBe(false);
+    expect(preview.textContent).toBe('');
+    expect(preview.querySelector('strong.context-current')).toBeNull();
+    overlay.unmount();
+  });
+
+  test('contextLine undefined → treated as off (off-by-default schema intent)', () => {
+    const overlay = createOverlay(
+      defaultOpts({ initialSettings: { theme: 'system', wpm: 300, fontSize: 20 } }),
+    );
+    overlay.mount();
+    const preview = getPreview();
+    getPlayPauseBtn().click(); // pause
+    expect(isPreviewVisible(preview)).toBe(false);
+    expect(preview.textContent).toBe('');
+    overlay.unmount();
+  });
+
+  test('contextLine: true → preview visible on pause', () => {
+    const overlay = createOverlay(
+      defaultOpts({
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, contextLine: true },
+      }),
+    );
+    overlay.mount();
+    const preview = getPreview();
+    getPlayPauseBtn().click(); // pause
+    expect(isPreviewVisible(preview)).toBe(true);
+    expect(getCurrentStrong(preview).textContent).toBe('the');
+    overlay.unmount();
+  });
+
+  test('live subscribeSettings toggle of contextLine updates the preview without remount', () => {
+    let push: ((s: OverlaySettings) => void) | undefined;
+    const overlay = createOverlay(
+      defaultOpts({
+        initialSettings: { theme: 'system', wpm: 300, fontSize: 20, contextLine: false },
+        subscribeSettings: (listener) => {
+          push = listener;
+          return () => undefined;
+        },
+      }),
+    );
+    overlay.mount();
+    const preview = getPreview();
+    getPlayPauseBtn().click(); // pause — still off, not visible
+    expect(isPreviewVisible(preview)).toBe(false);
+
+    // Enable contextLine live (paused) → preview appears, same DOM node.
+    push?.({ theme: 'system', wpm: 300, fontSize: 20, contextLine: true });
+    expect(isPreviewVisible(preview)).toBe(true);
+    expect(getCurrentStrong(preview).textContent).toBe('the');
+
+    // Disable live → preview hides again, slot still in flow.
+    push?.({ theme: 'system', wpm: 300, fontSize: 20, contextLine: false });
+    expect(isPreviewVisible(preview)).toBe(false);
+    expect(preview.hasAttribute('hidden')).toBe(false);
     overlay.unmount();
   });
 });

--- a/src/core/overlay/__tests__/context-preview.test.ts
+++ b/src/core/overlay/__tests__/context-preview.test.ts
@@ -326,18 +326,16 @@ describe('createOverlay — context preview reflow + contextLine gate (#242)', (
     const btn = getPlayPauseBtn();
     const preview = getPreview();
 
-    // Initial (playing): slot reserved, no hidden attr, display untouched.
+    // Initial (playing): slot reserved, no hidden attr (the source never
+    // writes display:none — the slot stays in flow at all times).
     expect(preview.hasAttribute('hidden')).toBe(false);
-    expect(preview.style.display).not.toBe('none');
 
     btn.click(); // pause — visible
     expect(preview.hasAttribute('hidden')).toBe(false);
-    expect(preview.style.display).not.toBe('none');
     expect(isPreviewVisible(preview)).toBe(true);
 
     btn.click(); // resume — hidden via visibility, NOT the hidden attribute
     expect(preview.hasAttribute('hidden')).toBe(false);
-    expect(preview.style.display).not.toBe('none');
     expect(isPreviewVisible(preview)).toBe(false);
 
     overlay.unmount();

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -454,15 +454,22 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     const word = doc.createElement('div');
     word.className = OVERLAY_CLASS.WORD_REGION;
 
-    // Surrounding-sentence preview (#20). Hidden by default; the pause
-    // hook in mount() shows it with before/<strong>current</strong>/after.
-    // Built with textContent + a single appended <strong> (no innerHTML,
-    // no XSS surface).
+    // Surrounding-sentence preview (#20, #242). The pause hook in mount()
+    // shows it with before/<strong>current</strong>/after. Built with
+    // textContent + a single appended <strong> (no innerHTML, no XSS
+    // surface).
+    //
+    // #242 — the slot is kept in flow at ALL times (no `hidden` attribute,
+    // no `display:none`) so toggling play/pause never reflows the modal.
+    // Visibility is carried by inline `visibility`/`opacity`; styles.ts
+    // reserves ~2 lines of height for the slot. Initial state is hidden
+    // (engine starts playing); `setPreviewVisible(false)` writes that.
     const preview = doc.createElement('div');
     preview.className = OVERLAY_CLASS.CONTEXT_PREVIEW;
     preview.setAttribute('role', 'region');
     preview.setAttribute('aria-label', OVERLAY_TEXT.CONTEXT_LABEL);
-    preview.hidden = true;
+    preview.style.visibility = 'hidden';
+    preview.style.opacity = '0';
 
     const ariaLive = doc.createElement('div');
     ariaLive.className = OVERLAY_CLASS.ARIA_LIVE;
@@ -807,6 +814,12 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     // subscribeSettings handler flips it and recomputes so a user toggling
     // the option reveals/hides the bar mid-session without a remount.
     let currentScrubberAutoHide: boolean = opts.initialSettings.scrubberAutoHide ?? true;
+    // #242 — local cache for the context-preview decoration toggle. Default
+    // `false` (undefined treated as off) matches the schema's off-by-default
+    // intent. The subscribeSettings handler flips it and re-renders so a user
+    // toggling the option reveals/hides the preview mid-session (only while
+    // paused — playing never shows it) without a remount.
+    let currentContextLine: boolean = opts.initialSettings.contextLine ?? false;
 
     // Single point of truth for keeping the stepper UI in sync with
     // `currentWpm`. Called from mount-time init, the ArrowUp/Down keyboard
@@ -930,6 +943,15 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       if (nextScrubberAutoHide !== currentScrubberAutoHide) {
         currentScrubberAutoHide = nextScrubberAutoHide;
         recomputeScrubberVisibility();
+      }
+      // #242 — live context-preview toggle. Re-render so enabling it while
+      // paused reveals the preview and disabling it clears the slot, both
+      // without a remount. `renderPreview` is self-gating: it shows only
+      // when paused AND the decoration is on, and clears otherwise.
+      const nextContextLine: boolean = s.contextLine ?? false;
+      if (nextContextLine !== currentContextLine) {
+        currentContextLine = nextContextLine;
+        renderPreview();
       }
     });
 
@@ -1118,14 +1140,24 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       recomputeScrubberVisibility();
     };
 
+    // #242 — visibility-only show/hide. The slot is permanently in flow
+    // (styles.ts reserves its height); state is carried by inline
+    // `visibility`/`opacity` so toggling never reflows the modal. The CSS
+    // transition fades opacity (instant under prefers-reduced-motion via
+    // the reduced-motion block in styles.ts).
+    const setPreviewVisible = (visible: boolean): void => {
+      preview.style.visibility = visible ? 'visible' : 'hidden';
+      preview.style.opacity = visible ? '1' : '0';
+    };
+
     const clearPreview = (): void => {
       // Idempotency guard — clearPreview can be called on every state
       // transition; skip the layout-touching property writes when the
       // node is already in the cleared state. Matters when callers fan
       // out (toggle, swap, paused-state seek-driven word emits) — the
       // hot path stays free of redundant DOM writes.
-      if (preview.hidden && preview.firstChild === null) return;
-      preview.hidden = true;
+      if (preview.style.visibility === 'hidden' && preview.firstChild === null) return;
+      setPreviewVisible(false);
       // textContent='' removes children too, dropping the <strong>.
       preview.textContent = '';
     };
@@ -1134,8 +1166,15 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     // on `engine.state === 'paused'`. The internal early-return below
     // is belt-and-braces only; the per-word hot path should never reach
     // this function (perf-adversary F1 + scope-adversary F1).
+    //
+    // #242 — also gated on `currentContextLine`: when the decoration is
+    // off (the off-by-default schema state), the preview is never shown.
     const renderPreview = (): void => {
       if (!engine) return;
+      if (!currentContextLine) {
+        clearPreview();
+        return;
+      }
       if (engine.state !== 'paused') {
         clearPreview();
         return;
@@ -1164,7 +1203,7 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
       strong.textContent = ctx.current;
       preview.appendChild(strong);
       preview.appendChild(opts.doc.createTextNode(afterText));
-      preview.hidden = false;
+      setPreviewVisible(true);
     };
 
     engine.subscribe((ev) => {

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -315,10 +315,20 @@ export const OVERLAY_CSS = `
   font: 400 13px / 1.5 var(--font-reader);
   color: var(--text-muted);
   text-align: center;
-  min-block-size: 24px;
+  /* #242 — reserve ~2 lines so the slot stays in flow whether or not the
+   * preview is showing; toggling play/pause then fades opacity instead of
+   * reflowing the modal. 2 × 13px × 1.5 line-height ≈ 39px. Typical
+   * one-/two-line context fits; longer context scrolls within the slot
+   * (overflow:auto) rather than growing the modal. */
+  min-block-size: 39px;
+  max-block-size: 39px;
+  overflow-y: auto;
+  /* #242 — fade the show/hide. visibility is transitioned too so the
+   * element is removed from the AT rotor / hit-testing while hidden but
+   * the height stays reserved. Instant under prefers-reduced-motion (see
+   * the reduced-motion block below). */
+  transition: opacity 200ms ease-out, visibility 200ms ease-out;
 }
-
-.context-preview[hidden] { display: none; }
 
 .context-current {
   color: var(--text);
@@ -863,6 +873,8 @@ export const OVERLAY_CSS = `
 @media (prefers-reduced-motion: reduce) {
   .backdrop, .modal { transition: none !important; animation: none !important; }
   .scrubber-area { transition: none !important; }
+  /* #242 — motion-sensitive users get an instant preview swap, no fade. */
+  .context-preview { transition: none !important; }
 }
 
 /* ===== Touch-primary (#36) ===== */

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -315,14 +315,19 @@ export const OVERLAY_CSS = `
   font: 400 13px / 1.5 var(--font-reader);
   color: var(--text-muted);
   text-align: center;
-  /* #242 — reserve ~2 lines so the slot stays in flow whether or not the
+  /* #242 — reserve ~3 lines so the slot stays in flow whether or not the
    * preview is showing; toggling play/pause then fades opacity instead of
-   * reflowing the modal. 2 × 13px × 1.5 line-height ≈ 39px. Typical
-   * one-/two-line context fits; longer context scrolls within the slot
-   * (overflow:auto) rather than growing the modal. */
-  min-block-size: 39px;
-  max-block-size: 39px;
+   * reflowing the modal. 3 × 13px × 1.5 line-height ≈ 58px. The extra line
+   * over the prior 2-line (39px) reserve gives the common case slack so a
+   * 3rd line does not trip the mid-modal scrollbar; overflow-y:auto stays as
+   * the outlier safety net for genuinely long context. scrollbar-gutter:stable
+   * reserves the gutter whether or not the scrollbar shows, so an overflow
+   * can not reflow the inline text width (a small cousin of the play/pause
+   * reflow this slot fixes). */
+  min-block-size: 58px;
+  max-block-size: 58px;
   overflow-y: auto;
+  scrollbar-gutter: stable;
   /* #242 — fade the show/hide. visibility is transitioned too so the
    * element is removed from the AT rotor / hit-testing while hidden but
    * the height stays reserved. Instant under prefers-reduced-motion (see

--- a/src/core/overlay/types.ts
+++ b/src/core/overlay/types.ts
@@ -86,6 +86,21 @@ export interface OverlaySettings {
    * `subscribeSettings`.
    */
   scrubberAutoHide?: boolean;
+  /**
+   * Surrounding-sentence context preview toggle (#242, wires the #72
+   * `contextLine` setting). When `true`, the preview decoration appears
+   * on pause (showing the current sentence with the current word
+   * highlighted). When `false` (the schema default), the preview is never
+   * shown — its layout slot is still reserved (kept in flow) so toggling
+   * play/pause never reflows the modal, but the slot stays empty and
+   * invisible.
+   *
+   * Optional so existing callers and tests that pre-date this field
+   * continue to type-check — overlay treats `undefined` as `false`
+   * (matches the off-by-default schema intent). Live-updated via
+   * `subscribeSettings`.
+   */
+  contextLine?: boolean;
 }
 
 export type SettingsSubscriber = (s: OverlaySettings) => void;


### PR DESCRIPTION
## Summary
- **Reserve the layout slot** — `.context-preview` stays in flow at all times (~3-line reserved height + internal scroll for outliers, `scrollbar-gutter: stable`); show/hide carried via `visibility`+`opacity` with a faded transition instead of the `hidden` attribute / `display:none`. No reflow on play/pause toggle. Instant swap under `prefers-reduced-motion`.
- **Wire the `contextLine` setting end-to-end** (types → overlay gate → `content/index.ts` initialSettings + subscribeSettings) so the preview only shows when the decoration is enabled (off by default), and live-toggles without remount. The options-page checkbox ("Show line of context around current word", `options/index.html`) and the context-menu toggle already persisted `contextLine`; this PR connects that setting to its consumer (the preview), which was previously unwired.

Closes #242

## Ring fixes applied
- Added `src/chrome/content/__tests__/context-line-wire.test.ts` (boundary wire-test, mirrors `scrubber-autohide-wire`).
- Reserve bumped 39px → ~58px (3 lines) + `scrollbar-gutter: stable` (no mid-modal scrollbar / inline reflow on typical sentences).

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test` — full suite passes
- [x] `npm run build` — built
- [x] Mutation-verified: re-add `hidden=true` on hide path → tests RED; drop contextLine gate → tests RED; stash content/index.ts threading → wire-test RED
- [ ] Manual: `prefers-reduced-motion` → instant context swap (jsdom can't assert cascade)
