### PR TITLE
fix(overlay): reconnect A−/A+ steppers as a clamp multiplier (WCAG 1.4.4)

### DIFF
--- a/src/core/overlay/__tests__/font-size-stepper.test.ts
+++ b/src/core/overlay/__tests__/font-size-stepper.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { createOverlay } from '../overlay';
 import type { OverlayOptions, OverlaySettings, SettingsSubscriber } from '../types';
 import { createRsvpEngine } from '../../rsvp-engine';
-import { FONT_SIZE_MAX, FONT_SIZE_MIN, FONT_SIZE_STEP } from '../../settings/bounds';
+import {
+  FONT_SIZE_DEFAULT,
+  FONT_SIZE_MAX,
+  FONT_SIZE_MIN,
+  FONT_SIZE_STEP,
+} from '../../settings/bounds';
 import { OVERLAY_CLASS } from '../constants';
 
 /**
@@ -247,6 +252,63 @@ describe('createOverlay — font-size stepper (#29)', () => {
       );
       overlay.mount();
       expect(getModal().style.getPropertyValue('--rsvp-font-size')).toBe('');
+      overlay.unmount();
+      document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
+    }
+  });
+
+  // #247 — the stepper resizes the streaming word again, but via a MULTIPLIER
+  // (`--rsvp-font-scale`) on the responsive clamp, not the legacy absolute
+  // `--rsvp-font-size` pin (#241 removed that). scale = fontSize /
+  // FONT_SIZE_DEFAULT, so the default (20) is neutral (1.0) and the reader can
+  // push past the clamp's 40–54px bounds for low-vision needs (WCAG 1.4.4).
+  test('#247 — default fontSize writes a neutral --rsvp-font-scale of 1 on the modal', () => {
+    const overlay = createOverlay(
+      defaultOpts({ initialSettings: defaultSettings({ fontSize: FONT_SIZE_DEFAULT }) }),
+    );
+    overlay.mount();
+    expect(getModal().style.getPropertyValue('--rsvp-font-scale')).toBe('1');
+    overlay.unmount();
+  });
+
+  test('#247 — a non-default initial fontSize scales the clamp (40 → 2.0)', () => {
+    const overlay = createOverlay(
+      defaultOpts({ initialSettings: defaultSettings({ fontSize: 40 }) }),
+    );
+    overlay.mount();
+    expect(getModal().style.getPropertyValue('--rsvp-font-scale')).toBe(
+      String(40 / FONT_SIZE_DEFAULT),
+    );
+    overlay.unmount();
+  });
+
+  test('#247 — A+ / A− live-update --rsvp-font-scale (mutation: drop the setProperty → RED)', () => {
+    const overlay = createOverlay(
+      defaultOpts({ initialSettings: defaultSettings({ fontSize: FONT_SIZE_DEFAULT }) }),
+    );
+    overlay.mount();
+    getIncBtn().click();
+    expect(getModal().style.getPropertyValue('--rsvp-font-scale')).toBe(
+      String((FONT_SIZE_DEFAULT + FONT_SIZE_STEP) / FONT_SIZE_DEFAULT),
+    );
+    getDecBtn().click();
+    getDecBtn().click();
+    expect(getModal().style.getPropertyValue('--rsvp-font-scale')).toBe(
+      String((FONT_SIZE_DEFAULT - FONT_SIZE_STEP) / FONT_SIZE_DEFAULT),
+    );
+    overlay.unmount();
+  });
+
+  test('#247 — malformed initial fontSize cannot leak a non-finite scale (mount clamp guards it)', () => {
+    for (const fontSize of [Number.POSITIVE_INFINITY, Number.NaN, -50, 10_000]) {
+      const overlay = createOverlay(
+        defaultOpts({ initialSettings: defaultSettings({ fontSize }) }),
+      );
+      overlay.mount();
+      const scale = Number(getModal().style.getPropertyValue('--rsvp-font-scale'));
+      expect(Number.isFinite(scale)).toBe(true);
+      expect(scale).toBeGreaterThanOrEqual(FONT_SIZE_MIN / FONT_SIZE_DEFAULT);
+      expect(scale).toBeLessThanOrEqual(FONT_SIZE_MAX / FONT_SIZE_DEFAULT);
       overlay.unmount();
       document.querySelectorAll('[data-speedreader-overlay]').forEach((n) => n.remove());
     }

--- a/src/core/overlay/__tests__/styles.test.ts
+++ b/src/core/overlay/__tests__/styles.test.ts
@@ -96,6 +96,22 @@ describe('OVERLAY_CSS word-region vertical centering (issue #241)', () => {
     expect(block).toMatch(/font-size:[^;]*clamp\(40px,\s*8\.5cqi \+ 0\.5rem,\s*54px\)/);
   });
 
+  // #247 — the clamp is the BASE; the A−/A+ stepper scales it via
+  // `calc(clamp(...) * var(--rsvp-font-scale, 1))` so the reader can enlarge the
+  // streaming word past the 54px ceiling (WCAG 1.4.4). The legacy absolute
+  // `--rsvp-font-size` pin must be gone (it overrode the clamp → 20px word).
+  // Mutation: dropping the `* var(--rsvp-font-scale, 1)` factor flips this RED.
+  test('default .word-region scales the clamp by --rsvp-font-scale (no legacy --rsvp-font-size pin)', () => {
+    const block = OVERLAY_CSS.match(
+      /\.word-region\s*\{[^}]*font-family:\s*var\(--font-mono[^}]*\}/,
+    )?.[0];
+    expect(block, 'expected the default .word-region rule').not.toBeUndefined();
+    expect(block).toMatch(
+      /font-size:\s*calc\(\s*clamp\(40px,\s*8\.5cqi \+ 0\.5rem,\s*54px\)\s*\*\s*var\(--rsvp-font-scale,\s*1\)\s*\)/,
+    );
+    expect(block).not.toMatch(/var\(--rsvp-font-size/);
+  });
+
   // #241 (a11y ring MED) — the accent focus-ticks must anchor to the region's
   // vertical CENTER, not its top/bottom EDGES. With the word now centered
   // (align-items: center) and the region free to grow (touch flex: 1 1 auto,

--- a/src/core/overlay/__tests__/styles.test.ts
+++ b/src/core/overlay/__tests__/styles.test.ts
@@ -132,6 +132,10 @@ describe('OVERLAY_CSS word-region vertical centering (issue #241)', () => {
     expect(block).toMatch(/top:\s*50%/);
     expect(block).toMatch(/transform:\s*translate\(-50%,/);
     expect(block).not.toMatch(/top:\s*18px/);
+    // #247 (a11y ring HIGH) — the vertical offset must scale with the word so
+    // the tick tracks the enlarged glyph instead of collapsing inside it.
+    // Mutation: dropping the `* var(--rsvp-font-scale, 1)` factor flips this RED.
+    expect(block).toMatch(/translate\(-50%,\s*calc\(-40px \* var\(--rsvp-font-scale,\s*1\)\)\)/);
   });
 
   test('::after focus-tick anchors to vertical center (top: 50% + translate), not the bottom edge', () => {
@@ -141,6 +145,8 @@ describe('OVERLAY_CSS word-region vertical centering (issue #241)', () => {
     expect(block).toMatch(/top:\s*50%/);
     expect(block).toMatch(/transform:\s*translate\(-50%,/);
     expect(block).not.toMatch(/bottom:\s*6px/);
+    // #247 (a11y ring HIGH) — see ::before note; the offset scales with the word.
+    expect(block).toMatch(/translate\(-50%,\s*calc\(26px \* var\(--rsvp-font-scale,\s*1\)\)\)/);
   });
 });
 

--- a/src/core/overlay/overlay.ts
+++ b/src/core/overlay/overlay.ts
@@ -15,6 +15,7 @@ import { renderChunk, renderWord } from './word';
 import { buildSentenceContext } from './sentence-context';
 import { installFocusTrap } from './focus-trap';
 import {
+  FONT_SIZE_DEFAULT,
   FONT_SIZE_MAX,
   FONT_SIZE_MIN,
   FONT_SIZE_STEP,
@@ -854,14 +855,17 @@ export function createOverlay(opts: OverlayOptions): OverlayHandle {
     };
     const applyFontSize = (n: number): void => {
       currentFontSize = n;
-      // #241 — the streaming RSVP word is sized by the responsive
-      // `clamp(40px, 8.5cqi + 0.5rem, 54px)` on `.word-region` (styles.ts),
-      // NOT by the body `fontSize` setting. Writing `--rsvp-font-size` here
-      // pinned the word to the 20px default and made the clamp dead fallback,
-      // rendering the word tiny. So this no longer touches the custom property;
-      // it only keeps `currentFontSize` and the stepper boundary state in sync.
-      // (The A−/A+ stepper consequently no longer resizes the streaming word —
-      // accepted behavior change; it stays wired to onFontSizeChange/persistence.)
+      // #247 — the streaming RSVP word's BASE size is the responsive
+      // `clamp(40px, 8.5cqi + 0.5rem, 54px)` on `.word-region` (styles.ts).
+      // The A−/A+ stepper scales it via `--rsvp-font-scale` (a MULTIPLIER on
+      // the clamp), NOT the legacy `--rsvp-font-size` absolute pin that #241
+      // removed (that pinned the word to the 20px default and killed the clamp).
+      // scale = fontSize / FONT_SIZE_DEFAULT, so the default (20) yields 1.0
+      // (clamp governs unchanged) and the reader can grow the word past the
+      // 54px ceiling / below the 40px floor for low-vision needs (WCAG 1.4.4).
+      // Written on `.modal` (not the hot per-tick `word` element) so the word
+      // reads it via cascade with no inline-style invalidation per RSVP tick.
+      modal.style.setProperty('--rsvp-font-scale', String(n / FONT_SIZE_DEFAULT));
       // #215 — aria-disabled (not native `disabled`) so the buttons stay in
       // the tab chain at MIN/MAX (WCAG 2.4.3); the click handlers short-circuit
       // on it. Mirrors the #214 WPM-stepper treatment.

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -251,7 +251,12 @@ export const OVERLAY_CSS = `
   gap: 0 0.4ch;
   padding: 36px 24px 20px;
   font-family: var(--font-mono);
-  font-size: var(--rsvp-font-size, clamp(40px, 8.5cqi + 0.5rem, 54px));
+  /* #247 — the responsive clamp is the BASE size; --rsvp-font-scale (written
+   * by the A-/A+ stepper from fontSize / FONT_SIZE_DEFAULT, default 1.0) lets
+   * the reader scale the streaming word above the 54px ceiling / below the
+   * 40px floor for low-vision needs (WCAG 1.4.4) without losing the responsive
+   * base. The legacy --rsvp-font-size pin is gone (it overrode the clamp). */
+  font-size: calc(clamp(40px, 8.5cqi + 0.5rem, 54px) * var(--rsvp-font-scale, 1));
   font-weight: 500;
   letter-spacing: 0.01em;
   line-height: 1.15;

--- a/src/core/overlay/styles.ts
+++ b/src/core/overlay/styles.ts
@@ -276,11 +276,14 @@ export const OVERLAY_CSS = `
    * they track the now-centered word at ANY region height (touch full-height
    * flex: 1 1 auto, tall viewports) — not just at min-block-size. The
    * per-tick transform carries BOTH the horizontal centering (-50% X, was the
-   * shared translateX) and the vertical offset above/below center. Each tick
-   * is 14px tall and sits with its inner edge 26px from center (a ~52px gap
-   * straddling the word line), so the two ticks stay symmetric about the
-   * gaze anchor as the region grows. Previously edge-anchored
-   * (top: 18px / bottom: 6px), which drifted off the centered word. */
+   * shared translateX) and the vertical offset above/below center.
+   * #247 — the vertical offset is multiplied by --rsvp-font-scale so the ticks
+   * grow WITH the scaled word: at scale 1 they straddle the ~54px word with a
+   * ~52px gap; at the stepper's max scale the offsets grow proportionally to
+   * the larger glyph, keeping the two ticks symmetric about (and clear of) the
+   * gaze anchor instead of collapsing inside the enlarged glyph. Each tick is
+   * 14px tall. Previously edge-anchored (top: 18px / bottom: 6px), which
+   * drifted off the centered word. */
   width: 1.5px;
   height: 14px;
   background: var(--accent, #1a73e8);
@@ -291,12 +294,12 @@ export const OVERLAY_CSS = `
 
 .word-region::before {
   top: 50%;
-  transform: translate(-50%, -40px);
+  transform: translate(-50%, calc(-40px * var(--rsvp-font-scale, 1)));
 }
 
 .word-region::after {
   top: 50%;
-  transform: translate(-50%, 26px);
+  transform: translate(-50%, calc(26px * var(--rsvp-font-scale, 1)));
 }
 
 .word-region .focus {

--- a/src/core/settings/bounds.ts
+++ b/src/core/settings/bounds.ts
@@ -16,6 +16,15 @@ export const WPM_STEP = 10;
 export const FONT_SIZE_MIN = 12;
 export const FONT_SIZE_MAX = 48;
 /**
+ * Neutral point for the RSVP word-scale (#247). The overlay sizes the
+ * streaming word as `clamp(...) * (fontSize / FONT_SIZE_DEFAULT)`, so a
+ * stored `fontSize` equal to this default yields a scale of 1.0 (the
+ * responsive clamp governs unchanged). Kept as the single source of truth
+ * for the default so the "default → scale 1.0" invariant cannot silently
+ * drift if the default is ever retuned.
+ */
+export const FONT_SIZE_DEFAULT = 20;
+/**
  * Increment used by the overlay's in-modal `A−` / `A+` stepper (#29).
  * Mirrors Safari upstream `FONT_SIZE_STEP = 2`
  * (`SpeedReader/SpeedReaderExtension/Resources/rsvp/settings-defaults.js`).

--- a/src/core/settings/defaults.ts
+++ b/src/core/settings/defaults.ts
@@ -1,3 +1,4 @@
+import { FONT_SIZE_DEFAULT } from './bounds';
 import type { SettingsV7 } from './schema';
 
 export const DEFAULT_SETTINGS: SettingsV7 = {
@@ -5,7 +6,7 @@ export const DEFAULT_SETTINGS: SettingsV7 = {
   wpm: 250,
   theme: 'system',
   font: 'system-ui',
-  fontSize: 20,
+  fontSize: FONT_SIZE_DEFAULT,
   openDyslexic: false,
   punctuationPacing: true,
   alignment: 'orp',


### PR DESCRIPTION
## Summary
Reconnect the A−/A+ font steppers to the streaming RSVP word — they went inert in #244 when the word was decoupled from the body `fontSize` (a WCAG 1.4.4 resize-text gap for low-vision readers needing text past the 54px clamp ceiling).

- `.word-region` font-size → `calc(clamp(40px, 8.5cqi + 0.5rem, 54px) * var(--rsvp-font-scale, 1))` — the responsive clamp stays the BASE; the scale is a multiplier.
- `applyFontSize` writes `--rsvp-font-scale = fontSize / FONT_SIZE_DEFAULT` on `.modal` (cascade — no per-tick inline-style invalidation).
- `FONT_SIZE_DEFAULT` (20) added to `bounds.ts` as the single source of the neutral point; `defaults.ts` references it. Default `fontSize` 20 → scale 1.0 → clamp unchanged. **Zero schema change / zero migration** — existing stored `fontSize` values map straight to scale factors.
- Removed the dead `--rsvp-font-size` var wrapper from the CSS.

Closes #247

## Design note
Chose to repurpose the (post-#244 inert) `fontSize` setting as the scale source rather than add a new `rsvpWordScale` setting — identical UX, no schema/migration. Steppers already persisted `fontSize`, so persistence "just works."

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test` — 94 files / 1506 passed
- [x] `npm run build` — built
- [x] Mutation-verified: drop the scale `setProperty` → 4 stepper tests RED; drop the `* var(--rsvp-font-scale, 1)` CSS factor → styles test RED
- [ ] Manual: A+ grows the streaming word past 54px, A− shrinks below 40px (jsdom has no layout engine)
